### PR TITLE
Fix examples

### DIFF
--- a/examples/checkpoint.ml
+++ b/examples/checkpoint.ml
@@ -4,7 +4,7 @@
 open Owl
 open Neural.S
 open Neural.S.Graph
-open Algodiff.S
+open Owl.Algodiff.S
 
 
 let make_network input_shape =

--- a/examples/feedforward.ml
+++ b/examples/feedforward.ml
@@ -250,7 +250,7 @@ let train ?state ?params ?(init_model=true) nn x y =
     | Some p -> p
     | None   -> Params.default ()
   in
-  Optimise.S.minimise_network ?state p (forward nn) (backward nn) (update nn) (save nn) (Arr x) (Arr y)
+  Optimise.minimise_network ?state p (forward nn) (backward nn) (update nn) (save nn) (Arr x) (Arr y)
 
 let test_model nn x y =
   Dense.Matrix.S.iter2_rows (fun u v ->

--- a/examples/kmeans.ml
+++ b/examples/kmeans.ml
@@ -6,9 +6,9 @@ module LL = Owl_cluster
 let _ =
   let x = Mat.load_txt "kmeans.data" in
   let m, n = Mat.shape x in
-  print_endline (Bytes.make 60 '+');
+  print_endline (String.make 60 '+');
   Printf.printf "| test matrix size: %i x %i\n" m n;
-  print_endline (Bytes.make 60 '-');
+  print_endline (String.make 60 '-');
   print_endline "test on input data ...";
   let centers, _ = LL.kmeans x 2 in Mat.print centers;
   print_endline "test on random data ...";

--- a/examples/opencl_01.ml
+++ b/examples/opencl_01.ml
@@ -18,7 +18,7 @@ let prog_s = "
 Owl_log.info "pick platform, device, build program ...";;
 let l = Owl_opencl_base.Platform.get_platforms ();;
 let m = Owl_opencl_base.Device.get_devices l.(0);;
-let gpu = m.(1);;
+let gpu = m.(0);;
 let ctx = Owl_opencl_base.Context.create [|gpu|];;
 let cmdq = Owl_opencl_base.CommandQueue.create ctx gpu;;
 let program = Owl_opencl_base.Program.create_with_source ctx [|prog_s|];;

--- a/examples/opencl_04.ml
+++ b/examples/opencl_04.ml
@@ -20,6 +20,6 @@ let loop_gpu a =
 
 let _ =
   let a = Dense.Ndarray.S.uniform [|2000; 2000|] in
-  let f () = loop_gpu a in
+  let f () = ignore @@ loop_gpu a in
   let t = Utils.time f in
   Owl_log.info "loop_gpu takes %g ms" t

--- a/examples/opencl_05.ml
+++ b/examples/opencl_05.ml
@@ -11,14 +11,14 @@ let test_01 a =
   let x = M.var_arr "x" in
   M.assign_arr x a;
   let y = M.sin x in
-  M.eval_arr ~dev_id:1 [|y|];
+  M.eval_arr ~dev_id:0 [|y|];
   M.unpack_arr y
 
 
 let test_02 a =
   let x = M.uniform [|100; 100|] in
   let y = M.cos x in
-  M.eval_arr ~dev_id:1 [|y|];
+  M.eval_arr ~dev_id:0 [|y|];
   M.unpack_arr y
 
 
@@ -26,7 +26,7 @@ let test_05 a =
   let x = M.var_arr "x" in
   M.assign_arr x (Dense.Ndarray.S.ones [|10; 10|]);
   let y = M.cos x in
-  M.eval_arr ~dev_id:1 [|y|];
+  M.eval_arr ~dev_id:0 [|y|];
   M.unpack_arr y
 
 
@@ -36,7 +36,7 @@ let test_06 a =
   M.assign_arr x (Dense.Ndarray.S.ones [|10; 10|]);
   M.assign_arr y (Dense.Ndarray.S.ones [|10; 10|]);
   let z = M.(add (cos x) y) in
-  M.eval_arr ~dev_id:1 [|z|];
+  M.eval_arr ~dev_id:0 [|z|];
   M.unpack_arr z
 
 
@@ -46,7 +46,7 @@ let test_03 a =
   M.assign_arr x (Dense.Ndarray.S.ones [|100; 100|]);
   M.assign_arr y (Dense.Ndarray.S.ones [|1; 100|]);
   let z = M.add x y in
-  M.eval_arr ~dev_id:1 [|z|];
+  M.eval_arr ~dev_id:0 [|z|];
   M.unpack_arr z
 
 

--- a/examples/opencl_06.ml
+++ b/examples/opencl_06.ml
@@ -9,14 +9,14 @@ module M = Owl_computation_opencl_engine.Make (Dense.Ndarray.S);;
 
 let test_01 a =
   let x = M.uniform [|100; 100|] in
-  M.eval_arr ~dev_id:1 [|x|];
+  M.eval_arr ~dev_id:0 [|x|];
   M.unpack_arr x
 
 
 let test_02 a =
   let x = M.uniform [|100; 100|] in
   let y = M.cos x in
-  M.eval_arr ~dev_id:1 [|y|];
+  M.eval_arr ~dev_id:0 [|y|];
   M.unpack_arr y
 
 
@@ -25,7 +25,7 @@ let test_03 a =
   let x = M.uniform [|2000; 2000|] in
   let f () =
     M.(arr_to_node x |> invalidate);
-    M.eval_arr ~dev_id:1 [|x|]
+    M.eval_arr ~dev_id:0 [|x|]
   in
   Owl_log.info "PRNG uniform ...";
   Owl_log.info "PRNG #1: %.g ms" (Utils.time f);
@@ -41,7 +41,7 @@ let test_04 a =
   let x = M.var_arr "x" in
   M.assign_arr x a;
   let y = M.min ~axis:1 x in
-  M.eval_arr ~dev_id:1 [|y|];
+  M.eval_arr ~dev_id:0 [|y|];
   M.unpack_arr y
 
 
@@ -52,7 +52,7 @@ let test_05 a =
   let y = M.sum ~axis:0 x in
   let f () =
     M.(arr_to_node y |> invalidate);
-    M.eval_arr ~dev_id:1 [|y|]
+    M.eval_arr ~dev_id:0 [|y|]
   in
   Owl_log.info "PRNG #1: %.g ms" (Utils.time f);
   Owl_log.info "PRNG #2: %.g ms" (Utils.time f);
@@ -68,7 +68,7 @@ let test_06 a =
   let x = M.gaussian ~mu [|2000; 2000|] in
   let f () =
     M.(arr_to_node x |> invalidate);
-    M.eval_arr ~dev_id:1 [|x|]
+    M.eval_arr ~dev_id:0 [|x|]
   in
   Owl_log.info "PRNG gaussian ...";
   Owl_log.info "PRNG #1: %.g ms" (Utils.time f);

--- a/examples/opencl_07.ml
+++ b/examples/opencl_07.ml
@@ -13,7 +13,7 @@ let test_01 () =
   M.assign_elt x 2.;
   let w = M.Scalar.sin x in
   let z = M.Scalar.add w y in
-  M.eval_elt ~dev_id:1 [|z|];
+  M.eval_elt ~dev_id:0 [|z|];
   let a = M.unpack_elt z in
   Owl_log.info "a = %g" a
 
@@ -22,7 +22,7 @@ let test_02 () =
   let x = M.ones [|3; 4|] in
   let y = M.uniform [|3; 4|] in
   let z = M.add x y in
-  M.eval_arr ~dev_id:1 [|z|];
+  M.eval_arr ~dev_id:0 [|z|];
   let a = M.unpack_arr z in
   Dense.Ndarray.S.print a
 
@@ -32,7 +32,7 @@ let test_03 () =
   let x = M.sequential ~a [|3; 4|] in
   let y = M.uniform [|3; 4|] in
   let z = M.add x y in
-  M.eval_arr ~dev_id:1 [|z|];
+  M.eval_arr ~dev_id:0 [|z|];
   let a = M.unpack_arr z in
   Dense.Ndarray.S.print a
 
@@ -43,7 +43,7 @@ let test_04 () =
   let x = M.create [|10; 10|] a in
   let y = M.uniform ~b [|10; 10|] in
   let z = M.add x y in
-  M.eval_arr ~dev_id:1 [|z|];
+  M.eval_arr ~dev_id:0 [|z|];
   let a = M.unpack_arr z in
   Dense.Ndarray.S.print a
 
@@ -51,7 +51,7 @@ let test_04 () =
 let test_05 () =
   let p = M.const_elt "p" 0.3 in
   let x = M.bernoulli ~p [|10; 10|] in
-  M.eval_arr ~dev_id:1 [|x|];
+  M.eval_arr ~dev_id:0 [|x|];
   let a = M.unpack_arr x in
   Dense.Ndarray.S.print a
 

--- a/examples/svm.ml
+++ b/examples/svm.ml
@@ -27,8 +27,8 @@ let draw_line x0 y0 p =
   let y' = Mat.empty 1 c in
   for i = 0 to c - 1 do
     let x = a +. (float_of_int i *. (b -. a) /. float_of_int c) in
-    let y = (p.{0,0} *. x +. p.{2,0}) /. (p.{1,0} *. (-1.)) in
-    x'.{0,i} <- x; y'.{0,i} <- y
+    let y = (Mat.get p 0 0 *. x +. Mat.get p 2 0) /. (Mat.get p 1 0 *. (-1.)) in
+    Mat.set x' 0 i x; Mat.set y' 0 i y
   done;
   let h = Plot.create "plot_svm.png" in
   Plot.(plot ~h ~spec:[ RGB (100,100,100) ] x' y');
@@ -42,4 +42,4 @@ let _ =
   let r = Regression.D.svm ~i:true x y in
   let p = Mat.(r.(0) @= r.(1)) in
   draw_line (Mat.col x 0) (Mat.col x 1) p;
-  Mat.pp_dsmat Mat.(r.(0) @= r.(1))
+  Owl_pretty.print_dsnda Mat.(r.(0) @= r.(1))


### PR DESCRIPTION
This pullreq fix some examples: maybe because of the change of signature, typing failed.
See commit log for the detail.

Other errors remain in examples:

- test_lda.ml, tfidf.ml
  data is missing even after execution of `Owl.Dataset.download_all`
- test_log.ml, computation_graph_01.ml, computation_graph_02.ml
  typing error
- opencl_03.ml
  abort due to `Exception: Owl_opencl_generated.EXN_MEM_OBJECT_ALLOCATION_FAILURE.`
- opencl_cifar.ml
  segmentation fault
- opencl_context.ml
   The implementation of Owl_opencl_context.eval`  seem to have a bug. I will make another issue.