### PR TITLE
rename jbuilder to dune in readme and docker files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ git clone https://github.com/owlbarn/owl.git
 Second, you need to figure out the missing dependencies and install them.
 
 ```bash
-jbuilder external-lib-deps --missing @install
+dune external-lib-deps --missing @install
 ```
 
 Last, this is perhaps the most classic step.

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -12,7 +12,7 @@ USER opam
 
 RUN sudo apk update
 RUN sudo apk add m4 wget unzip aspcud openblas-dev
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes alcotest utop base stdio configurator
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes alcotest utop base stdio configurator
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -15,7 +15,7 @@ RUN sudo yum -y install git wget unzip m4 pkg-config gcc-gfortran epel-release
 RUN sudo yum -y install openblas-devel
 
 RUN opam update && opam switch 4.06.0 && eval $(opam config env)
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -12,7 +12,7 @@ USER opam
 
 RUN sudo apt-get -y update
 RUN sudo apt-get -y install m4 wget unzip aspcud libshp-dev libplplot-dev gfortran
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes alcotest utop plplot eigen base stdio configurator
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes alcotest utop plplot eigen base stdio configurator
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -15,7 +15,7 @@ RUN sudo yum -y install git wget unzip m4 pkg-config gcc-gfortran
 RUN sudo dnf -y install openblas-devel
 
 RUN opam update && opam switch 4.06.0 && eval $(opam config env)
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -15,7 +15,7 @@ RUN sudo zypper -n in git wget unzip m4 pkg-config gcc-fortran
 RUN sudo sudo zypper ref && sudo zypper -n in openblas-devel && sudo update-alternatives --config libblas.so.3
 
 RUN opam update && opam switch 4.06.0 && eval $(opam config env)
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes utop eigen base stdio configurator alcotest
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -16,7 +16,7 @@ RUN sudo apt-get -y install camlp4-extra libshp-dev libplplot-dev
 RUN sudo apt-get -y install libopenblas-dev liblapacke-dev
 
 RUN opam update && opam switch 4.06.0 && eval $(opam config env)
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes utop eigen plplot base stdio configurator alcotest
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes utop eigen plplot base stdio configurator alcotest
 
 
 #################### SET UP ENV VARS #######################

--- a/docker/Dockerfile.ubuntu.arm
+++ b/docker/Dockerfile.ubuntu.arm
@@ -23,7 +23,7 @@ RUN wget https://github.com/ocaml/opam/releases/download/$VER/opam-full-$VER.tar
 
 RUN yes | opam init && eval $(opam config env) && opam switch create 4.06.0
 
-RUN opam install -y oasis jbuilder ocaml-compiler-libs ctypes plplot alcotest utop base stdio configurator
+RUN opam install -y oasis dune ocaml-compiler-libs ctypes plplot alcotest utop base stdio configurator
 
 #################### SET UP ENV VARS #######################
 


### PR DESCRIPTION
This minor PR renames some remaining dangling references from `jbuilder` to `dune` in the `README.md` and docker related files.