### PR TITLE
Add log1mexp and log1pexp

### DIFF
--- a/src/base/maths/owl_base_maths.ml
+++ b/src/base/maths/owl_base_maths.ml
@@ -183,6 +183,22 @@ let logit x = log (x /. (1. -. x))
 let expit x = 1. /. (1. +. exp(-.x))
 
 
+let log1mexp x =
+  if -.x > log 2. then log1p (-.(exp x))
+  else log (-.(expm1 x))
+
+
+let log1pexp x =
+  if x <= -37. then
+    exp x
+  else if x <= 18. then
+    log1p (exp x)
+  else if x <= 33.3 then
+    x +. exp(-.x)
+  else
+    x
+
+
 (* Helper functions *)
 
 let is_nan x = FP_nan = classify_float x

--- a/src/base/maths/owl_base_maths.mli
+++ b/src/base/maths/owl_base_maths.mli
@@ -176,6 +176,12 @@ val logit : float -> float
 val expit : float -> float
 (** ``expit(x)`` *)
 
+val log1mexp : float -> float
+(** ``log1mexp(x)`` *)
+
+val log1pexp : float -> float
+(** ``log1pexp(x)`` *)
+
 
 (** {6 Helper functions} *)
 

--- a/src/owl/maths/owl_maths.h
+++ b/src/owl/maths/owl_maths.h
@@ -183,6 +183,10 @@ extern double expit(double x);
 
 extern double logit(double x);
 
+extern double log1mexp(double x);
+
+extern double log1pexp(double x);
+
 extern double logabs(double x);
 
 extern double sinc(double x);

--- a/src/owl/maths/owl_maths.ml
+++ b/src/owl/maths/owl_maths.ml
@@ -154,6 +154,10 @@ let logit x = Owl_maths_special.logit x
 
 let expit x = Owl_maths_special.expit x
 
+let log1mexp x = Owl_maths_special.log1mexp x
+
+let log1pexp x = Owl_maths_special.log1pexp x
+
 let airy x =
   let ai = Ctypes.(allocate double 0.) in
   let aip = Ctypes.(allocate double 0.) in

--- a/src/owl/maths/owl_maths.mli
+++ b/src/owl/maths/owl_maths.mli
@@ -219,6 +219,12 @@ val logit : float -> float
 val expit : float -> float
 (** ``expit(x)`` returns :math:`1/(1+\exp(-x))`. *)
 
+val log1mexp : float -> float
+(** ``log1mexp(x)`` returns :math:`log(1-exp(x))`. *)
+
+val log1pexp : float -> float
+(** ``log1pexp(x)`` returns :math:`log(1+exp(x))`. *)
+
 
 (** {6 Airy functions} *)
 

--- a/src/owl/maths/owl_maths_special.ml
+++ b/src/owl/maths/owl_maths_special.ml
@@ -155,6 +155,10 @@ external logit : float -> float = "owl_stub_sf_logit"
 
 external expit : float -> float = "owl_stub_sf_expit"
 
+external log1mexp : float -> float = "owl_stub_sf_log1mexp"
+
+external log1pexp : float -> float = "owl_stub_sf_log1pexp"
+
 external logabs : float -> float = "owl_stub_sf_logabs"
 
 external sinc : float -> float = "owl_stub_sf_sinc"

--- a/src/owl/maths/owl_maths_special_impl.c
+++ b/src/owl/maths/owl_maths_special_impl.c
@@ -37,6 +37,26 @@ double logit(double x) {
 }
 
 
+double log1mexp(double x) {
+  if (-x > OWL_LOGE2)
+    return log1p(-exp(x));
+  else
+    return log(-expm1(x));
+}
+
+
+double log1pexp(double x) {
+  if (x <= -37.)
+    return exp(x);
+  else if (x <= 18.)
+    return log1p(exp(x));
+  else if (x <= 33.3)
+    return x + exp(-x);
+  else
+    return x;
+}
+
+
 double logabs(double x) {
   return log(fabs (x));
 }

--- a/src/owl/maths/owl_maths_special_stub.c
+++ b/src/owl/maths/owl_maths_special_stub.c
@@ -413,6 +413,20 @@ value owl_stub_sf_expit(value vX) {
 }
 
 
+value owl_stub_sf_log1mexp(value vX) {
+  double x = Double_val(vX);
+  double y = log1mexp(x);
+  return caml_copy_double(y);
+}
+
+
+value owl_stub_sf_log1pexp(value vX) {
+  double x = Double_val(vX);
+  double y = log1pexp(x);
+  return caml_copy_double(y);
+}
+
+
 value owl_stub_sf_logabs(value vX) {
   double x = Double_val(vX);
   double y = logabs(x);


### PR DESCRIPTION
Adds the log1mexp and log1pexp functions for accurate computation of log(1 + exp(x)) and log(1 - exp(x)), respectively:

https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf