### PR TITLE
Minor fix of neural node parameter names

### DIFF
--- a/examples/feedforward.ml
+++ b/examples/feedforward.ml
@@ -155,14 +155,14 @@ let gru ?name ?(init_typ=Init.Tanh) cells nn =
   |> add_layer nn;
   nn
 
-let conv2d ?name ?(padding = SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides nn =
-  Conv2D (Conv2D.create padding kernel strides init_typ)
+let conv2d ?name ?(padding = SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride nn =
+  Conv2D (Conv2D.create padding kernel stride init_typ)
   |> make_layer ?name nn
   |> add_layer ?act_typ nn;
   nn
 
-let conv3d ?name ?(padding = SAME) ?(init_typ=Init.Tanh) ?act_typ kernel_width kernel strides nn =
-  Conv3D (Conv3D.create padding kernel strides init_typ)
+let conv3d ?name ?(padding = SAME) ?(init_typ=Init.Tanh) ?act_typ kernel_width kernel stride nn =
+  Conv3D (Conv3D.create padding kernel stride init_typ)
   |> make_layer ?name nn
   |> add_layer ?act_typ nn;
   nn
@@ -253,12 +253,12 @@ let train ?state ?params ?(init_model=true) nn x y =
   Optimise.S.minimise_network ?state p (forward nn) (backward nn) (update nn) (save nn) (Arr x) (Arr y)
 
 let test_model nn x y =
-  Mat.iter2_rows (fun u v ->
-    Owl_dataset.print_mnist_image (unpack_arr u);
-    let p = run u nn |> unpack_arr in
+  Dense.Matrix.S.iter2_rows (fun u v ->
+    Owl_dataset.print_mnist_image u;
+    let p = run (Arr u) nn |> unpack_arr in
     Owl_dense_matrix_generic.print p;
     Printf.printf "prediction: %i\n" (let _, i = Owl_dense_matrix_generic.max_i p in i.(1))
-  ) (Arr x) (Arr y)
+  ) x y
 
 
 

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -299,64 +299,64 @@ module Make
     add_node nn [|input_node|] n
 
 
-  let conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = Conv1D (Conv1D.create padding kernel strides init_typ) in
+  let conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = Conv1D (Conv1D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = Conv2D (Conv2D.create padding kernel strides init_typ) in
+  let conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = Conv2D (Conv2D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = Conv3D (Conv3D.create padding kernel strides init_typ) in
+  let conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = Conv3D (Conv3D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let dilated_conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides rates input_node =
-    let neuron = DilatedConv1D (DilatedConv1D.create padding kernel strides rates init_typ) in
+  let dilated_conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride rate input_node =
+    let neuron = DilatedConv1D (DilatedConv1D.create padding kernel stride rate init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let dilated_conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides rates input_node =
-    let neuron = DilatedConv2D (DilatedConv2D.create padding kernel strides rates init_typ) in
+  let dilated_conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride rate input_node =
+    let neuron = DilatedConv2D (DilatedConv2D.create padding kernel stride rate init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let dilated_conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides rates input_node =
-    let neuron = DilatedConv3D (DilatedConv3D.create padding kernel strides rates init_typ) in
+  let dilated_conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride rate input_node =
+    let neuron = DilatedConv3D (DilatedConv3D.create padding kernel stride rate init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let transpose_conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = TransposeConv1D (TransposeConv1D.create padding kernel strides init_typ) in
+  let transpose_conv1d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = TransposeConv1D (TransposeConv1D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let transpose_conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = TransposeConv2D (TransposeConv2D.create padding kernel strides init_typ) in
+  let transpose_conv2d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = TransposeConv2D (TransposeConv2D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n
 
 
-  let transpose_conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel strides input_node =
-    let neuron = TransposeConv3D (TransposeConv3D.create padding kernel strides init_typ) in
+  let transpose_conv3d ?name ?(padding=SAME) ?(init_typ=Init.Tanh) ?act_typ kernel stride input_node =
+    let neuron = TransposeConv3D (TransposeConv3D.create padding kernel stride init_typ) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [|input_node|] n

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -174,7 +174,7 @@ Arguments:
 
   val conv1d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``conv1d kernels strides node`` adds a 1D convolution node (e.g. temporal
+``conv1d kernel stride node`` adds a 1D convolution node (e.g. temporal
 convolution) on previous ``node``.
 
 Arguments:
@@ -184,7 +184,7 @@ Arguments:
 
   val conv2d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``conv2d kernels strides node`` adds a 2D convolution node (e.g. spatial convolution over images) on previous ``node``.
+``conv2d kernel stride node`` adds a 2D convolution node (e.g. spatial convolution over images) on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``w, h, i, o``. ``w`` and ``h`` specify the width and height of the 2D convolution window. ``i`` and ``o`` are the dimensionality of the input and output space.
@@ -193,7 +193,7 @@ Arguments:
 
   val conv3d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``conv3d kernels strides node`` adds a 3D convolution node (e.g. spatial
+``conv3d kernel stride node`` adds a 3D convolution node (e.g. spatial
 convolution over volumes) on previous ``node``.
 
 Arguments:
@@ -203,7 +203,7 @@ Arguments:
 
   val dilated_conv1d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> int array -> node -> node
   (**
-``dilated_conv1d kernels strides rates node`` adds a 1D dilated convolution node (e.g. temporal convolution) on previous ``node``.
+``dilated_conv1d kernel stride rate node`` adds a 1D dilated convolution node (e.g. temporal convolution) on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``h, i, o``. ``h`` specifies the dimension of the 1D convolution window. ``i`` and ``o`` are the dimensionalities of the input and output space.
@@ -213,17 +213,17 @@ Arguments:
 
   val dilated_conv2d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> int array -> node -> node
   (**
-``dilated_conv2d kernels strides rates node`` adds a 2D dilated convolution node (e.g. spatial convolution over images) on previous ``node``.
+``dilated_conv2d kernel stride rate node`` adds a 2D dilated convolution node (e.g. spatial convolution over images) on previous ``node``.
 
 Arguments:
   * ``kernel`: int array consists of ``w, h, i, o``. ``w`` and ``h`` specify the width and height of the 2D convolution window. ``i`` and ``o`` are the dimensionality of the input and output space.
-  * ``strides``: int array of 2 integers.
-  * ``rates``: int array of 2 integers.
+  * ``stride``: int array of 2 integers.
+  * ``rate``: int array of 2 integers.
   *)
 
   val dilated_conv3d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> int array -> node -> node
   (**
-``dilated_conv3d kernels strides rates node`` adds a 3D dilated convolution node (e.g. spatial convolution over volumes) on previous ``node``.
+``dilated_conv3d kernel stride rate node`` adds a 3D dilated convolution node (e.g. spatial convolution over volumes) on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``w, h, d, i, o``. ``w``, ``h``, and ``d`` specify the 3 dimensionality of the 3D convolution window. ``i`` and ``o`` are the dimensionality of the input and output space.
@@ -233,7 +233,7 @@ Arguments:
 
   val transpose_conv1d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``transpose_conv1d kernels strides node`` adds a 1D transpose convolution node (e.g. temporal convolution) on previous ``node``.
+``transpose_conv1d kernel stride node`` adds a 1D transpose convolution node (e.g. temporal convolution) on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``h, i, o``. ``h`` specifies the dimension of the 1D convolution window. ``i`` and ``o`` are the dimensionalities of the input and output space.
@@ -242,7 +242,7 @@ Arguments:
 
   val transpose_conv2d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``transpose_conv2d kernels strides node`` adds a 2D transpose convolution node on previous ``node``.
+``transpose_conv2d kernel stride node`` adds a 2D transpose convolution node on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``w, h, i, o``. ``w`` and ``h`` specify the width and height of the 2D convolution window. ``i`` and ``o`` are the dimensionality of the input and output space.
@@ -251,7 +251,7 @@ Arguments:
 
   val transpose_conv3d : ?name:string -> ?padding:Owl_types.padding -> ?init_typ:Init.typ -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``transpose_conv3d kernels strides node`` adds a 3D transpose convolution node (e.g. spatial convolution over volumes) on previous ``node``.
+``transpose_conv3d kernel stride node`` adds a 3D transpose convolution node (e.g. spatial convolution over volumes) on previous ``node``.
 
 Arguments:
   * ``kernel``: int array consists of ``w, h, d, i, o``. ``w``, ``h``, and ``d`` specify the 3 dimensionality of the 3D convolution window. ``i`` and ``o`` are the dimensionality of the input and output space.
@@ -268,41 +268,41 @@ Arguments:
 
   val max_pool1d : ?name:string -> ?padding:Owl_types.padding -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``max_pool1d ~padding ~act_typ pool_size strides node`` adds a max pooling
+``max_pool1d ~padding ~act_typ pool_size stride node`` adds a max pooling
 operation for temporal data to ``node``.
 
 Arguments:
   * ``pool_size``: Array of one integer, size of the max pooling windows.
-  * ``strides``: Array of one integer, factor by which to downscale.
+  * ``stride``: Array of one integer, factor by which to downscale.
   *)
 
   val max_pool2d : ?name:string -> ?padding:Owl_types.padding -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``max_pool2d ~padding ~act_typ pool_size strides node`` adds a max pooling
+``max_pool2d ~padding ~act_typ pool_size stride node`` adds a max pooling
 operation for spatial data to ``node``.
 
 Arguments:
   * ``pool_size``: Array of 2 integers, size of the max pooling windows.
-  * ``strides``: Array of 2 integers, factor by which to downscale.
+  * ``stride``: Array of 2 integers, factor by which to downscale.
   *)
 
   val avg_pool1d : ?name:string -> ?padding:Owl_types.padding -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``avg_pool1d ~padding ~act_typ pool_size strides node`` adds a average pooling
+``avg_pool1d ~padding ~act_typ pool_size stride node`` adds a average pooling
 operation for temporal data to ``node``.
 
 Arguments:
   * ``pool_size``: Array of one integer, size of the max pooling windows.
-  * ``strides``: Array of one integer, factor by which to downscale.
+  * ``stride``: Array of one integer, factor by which to downscale.
   *)
 
   val avg_pool2d : ?name:string -> ?padding:Owl_types.padding -> ?act_typ:Activation.typ -> int array -> int array -> node -> node
   (**
-``avg_pool2d ~padding ~act_typ pool_size strides node`` adds a average pooling operation for spatial data to ``node``.
+``avg_pool2d ~padding ~act_typ pool_size stride node`` adds a average pooling operation for spatial data to ``node``.
 
 Arguments:
   * ``pool_size``: Array of 2 integers, size of the max pooling windows.
-  * ``strides``: Array of 2 integers, factor by which to downscale.
+  * ``stride``: Array of 2 integers, factor by which to downscale.
   *)
 
   val global_max_pool1d : ?name:string -> ?act_typ:Activation.typ -> node -> node

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -62,7 +62,6 @@ CAMLprim value FUN_NATIVE (spatial_im2col) (
     if (pc < 0) pc = 0;
   }
 
-
   #ifdef _OPENMP
     #pragma omp parallel for schedule(static)
   #endif /* _OPENMP */

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -62,6 +62,7 @@ CAMLprim value FUN_NATIVE (spatial_im2col) (
     if (pc < 0) pc = 0;
   }
 
+
   #ifdef _OPENMP
     #pragma omp parallel for schedule(static)
   #endif /* _OPENMP */


### PR DESCRIPTION
This PR changes the parameter names of neural nodes from `kernels/strides/rates` to `kernel/stride/rate`, in line with existing naming convention. An error in `examples/feedforward.ml` is also fixed.