### PR TITLE
tukey fences implementation

### DIFF
--- a/src/owl/stats/owl_stats.ml
+++ b/src/owl/stats/owl_stats.ml
@@ -761,5 +761,10 @@ let gibbs_sampling f p n =
   done; s
 
 
+let tukey_fences ?(k=1.5) arr =
+  let first_quartile = first_quartile arr in
+  let third_quartile = third_quartile arr in
+  let offset = k *. (third_quartile -. first_quartile) in
+  first_quartile -. offset, third_quartile +. offset
 
 (* ends here *)

--- a/src/owl/stats/owl_stats.ml
+++ b/src/owl/stats/owl_stats.ml
@@ -767,4 +767,6 @@ let tukey_fences ?(k=1.5) arr =
   let offset = k *. (third_quartile -. first_quartile) in
   first_quartile -. offset, third_quartile +. offset
 
+
+
 (* ends here *)

--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -1020,4 +1020,15 @@ val dirichlet_logpdf : float array -> alpha:float array -> float
 (** TODO *)
 
 
+(**
+``tukey_fences ?k x`` returns a tuple of the lower and upper boundaries for
+values that are not outliers. ``k`` defaults to the standard coefficient of ``1.5``.
+For first and third quartiles ``Q1`` and `Q3`, the range is computed as follows:
+
+.. math::
+  (Q1 - k*(Q3-Q1), Q3 + k*(Q3-Q1))
+*)
+val tukey_fences : ?k:float -> float array -> float * float
+
+
 (* ends here *)

--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -1019,7 +1019,7 @@ val dirichlet_pdf : float array -> alpha:float array -> float
 val dirichlet_logpdf : float array -> alpha:float array -> float
 (** TODO *)
 
-
+val tukey_fences : ?k:float -> float array -> float * float
 (**
 ``tukey_fences ?k x`` returns a tuple of the lower and upper boundaries for
 values that are not outliers. ``k`` defaults to the standard coefficient of ``1.5``.
@@ -1028,7 +1028,6 @@ For first and third quartiles ``Q1`` and `Q3`, the range is computed as follows:
 .. math::
   (Q1 - k*(Q3-Q1), Q3 + k*(Q3-Q1))
 *)
-val tukey_fences : ?k:float -> float array -> float * float
 
 
 (* ends here *)


### PR DESCRIPTION
This PR adds a function to compute [tukey fences](https://en.wikipedia.org/wiki/Outlier#Tukey's_fences):

`val tukey_fences : ?k:float -> float array -> float * float`

Given an array of floats, it determines the lower and upper bounds for non outlier values. 
 

