### PR TITLE
Add append option to save_txt

### DIFF
--- a/src/owl/dense/owl_dense_matrix_c.mli
+++ b/src/owl/dense/owl_dense_matrix_c.mli
@@ -419,7 +419,7 @@ val save : mat -> string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_d.mli
+++ b/src/owl/dense/owl_dense_matrix_d.mli
@@ -398,7 +398,7 @@ val save : mat -> string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -559,13 +559,13 @@ let of_array k x m n =
 
 
 let save_txt ?(sep="\t") ?(append=false) x f =
-  let perm = 0o644  (* note: will be AND'ed with user's umask *)
+  let perm = 0o644 in (* will be AND'ed with user's umask *)
   let open_flags = if append
                    then [Open_wronly; Open_creat; Open_append] 
 		   else [Open_wronly; Open_creat; Open_trunc] 
   in
   let _op = Owl_utils.elt_to_str (kind x) in
-  let h = open_out_gen open_flags f in
+  let h = open_out_gen open_flags perm f in
   iter_rows (fun y ->
     iter (fun z -> Printf.fprintf h "%s%s" (_op z) sep) y;
     Printf.fprintf h "\n"

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -558,9 +558,14 @@ let of_array k x m n =
   reshape y [|m; n|]
 
 
-let save_txt ?(sep="\t") x f =
+let save_txt ?(sep="\t") ?(append=false) x f =
+  let perm = 0o644  (* note: will be AND'ed with user's umask *)
+  let open_flags = if append
+                   then [Open_wronly; Open_creat; Open_append] 
+		   else [Open_wronly; Open_creat; Open_trunc] 
+  in
   let _op = Owl_utils.elt_to_str (kind x) in
-  let h = open_out f in
+  let h = open_out_gen open_flags f in
   iter_rows (fun y ->
     iter (fun z -> Printf.fprintf h "%s%s" (_op z) sep) y;
     Printf.fprintf h "\n"

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1198,10 +1198,10 @@ by using ``save`` function.
 
 val save_txt : ?sep:string -> ?append:bool -> ('a, 'b) t -> string -> unit
 (**
-``save_txt ~sep ~append x f`` saves the matrix ``x`` into a tab-delimited text 
-file ``f`` delimited by the specified string ``sep`` (default: tab).  If ``append``
-is ``false`` (it is by default), an existing file will be truncated and overwritten;
-if ``append`` is ``true`` and the file exists, new rows will be appended to it.
+``save_txt ~sep ~append x f`` saves the matrix ``x`` into a text file ``f`` 
+delimited by the specified string ``sep`` (default: tab).  If ``append`` is
+``false`` (it is by default), an existing file will be truncated and overwritten.
+If ``append`` is ``true`` and the file exists, new rows will be appended to it.
 Files are created, if necessary, with the AND of 0o644 and the user's umask value.
 Note that the operation can be very time consuming.
  *)

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1196,11 +1196,14 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 by using ``save`` function.
  *)
 
-val save_txt : ?sep:string -> ('a, 'b) t -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> ('a, 'b) t -> string -> unit
 (**
-``save_txt ~sep x f`` save the matrix ``x`` into a tab-delimited text file ``f``
-delimited by the specified string ``sep``. Note that the operation can be very
-time consuming.
+``save_txt ~sep ~append x f`` saves the matrix ``x`` into a tab-delimited text 
+file ``f`` delimited by the specified string ``sep`` (default: tab).  If ``append``
+is ``false`` (it is by default), an existing file will be truncated and overwritten;
+if ``append`` is ``true`` and the file exists, new rows will be appended to it.
+Files are created, if necessary, with the AND of 0o644 and the user's umask value.
+Note that the operation can be very time consuming.
  *)
 
 val load_txt : ?sep:string -> ('a, 'b) kind -> string -> ('a, 'b) t

--- a/src/owl/dense/owl_dense_matrix_s.mli
+++ b/src/owl/dense/owl_dense_matrix_s.mli
@@ -398,7 +398,7 @@ val save : mat -> string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_z.mli
+++ b/src/owl/dense/owl_dense_matrix_z.mli
@@ -419,7 +419,7 @@ val save : mat -> string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 


### PR DESCRIPTION
I added parameter `?(append=false)` to `save_txt`.  When `true`, append causes a new write into an existing file to append to it rather than overwriting the file.

I thought about doing something more complicated that would allow the user to set the Unix file open flags individually.  That would allow a user to specify that `save_txt` should fail if the file exists.  I'm not sure there's anything else that would really be useful in the file open flags.  My feeling is that allowing the user the choice to append rather than overwrite is a useful, simple, function that could be used often, but if the user wants to fail if the file exists, they should handle that case some other way, by checking whether the file exists before `save_txt` is called.

Similarly, we could allow the user to pass a file permission value to `save_txt`, but this just seems like too much for a simple function.  The user can go back and change the permissions separately.

So I have only added `~append` as a boolean that determines whether to append or overwrite.