### PR TITLE
Implementation of Lambda Array neuron in neural module

### DIFF
--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -490,6 +490,13 @@ module Make
     add_node ?act_typ nn [|input_node|] n
 
 
+  let lambda_array ?name ?act_typ out_shape lambda input_node =
+    let neuron = LambdaArray (LambdaArray.create out_shape lambda) in
+    let nn = get_network input_node.(0) in
+    let n = make_node ?name [||] [||] neuron None nn in
+    add_node ?act_typ nn input_node n
+
+
   let add ?name ?act_typ input_node =
     let neuron = Add (Add.create ()) in
     let nn = get_network input_node.(0) in

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -389,9 +389,17 @@ Arguments:
   val lambda : ?name:string -> ?act_typ:Activation.typ -> (t -> t) -> node -> node
   (**
 ``lambda func node`` wraps arbitrary expression as a Node object.
-
 Arguments:
   * ``func``: The function to be evaluated. Takes input tensor as first argument.
+  *)
+
+  val lambda_array : ?name:string -> ?act_typ:Activation.typ -> int array -> (t array -> t) -> node array -> node
+  (**
+``lambda_array target_shape func node`` wraps arbitrary expression as a Node object.
+
+Arguments:
+  * ``target_shape``: the shape of the tensor returned by ``func``.
+  * ``func``: The function to be evaluated. Takes input tensor array as first argument.
   *)
 
   val add : ?name:string -> ?act_typ:Activation.typ -> node array -> node

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2216,6 +2216,45 @@ module Make
   end
 
 
+  (* definition of LambdaArray neuron *)
+  module LambdaArray = struct
+
+    type neuron_typ = {
+      mutable lambda    : t array -> t;
+      mutable in_shape  : int array;
+      mutable out_shape : int array;
+    }
+
+    let create o lambda = {
+      lambda;
+      in_shape  = [||];
+      out_shape = o;
+    }
+
+    let connect out_shape l =
+      l.in_shape <- Array.copy out_shape.(0)
+
+    let copy l = create l.out_shape l.lambda
+
+    let run x l =
+      let y = l.lambda x in
+      (* check that the output shape is indeed out_shape *)
+      let s = shape y in
+      assert (Array.sub s 1 ((Array.length s) - 1) = l.out_shape);
+      y
+
+    let to_string l =
+      let in_str = Owl_utils_array.to_string string_of_int l.in_shape in
+      let out_str = Owl_utils_array.to_string string_of_int l.out_shape in
+      Printf.sprintf "    LambdaArray  : in:[[*,%s],...] out:[*,%s]\n" in_str out_str ^
+      Printf.sprintf "    customised f : t array -> t\n" ^
+      ""
+
+    let to_name () = "lambda_array"
+
+  end
+
+
   (* definition of Dropout neuron *)
   module Dropout = struct
 
@@ -2918,6 +2957,7 @@ module Make
     | Reshape         of Reshape.neuron_typ
     | Flatten         of Flatten.neuron_typ
     | Lambda          of Lambda.neuron_typ
+    | LambdaArray     of LambdaArray.neuron_typ
     | Activation      of Activation.neuron_typ
     | GaussianNoise   of GaussianNoise.neuron_typ
     | GaussianDropout of GaussianDropout.neuron_typ
@@ -2962,6 +3002,7 @@ module Make
     | Reshape l         -> Reshape.(l.in_shape, l.out_shape)
     | Flatten l         -> Flatten.(l.in_shape, l.out_shape)
     | Lambda l          -> Lambda.(l.in_shape, l.out_shape)
+    | LambdaArray l     -> LambdaArray.(l.in_shape, l.out_shape)
     | Activation l      -> Activation.(l.in_shape, l.out_shape)
     | GaussianNoise l   -> GaussianNoise.(l.in_shape, l.out_shape)
     | GaussianDropout l -> GaussianDropout.(l.in_shape, l.out_shape)
@@ -3012,6 +3053,7 @@ module Make
     | Reshape l         -> Reshape.connect out_shapes.(0) l
     | Flatten l         -> Flatten.connect out_shapes.(0) l
     | Lambda l          -> Lambda.connect out_shapes.(0) l
+    | LambdaArray l     -> LambdaArray.connect out_shapes l
     | Activation l      -> Activation.connect out_shapes.(0) l
     | GaussianNoise l   -> GaussianNoise.connect out_shapes.(0) l
     | GaussianDropout l -> GaussianDropout.connect out_shapes.(0) l
@@ -3203,6 +3245,7 @@ module Make
     | Reshape l         -> Reshape Reshape.(copy l)
     | Flatten l         -> Flatten Flatten.(copy l)
     | Lambda l          -> Lambda Lambda.(copy l)
+    | LambdaArray l     -> LambdaArray LambdaArray.(copy l)
     | Activation l      -> Activation Activation.(copy l)
     | GaussianNoise l   -> GaussianNoise GaussianNoise.(copy l)
     | GaussianDropout l -> GaussianDropout GaussianDropout.(copy l)
@@ -3247,6 +3290,7 @@ module Make
     | Reshape l         -> Reshape.run a.(0) l
     | Flatten l         -> Flatten.run a.(0) l
     | Lambda l          -> Lambda.run a.(0) l
+    | LambdaArray l     -> LambdaArray.run a l
     | Activation l      -> Activation.run a.(0) l
     | GaussianNoise l   -> GaussianNoise.run a.(0) l
     | GaussianDropout l -> GaussianDropout.run a.(0) l
@@ -3291,6 +3335,7 @@ module Make
     | Reshape l         -> Reshape.to_string l
     | Flatten l         -> Flatten.to_string l
     | Lambda l          -> Lambda.to_string l
+    | LambdaArray l     -> LambdaArray.to_string l
     | Activation l      -> Activation.to_string l
     | GaussianNoise l   -> GaussianNoise.to_string l
     | GaussianDropout l -> GaussianDropout.to_string l
@@ -3335,6 +3380,7 @@ module Make
     | Reshape _         -> Reshape.to_name ()
     | Flatten _         -> Flatten.to_name ()
     | Lambda _          -> Lambda.to_name ()
+    | LambdaArray _     -> LambdaArray.to_name ()
     | Activation _      -> Activation.to_name ()
     | GaussianNoise _   -> GaussianNoise.to_name ()
     | GaussianDropout _ -> GaussianDropout.to_name ()

--- a/src/base/neural/owl_neural_neuron_sig.ml
+++ b/src/base/neural/owl_neural_neuron_sig.ml
@@ -1353,6 +1353,38 @@ module Lambda : sig
 end
 
 
+  (** {6 LambdaArray neuron} *)
+
+module LambdaArray : sig
+
+  type neuron_typ = {
+    mutable lambda    : t array -> t;
+    mutable in_shape  : int array;
+    mutable out_shape : int array;
+  }
+  (** Neuron type definition. *)
+
+  val create : int array -> (t array -> t) -> neuron_typ
+  (** Create the neuron. *)
+
+  val connect : int array array -> neuron_typ -> unit
+  (** Connect this neuron to others in a neural network. *)
+
+  val copy : neuron_typ -> neuron_typ
+  (** Make a deep copy of the neuron and its parameters. *)
+
+  val run : t array -> neuron_typ -> t
+  (** Execute the computation in this neuron. *)
+
+  val to_string : neuron_typ -> string
+  (** Convert the neuron to its string representation. The string is often a summary of the parameters defined in the neuron. *)
+
+  val to_name : unit -> string
+  (** Return the name of the neuron. *)
+
+end
+
+
   (** {6 Dropout neuron} *)
 
 module Dropout : sig
@@ -1882,6 +1914,7 @@ type neuron =
   | Reshape         of Reshape.neuron_typ
   | Flatten         of Flatten.neuron_typ
   | Lambda          of Lambda.neuron_typ
+  | LambdaArray     of LambdaArray.neuron_typ
   | Activation      of Activation.neuron_typ
   | GaussianNoise   of GaussianNoise.neuron_typ
   | GaussianDropout of GaussianDropout.neuron_typ


### PR DESCRIPTION
More generalised version of the `Lambda` layer, with an arbitrary output shape and a function lambda that takes an array of node as an argument (instead of a single node).

Signed-off-by: pvdhove <pierre.vdhove@gmail.com>