### PR TITLE
Implementation of heap + improved top and bottom + tests

### DIFF
--- a/src/base/misc/owl_utils.ml
+++ b/src/base/misc/owl_utils.ml
@@ -11,6 +11,8 @@ include Owl_utils_ndarray
 
 module Stack = Owl_utils_stack
 
+module Heap = Owl_utils_heap
+
 module Array = Owl_utils_array
 
 

--- a/src/base/misc/owl_utils_heap.ml
+++ b/src/base/misc/owl_utils_heap.ml
@@ -1,0 +1,105 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2018 Liang Wang <liang.wang@cl.cam.ac.uk>
+ *)
+
+(* A naive implementation of a min-heap for Owl's internal use. *)
+
+
+type 'a t = {
+  mutable used : int;
+  mutable data : 'a array;
+  cmp          : 'a -> 'a -> int;
+}
+
+let left_son pos = (pos lsl 1) + 1
+
+let right_son pos = (pos lsl 1) + 2
+
+let parent pos = (pos - 1) lsr 1
+
+(* can't set an initial size without knowing the type *)
+let make cmp = {
+  used = 0;
+  data = [||];
+  cmp;
+}
+
+let make_int ?(initial_size=0) cmp = {
+  used = 0;
+  data = Array.make initial_size 0;
+  cmp;
+}
+
+let make_float ?(initial_size=0) cmp = {
+  used = 0;
+  data = Array.make initial_size 0.;
+  cmp;
+}
+
+let size_arr heap = Array.length heap.data
+
+let extend_size heap =
+  heap.data <- Array.(append heap.data (copy heap.data))
+
+let size heap = heap.used
+
+let push ({used; cmp; _} as heap) x =
+  if size_arr heap = 0 then (
+    heap.data <- [|x|];
+    heap.used <- 1
+  )
+  else (
+    if size_arr heap <= used then (
+      extend_size heap
+    );
+    (* insert x at the end and swap it with its parent if x is smaller *)
+    let pos = ref used in
+    let par = ref (parent !pos) in
+    while !pos > 0 && cmp x heap.data.(!par) < 0 do
+      heap.data.(!pos) <- heap.data.(!par);
+      pos := !par;
+      par := parent (!pos);
+    done;
+    heap.used <- used + 1;
+    heap.data.(!pos) <- x
+  )
+
+let pop ({data; cmp; _} as heap) = match heap.used with
+  | 0 -> invalid_arg "owl_utils_heap: can't pop an element from an empty heap"
+  | _ ->
+     let x = data.(0) in
+     (* replace the first element with the last one and swap it with its
+      * smallest son *)
+     heap.used <- heap.used - 1;
+     data.(0) <- data.(heap.used);
+     let pos = ref 0 in
+     let again = ref true in
+     while !again do
+       let small = ref !pos in
+       let left = left_son !pos
+       and right = right_son !pos in
+       if left < heap.used && cmp data.(left) data.(!small) < 0 then (
+         small := left
+       );
+       if right < heap.used && cmp data.(right) data.(!small) < 0 then (
+         small := right
+       );
+       if !pos = !small then
+         again := false
+       else (
+         let tmp = data.(!pos) in
+         data.(!pos) <- data.(!small);
+         data.(!small) <- tmp;
+         pos := !small
+       );
+     done;
+     x
+
+let peek heap = match heap.used with
+  | 0 -> invalid_arg "owl_utils_heap: can't peek at an empty heap"
+  | _ -> heap.data.(0)
+
+let is_empty heap = heap.used = 0
+
+let to_array heap = Array.sub heap.data 0 heap.used

--- a/src/base/misc/owl_utils_heap.mli
+++ b/src/base/misc/owl_utils_heap.mli
@@ -1,0 +1,64 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2018 Liang Wang <liang.wang@cl.cam.ac.uk>
+ *)
+
+
+(** {6 Type definition} *)
+
+type 'a t = {
+  mutable used : int;
+  mutable data : 'a array;
+  cmp : 'a -> 'a -> int;
+}
+(** Type of a min heap. *)
+
+val make : ('a -> 'a -> int) -> 'a t
+(**
+``make cmp`` creates an empty min heap, using ``cmp`` as a comparison function.
+*)
+
+val make_int : ?initial_size:int -> (int -> int -> int) -> int t
+(**
+``make_int ?initial_size cmp`` creates an empty integer heap, using ``cmp`` as a
+comparison function and pre-allocates a space of ``initial_size`` elements.
+ *)
+
+val make_float : ?initial_size:int -> (float -> float -> int) -> float t
+(**
+``make_float ?initial_size cmp`` creates an empty float heap, using ``cmp`` as a
+comparison function and pre-allocates a space of ``initial_size`` elements.
+ *)
+
+val size : 'a t -> int
+(** ``size heap`` returns the number of elements in the heap. *)
+
+val push : 'a t -> 'a -> unit
+(**
+``push heap x`` pushes ``x`` into ``heap``. Time complexity is ``O(log(n))``,
+where n is the size of ``heap``.
+ *)
+
+val pop : 'a t -> 'a
+(**
+``pop heap`` pops the minimal element from ``heap``. It raises an exception if
+the heap is empty. Time complexity is ``O(log(n))``, where n is the size of
+``heap``.
+ *)
+
+val peek : 'a t -> 'a
+(**
+``peek heap`` returns the value of the minimal element in ``heap`` but it does
+not remove the element from the heap. Raises an exception if the heap is empty.
+Time complexity is ``O(1)``.
+ *)
+
+val is_empty : 'a t -> bool
+(**
+``is_empty heap`` returns ``true`` if ``heap`` is empty, ``false`` otherwise.
+ *)
+
+val to_array : 'a t -> 'a array
+(**
+``to_array heap`` returns the elements in ``heap`` into an (unsorted) array.
+ *)

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -556,14 +556,14 @@ by setting their values to zeros.
 val top : ('a, 'b) t -> int -> int array array
 (**
 ``top x n`` returns the indices of ``n`` greatest values of ``x``. The indices are
-arranged according to the corresponding elelment values, from the greatest one
+arranged according to the corresponding element values, from the greatest one
 to the smallest one.
  *)
 
 val bottom : ('a, 'b) t -> int -> int array array
 (**
 ``bottom x n`` returns the indices of ``n`` smallest values of ``x``. The indices
-are arranged according to the corresponding elelment values, from the smallest
+are arranged according to the corresponding element values, from the smallest
 one to the greatest one.
  *)
 

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -533,14 +533,14 @@ by setting their values to zeros.
 val top : ('a, 'b) t -> int -> int array array
 (**
 ``top x n`` returns the indices of ``n`` greatest values of ``x``. The indices
-are arranged according to the corresponding elelment values, from the greatest
+are arranged according to the corresponding element values, from the greatest
 one to the smallest one.
  *)
 
 val bottom : ('a, 'b) t -> int -> int array array
 (**
 ``bottom x n`` returns the indices of ``n`` smallest values of ``x``. The
-indices are arranged according to the corresponding elelment values, from the
+indices are arranged according to the corresponding element values, from the
 smallest one to the greatest one.
  *)
 

--- a/test/unit_dense_ndarray.ml
+++ b/test/unit_dense_ndarray.ml
@@ -342,6 +342,30 @@ module To_test = struct
     let z = M.argsort x in
     M.(y = z)
 
+  let top_1 () =
+    let arr = M.init Float64 [|50|] (fun i -> float i) in
+    let tops = M.top arr 50 in
+    tops = Array.init 50 (fun i -> [|49 - i|])
+
+  let top_2 () =
+    let arr = M.init Float64 [||] (fun _ -> 0.) in
+    let tops = M.top arr 0 in
+    tops = [||]
+
+  let top_3 () =
+    let arr = M.of_array Float32 [|5.;7.;4.;2.;6.;8.;9.;1.;3.|] [|3;3|] in
+    let tops = M.top arr 4 in
+    tops = [|[|2;0|]; [|1;2|]; [|0;1|]; [|1;1|]|]
+
+  let bottom_1 () =
+    let arr = M.of_array Float32 [|5.;7.;4.;2.;6.;8.;9.;1.;3.|] [|3;3|] in
+    let bottoms = M.bottom arr 5 in
+    bottoms = [|[|2;1|]; [|1;0|]; [|2;2|]; [|0;2|]; [|0;0|]|]
+
+  let bottom_2 () =
+    let arr = M.of_array Float64 [|1.;2.;3.;1000.;4.|] [|5|] in
+    let bottoms = M.bottom arr 4 in
+    bottoms = [|[|0|]; [|1|]; [|2|]; [|4|]|]
 
 end
 
@@ -566,6 +590,21 @@ let argsort_1 () =
 let argsort_2 () =
   Alcotest.(check bool) "argsort_2" true (To_test.argsort_2 ())
 
+let top_1 () =
+  Alcotest.(check bool) "top_1" true (To_test.top_1 ())
+
+let top_2 () =
+  Alcotest.(check bool) "top_2" true (To_test.top_2 ())
+
+let top_3 () =
+  Alcotest.(check bool) "top_3" true (To_test.top_3 ())
+
+let bottom_1 () =
+  Alcotest.(check bool) "bottom_1" true (To_test.bottom_1 ())
+
+let bottom_2 () =
+  Alcotest.(check bool) "bottom_2" true (To_test.bottom_2 ())
+
 let test_set = [
   "shape", `Slow, shape;
   "num_dims", `Slow, num_dims;
@@ -640,4 +679,9 @@ let test_set = [
   "sort", `Slow, sort;
   "argsort_1", `Slow, argsort_1;
   "argsort_2", `Slow, argsort_2;
+  "top_1", `Slow, top_1;
+  "top_2", `Slow, top_2;
+  "top_3", `Slow, top_3;
+  "bottom_1", `Slow, bottom_1;
+  "bottom_2", `Slow, bottom_2;
 ]


### PR DESCRIPTION
Fixes Issue #305.
Implementation of a min-heap using an array representation.
Use of this min-heap to improve the time complexity of functions `top x k` and `bottom x k` in the Ndarray module, from O(n * k) to O(n * log(k)).
The time taken by these functions is now much more predictable.
The worst case for `top` is when the ndarray is initially sorted in increasing order. This improvement can be tested with the following example:
```
let arr = Dense.Ndarray.D.init [|1000000|] (fun i -> float i) in
let result = Dense.Ndarray.D.top arr 100000 in
...
```
This used to take several minutes on my laptop, but it now takes only a few seconds.