### PR TITLE
Improve numerical accuracy in stats distributions

### DIFF
--- a/src/owl/stats/owl_stats_dist_beta.c
+++ b/src/owl/stats/owl_stats_dist_beta.c
@@ -5,6 +5,7 @@
 
 #include "owl_maths.h"
 #include "owl_stats.h"
+#include "owl_cdflib.h"
 
 /** Beta distribution **/
 
@@ -43,26 +44,16 @@ double beta_rvs(double a, double b)
 }
 
 double beta_pdf(double x, double a, double b) {
-  if (x < 0 || x > 1)
-    return 0;
-  else {
-    double gab = lgam(a + b);
-    double ga = lgam(a);
-    double gb = lgam(b);
-
-    if (x == 0.0 || x == 1.0) {
-      if (a > 1.0 && b > 1.0)
-        return 0.0;
-      else
-       return exp(gab - ga - gb) * pow(x, a - 1) * pow(1 - x, b - 1);
-    }
-    else
-      return exp(gab - ga - gb + log(x) * (a - 1)  + log1p(-x) * (b - 1));
-    }
+  return exp(beta_logpdf(x, a, b));
 }
 
 double beta_logpdf(double x, double a, double b) {
-  return log(beta_pdf(x, a, b));
+  if (x < 0 || x > 1)
+    return OWL_NEGINF;
+  else {
+    double bl = betaln(&a, &b);
+    return xlogy(a - 1, x) + xlog1py(b - 1, -x) - bl;
+  }
 }
 
 double beta_cdf(double x, double a, double b) {
@@ -82,7 +73,7 @@ double beta_sf(double x, double a, double b) {
 }
 
 double beta_logsf(double x, double a, double b) {
-  return log(1 - beta_cdf(x, a, b));
+  return log1p(-beta_cdf(x, a, b));
 }
 
 double beta_isf(double q, double a, double b) {

--- a/src/owl/stats/owl_stats_dist_binomial.c
+++ b/src/owl/stats/owl_stats_dist_binomial.c
@@ -37,24 +37,23 @@ long binomial_rvs (double p, long n) {
 
 
 double binomial_pdf (long k, double p, long n) {
-  if (k > n)
-    return 0;
-  else {
-    if (p == 0)
-      return (k == 0) ? 1 : 0;
-    else if (p == 1)
-      return (k == n) ? 1 : 0;
-    else {
-      double ln_cnk = sf_log_combination (n, k);
-      double pp = ln_cnk + k * log (p) + (n - k) * log1p (-p);
-      return exp (pp);
-    }
-  }
+  return exp (binomial_logpdf (k, p, n));
 }
 
 
 double binomial_logpdf (long k, double p, long n) {
-  return log (binomial_pdf (k, p, n));
+  if (k > n)
+    return OWL_NEGINF;
+  else {
+    if (p == 0)
+      return (k == 0) ? 0. : OWL_NEGINF;
+    else if (p == 1)
+      return (k == n) ? 0. : OWL_NEGINF;
+    else {
+      double ln_cnk = sf_log_combination (n, k);
+      return ln_cnk + k * log (p) + (n - k) * log1p (-p);
+    }
+  }
 }
 
 
@@ -70,7 +69,13 @@ double binomial_cdf (long k, double p, long n) {
 
 
 double binomial_logcdf (long k, double p, long n) {
-  return log (binomial_cdf (k, p, n));
+  if (k >= n)
+    return 0.;
+  else {
+    double a = (double) k + 1.;
+    double b = (double) n - k;
+    return beta_logsf(p, a, b);
+  }
 }
 
 

--- a/src/owl/stats/owl_stats_dist_chi2.c
+++ b/src/owl/stats/owl_stats_dist_chi2.c
@@ -13,18 +13,18 @@ double chi2_rvs(double df) {
 }
 
 double chi2_pdf(double x, double df) {
-  if (x < 0)
-    return 0 ;
-  else {
-    if(df == 2.0)
-      return exp(-x / 2) / 2;
-    else
-      return exp((df / 2 - 1) * log (x / 2) - x / 2 - lgam(df / 2)) / 2;
-    }
+  return exp(chi2_logpdf(x, df));
 }
 
 double chi2_logpdf(double x, double df) {
-  return log(chi2_pdf(x, df));
+  if (x < 0)
+    return OWL_NEGINF;
+  else {
+    if (df == 2.0)
+      return -x / 2 - OWL_LOGE2;
+    else
+      return xlogy(df / 2 - 1, x / 2) - x / 2 - lgam (df / 2) - OWL_LOGE2;
+  }
 }
 
 double chi2_cdf(double x, double df) {

--- a/src/owl/stats/owl_stats_dist_exponential.c
+++ b/src/owl/stats/owl_stats_dist_exponential.c
@@ -21,7 +21,7 @@ double exponential_cdf(double x, double lambda) {
 }
 
 double exponential_logcdf(double x, double lambda) {
-  return log(-expm1(-lambda * x));
+  return log1mexp(-lambda * x);
 }
 
 double exponential_ppf(double q, double lambda) {

--- a/src/owl/stats/owl_stats_dist_exponpow.c
+++ b/src/owl/stats/owl_stats_dist_exponpow.c
@@ -52,14 +52,14 @@ double exponpow_rvs (const double a, const double b) {
 
 
 double exponpow_pdf (const double x, const double a, const double b) {
-  double l = lgam (1 + 1 / b);
-  double p = (1 / (2 * a)) * exp (-pow (fabs (x / a), b) - l);
-  return p;
+  return exp (exponpow_logpdf (x, a, b));
 }
 
 
 double exponpow_logpdf (const double x, const double a, const double b) {
-  return log (exponpow_pdf (x, a, b));
+  double l = lgam (1 + 1 / b);
+  double p = -log (2 * a) - pow (fabs (x / a), b) - l;
+  return p;
 }
 
 

--- a/src/owl/stats/owl_stats_dist_gamma.c
+++ b/src/owl/stats/owl_stats_dist_gamma.c
@@ -53,18 +53,18 @@ double gamma_rvs(double shape, double scale) {
 }
 
 double gamma_pdf(double x, double shape, double scale) {
-  if (x < 0)
-    return 0;
-  else if (x == 0)
-    return (shape == 1 ? 1 / scale : 0);
-  else if (shape == 1)
-    return exp(-x / scale) / scale;
-  else
-    return exp((shape - 1) * log(x/scale) - x/scale - lgam(shape)) / scale;
+  return exp(gamma_logpdf(x, shape, scale));
 }
 
 double gamma_logpdf(double x, double shape, double scale) {
-  return log(gamma_pdf(x, shape, scale));
+  if (x < 0)
+    return OWL_NEGINF;
+  else if (x == 0)
+    return (shape == 1 ? -log(scale) : OWL_NEGINF);
+  else if (shape == 1)
+    return -x / scale - log(scale);
+  else
+    return xlogy(shape - 1, x / scale) - x / scale - lgam(shape) - log(scale);
 }
 
 double gamma_cdf(double x, double shape, double scale) {

--- a/src/owl/stats/owl_stats_dist_gaussian.c
+++ b/src/owl/stats/owl_stats_dist_gaussian.c
@@ -28,7 +28,8 @@ double gaussian_cdf(double x, double mu, double sigma) {
 }
 
 double gaussian_logcdf(double x, double mu, double sigma) {
-  return log(gaussian_cdf(x, mu, sigma));
+  double y = (x - mu) / sigma;
+  return log_ndtr(y);
 }
 
 double gaussian_ppf(double q, double mu, double sigma) {
@@ -42,7 +43,7 @@ double gaussian_sf(double x, double mu, double sigma) {
 
 double gaussian_logsf(double x, double mu, double sigma) {
   double y = x - mu;
-  return log(gaussian_cdf(-y, 0., sigma));
+  return gaussian_logcdf(-y, 0., sigma);
 }
 
 double gaussian_isf(double q, double mu, double sigma) {
@@ -50,5 +51,5 @@ double gaussian_isf(double q, double mu, double sigma) {
 }
 
 double gaussian_entropy(double sigma) {
-  return 0.5 * (log(2 * OWL_PI) + 1) + log(sigma);
+  return 0.5 * (log(OWL_2PI) + 1) + log(sigma);
 }

--- a/src/owl/stats/owl_stats_dist_gumbel1.c
+++ b/src/owl/stats/owl_stats_dist_gumbel1.c
@@ -15,11 +15,11 @@ double gumbel1_rvs(double a, double b) {
 }
 
 double gumbel1_pdf(double x, double a, double b) {
-  return a * b *  exp(-(b * exp(-a * x) + a * x));
+  return exp(gumbel1_logpdf(x, a, b));
 }
 
 double gumbel1_logpdf(double x, double a, double b) {
-  return log(gumbel1_pdf(x, a, b));
+  return log(a) + log(b) - (b * exp(-a * x) + a * x);
 }
 
 double gumbel1_cdf(double x, double a, double b) {

--- a/src/owl/stats/owl_stats_dist_gumbel2.c
+++ b/src/owl/stats/owl_stats_dist_gumbel2.c
@@ -15,22 +15,22 @@ double gumbel2_rvs(double a, double b) {
 }
 
 double gumbel2_pdf(double x, double a, double b) {
-  if (x <= 0)
-    return 0;
-  else
-    return b * a * pow(x, -(a + 1)) * exp (-b * pow(x, -a));
+  return exp(gumbel2_logpdf(x, a, b));
 }
 
 double gumbel2_logpdf(double x, double a, double b) {
-  return log(gumbel2_pdf(x, a, b));
+  if (x <= 0)
+    return OWL_NEGINF;
+  else
+    return log(b) + log(a) - xlogy(a + 1, x) - b * pow(x, -a);
 }
 
 double gumbel2_cdf(double x, double a, double b) {
-  return (x == 0) ? 0 : exp(-b / pow(x, a));
+  return exp(gumbel2_logcdf(x, a, b));
 }
 
 double gumbel2_logcdf(double x, double a, double b) {
-  return log(gumbel2_cdf(x, a, b));
+  return (x == 0) ? OWL_NEGINF : -b / pow(x, a);
 }
 
 double gumbel2_ppf(double p, double a, double b) {

--- a/src/owl/stats/owl_stats_dist_laplace.c
+++ b/src/owl/stats/owl_stats_dist_laplace.c
@@ -43,12 +43,12 @@ double laplace_ppf(double q, double loc, double scale) {
 }
 
 double laplace_sf(double x, double loc, double scale) {
-  double y = (x - loc) / scale;
-  return (y < 0) ? (1 - exp(y) / 2) : (exp(-y) / 2);
+  return exp(laplace_logsf(x, loc, scale));
 }
 
 double laplace_logsf(double x, double loc, double scale) {
-  return log(laplace_sf(x, loc, scale));
+  double y = (x - loc) / scale;
+  return (y < 0) ? log1p(-exp(y) / 2) : -y - OWL_LOGE2;
 }
 
 double laplace_isf(double q, double loc, double scale) {

--- a/src/owl/stats/owl_stats_dist_logistic.c
+++ b/src/owl/stats/owl_stats_dist_logistic.c
@@ -29,7 +29,7 @@ double logistic_cdf(double x, double loc, double scale) {
 
 double logistic_logcdf(double x, double loc, double scale) {
   double y = (x - loc) / scale;
-  return log(expit(y));
+  return -log1pexp(-y);
 }
 
 double logistic_ppf(double q, double loc, double scale) {
@@ -43,7 +43,7 @@ double logistic_sf(double x, double loc, double scale) {
 
 double logistic_logsf(double x, double loc, double scale) {
   double y = (x - loc) / scale;
-  return log(expit(-y));
+  return -log1pexp(y);
 }
 
 double logistic_isf(double q, double loc, double scale) {

--- a/src/owl/stats/owl_stats_dist_lognormal.c
+++ b/src/owl/stats/owl_stats_dist_lognormal.c
@@ -13,16 +13,16 @@ double lognormal_rvs(double mu, double sigma) {
 }
 
 double lognormal_pdf(double x, double mu, double sigma) {
-  if (x <= 0)
-    return 0;
-  else {
-    double y = (log(x) - mu) / sigma;
-    return 1 / (x * fabs(sigma) * sqrt(2 * OWL_PI)) * exp(-(y * y) / 2);
-  }
+  return exp(lognormal_logpdf(x, mu, sigma));
 }
 
 double lognormal_logpdf(double x, double mu, double sigma) {
-  return log(lognormal_pdf(x, mu, sigma));
+  if (x <= 0)
+    return OWL_NEGINF;
+  else {
+    double y = (log(x) - mu) / sigma;
+    return -log(x) - logabs(sigma) - 0.5 * log(OWL_2PI) - y * y / 2;
+  }
 }
 
 double lognormal_cdf(double x, double mu, double sigma) {
@@ -32,7 +32,7 @@ double lognormal_cdf(double x, double mu, double sigma) {
 
 double lognormal_logcdf(double x, double mu, double sigma) {
   double y = (log(x) - mu) / sigma;
-  return log(ndtr(y));
+  return log_ndtr(y);
 }
 
 double lognormal_ppf(double q, double mu, double sigma) {
@@ -45,7 +45,8 @@ double lognormal_sf(double x, double mu, double sigma) {
 }
 
 double lognormal_logsf(double x, double mu, double sigma) {
-  return log(lognormal_sf(x, mu, sigma));
+  double y = (log(x) - mu) / sigma;
+  return log1p(-ndtr(y));
 }
 
 double lognormal_isf(double q, double mu, double sigma) {

--- a/src/owl/stats/owl_stats_dist_lomax.c
+++ b/src/owl/stats/owl_stats_dist_lomax.c
@@ -9,15 +9,15 @@
 /** Lomax distribution, i.e. Pareto Type II distribution **/
 
 double lomax_rvs(double shape, double scale) {
-  return scale * (exp(std_exponential_rvs() / shape) - 1.);
+  return scale * (expm1(std_exponential_rvs() / shape));
 }
 
 double lomax_pdf(double x, double shape, double scale) {
-  return (x < scale) ? 0 : ( (shape / scale) / pow(x / scale, shape + 1) );
+  return (x < scale) ? 0 : exp(lomax_logpdf(x, shape, scale));
 }
 
 double lomax_logpdf(double x, double shape, double scale) {
-  return log(lomax_pdf(x, shape, scale));
+  return (x < scale) ? OWL_NEGINF : log(shape / scale) - xlogy(shape + 1, x / scale);
 }
 
 double lomax_cdf(double x, double shape, double scale) {
@@ -25,7 +25,7 @@ double lomax_cdf(double x, double shape, double scale) {
 }
 
 double lomax_logcdf(double x, double shape, double scale) {
-  return log(lomax_cdf(x, shape, scale));
+  return (x < scale) ? OWL_NEGINF : log1p(-pow(scale / x, shape));
 }
 
 double lomax_ppf(double p, double shape, double scale) {
@@ -42,7 +42,7 @@ double lomax_sf(double x, double shape, double scale) {
 }
 
 double lomax_logsf(double x, double shape, double scale) {
-  return log(lomax_sf(x, shape, scale));
+  return (x < scale) ? 0 : xlogy(shape, scale / x);
 }
 
 double lomax_isf(double q, double shape, double scale) {

--- a/src/owl/stats/owl_stats_dist_rayleigh.c
+++ b/src/owl/stats/owl_stats_dist_rayleigh.c
@@ -15,16 +15,16 @@ double rayleigh_rvs(double sigma) {
 }
 
 double rayleigh_pdf(double x, double sigma) {
-  if (x < 0)
-    return 0;
-  else {
-    double y = x / sigma;
-    return (y / sigma) * exp(-y * y / 2) ;
-  }
+  return exp(rayleigh_logpdf(x, sigma));
 }
 
 double rayleigh_logpdf(double x, double sigma) {
-  return log(rayleigh_pdf(x, sigma));
+  if (x < 0)
+    return OWL_NEGINF;
+  else {
+    double y = x / sigma;
+    return log(y) - log(sigma) - y * y / 2;
+  }
 }
 
 double rayleigh_cdf(double x, double sigma) {
@@ -33,7 +33,8 @@ double rayleigh_cdf(double x, double sigma) {
 }
 
 double rayleigh_logcdf(double x, double sigma) {
-  return log(rayleigh_cdf(x, sigma));
+  double y = x / sigma;
+  return log1mexp(-y * y / 2);
 }
 
 double rayleigh_ppf(double q, double sigma) {

--- a/src/owl/stats/owl_stats_dist_t.c
+++ b/src/owl/stats/owl_stats_dist_t.c
@@ -19,16 +19,13 @@ double t_rvs(double df, double loc, double scale) {
 }
 
 double t_pdf(double x, double df, double loc, double scale) {
-  double y = (x - loc) / scale;
-  double p = exp(lgam((df + 1) / 2) - lgam(df / 2));
-  p /= scale * sqrt(OWL_PI * df) * pow(1 + y * y / df, (df + 1) / 2);
-  return p;
+  return exp(t_logpdf(x, df, loc, scale));
 }
 
 double t_logpdf(double x, double df, double loc, double scale) {
   double y = (x - loc) / scale;
   double lp = lgam((df + 1) / 2) - lgam(df / 2);
-  lp -= log(scale) + 0.5 * log(OWL_PI * df) + log(1 + y * y / df) * (df + 1) / 2;
+  lp -= log(scale) + 0.5 * log(OWL_PI * df) + xlog1py((df + 1) / 2, y * y / df);
   return lp;
 }
 

--- a/src/owl/stats/owl_stats_dist_vonmises.c
+++ b/src/owl/stats/owl_stats_dist_vonmises.c
@@ -53,12 +53,12 @@ double vonmises_rvs(double mu, double kappa) {
 }
 
 double vonmises_pdf(double x, double mu, double kappa) {
-  x = x - mu;
-  return exp(kappa * cos(x)) / (2 * OWL_PI * i0(kappa));
+  return exp(vonmises_logpdf(x, mu, kappa));
 }
 
 double vonmises_logpdf(double x, double mu, double kappa) {
-  return log(vonmises_pdf(x, mu, kappa));
+  x = x - mu;
+  return kappa * cos(x) - log(OWL_2PI * i0(kappa));
 }
 
 double vonmises_entropy(double kappa) {
@@ -122,5 +122,5 @@ double vonmises_sf(double x, double mu, double kappa) {
 }
 
 double vonmises_logsf(double x, double mu, double kappa) {
-  return log(vonmises_sf(x, mu, kappa));
+  return log1p(-vonmises_cdf(x, mu, kappa));
 }

--- a/src/owl/stats/owl_stats_dist_wald.c
+++ b/src/owl/stats/owl_stats_dist_wald.c
@@ -21,8 +21,7 @@ double wald_rvs(double mu, double lambda) {
 }
 
 double wald_pdf(double x, double mu, double lambda) {
-  double y = (x - mu) / mu;
-  return sqrt(lambda) / sqrt(OWL_2PI * x * x * x) * exp(-lambda * y * y / (2 * x));
+  return exp(wald_logpdf(x, mu, lambda));
 }
 
 double wald_logpdf(double x, double mu, double lambda) {
@@ -51,7 +50,7 @@ double wald_sf(double x, double mu, double lambda) {
 }
 
 double wald_logsf(double x, double mu, double lambda) {
-  return log(1 - wald_cdf(x, mu, lambda));
+  return log1p(-wald_cdf(x, mu, lambda));
 }
 
 double wald_isf(double q, double mu, double lambda) {

--- a/src/owl/stats/owl_stats_dist_weibull.c
+++ b/src/owl/stats/owl_stats_dist_weibull.c
@@ -13,18 +13,20 @@ double weibull_rvs(double shape, double scale) {
 }
 
 double weibull_pdf(double x, double shape, double scale) {
-  if (x < 0)
-    return 0 ;
-  else if (x == 0)
-    return (shape == 1) ? (1 / scale) : 0;
-  else if (shape == 1)
-    return exp(-x / scale) / scale;
-  else
-    return (shape / scale) * exp(-pow (x / scale, shape) + (shape - 1) * log(x / scale));
+  return exp(weibull_logpdf(x, shape, scale));
 }
 
 double weibull_logpdf(double x, double shape, double scale) {
-  return log(weibull_pdf(x, shape, scale));
+  if (x < 0)
+    return OWL_NEGINF;
+  else if (x == 0)
+    return (shape == 1) ? -log(scale) : OWL_NEGINF;
+  else if (shape == 1)
+    return (-x / scale) - log(scale);
+  else {
+    x /= scale;
+    return log(shape) - log(scale) - pow(x, shape) + xlogy(shape - 1, x);
+  }
 }
 
 double weibull_cdf(double x, double shape, double scale) {
@@ -32,7 +34,7 @@ double weibull_cdf(double x, double shape, double scale) {
 }
 
 double weibull_logcdf(double x, double shape, double scale) {
-  return log(weibull_cdf(x, shape, scale));
+  return log1mexp(-pow(x / scale, shape));
 }
 
 double weibull_ppf(double p, double shape, double scale) {


### PR DESCRIPTION
Improves numerical accuracy of the statistical distributions to help dealing with small probabilities. Previously for example

`Owl.Stats.binomial_logpdf 1 ~p:0.5 ~n:2000`

would return -infinity, whereas now it returns `-1378.69345866034632`.