### PR TITLE
Add pad operations and Padding2D neuron

### DIFF
--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -54,6 +54,7 @@ module Make
         | Reverse                                       -> _eval_map_01 x (fun ~out x -> A.reverse_ ~out x.(0))
         | Tile repeats                                  -> _eval_map_01 x (fun ~out x -> A.tile_ ~out x.(0) repeats)
         | Repeat repeats                                -> _eval_map_01 x (fun ~out x -> A.repeat_ ~out x.(0) repeats)
+        | Pad (v, padding)                              -> _eval_map_01 x (fun ~out x -> A.pad_ ~out ~v:(unpack_elt v) padding x.(0))
         | Concatenate axis                              -> _eval_map_00 x A.(concatenate ~axis)
         | Split (_axis, _parts)                         -> failwith "Split"
         | Draw (_axis, _n)                              -> failwith "Draw"

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -123,6 +123,7 @@ module Make
         | Reverse                                        -> _init_01 x
         | Tile _repeats                                  -> _init_00 x
         | Repeat _repeats                                -> _init_00 x
+        | Pad (_v, _padding)                             -> _init_00 x
         | Concatenate _axis                              -> _init_00 x
         | Split (_axis, _parts)                          -> failwith "Split"
         | Draw (_axis, _n)                               -> failwith "Draw"

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -123,6 +123,13 @@ module Make
   let repeat x repeats =
     make_then_connect (Repeat repeats) [|arr_to_node x|] |> node_to_arr
 
+  let pad ?v padding x =
+    let v = match v with
+      | Some v -> v
+      | None   -> const_elt "pad_v" (A.float_to_elt 0.)
+    in
+    make_then_connect (Pad (v, padding)) [|arr_to_node x|] |> node_to_arr
+
   let concatenate ?(axis=0) xs =
     make_then_connect (Concatenate axis) (Array.map arr_to_node xs) |> node_to_arr
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -86,6 +86,9 @@ module type Sig = sig
   val repeat : arr -> int array -> arr
   (** TODO *)
 
+  val pad : ?v:elt -> int list list -> arr -> arr
+  (** TODO *)
+
   val concatenate : ?axis:int -> arr array -> arr
   (** TODO *)
 

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -49,6 +49,7 @@ module Make
         | Reverse                                        -> pattern_000 x
         | Tile _repeats                                  -> pattern_000 x
         | Repeat _repeats                                -> pattern_023 x
+        | Pad (_v, _padding)                             -> pattern_000 x
         | Concatenate _axis                              -> pattern_000 x
         | Split (_axis, _parts)                          -> pattern_000 x
         | Draw (_axis, _n)                               -> pattern_000 x

--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -236,6 +236,14 @@ module Make
     | _          -> [| None |]
 
 
+  let _infer_shape_30 input_shapes pad =
+    let input_shape = input_shapes.(0).(0) in
+    let pad = Owl_utils.llss2aarr pad in
+    match input_shape with
+    | Some input -> [| Some (Array.map2 (fun m n -> m + n.(0) + n.(1)) input pad) |]
+    | _          -> [| None |]
+
+
   let infer_shape operator args =
     let input_shapes = Array.map (fun a -> (Owl_graph.attr a).shape) args in
     match operator with
@@ -248,6 +256,7 @@ module Make
     | Reverse                                        -> _infer_shape_01 input_shapes
     | Tile repeats                                   -> _infer_shape_05 input_shapes repeats
     | Repeat repeats                                 -> _infer_shape_06 input_shapes repeats
+    | Pad (_v, padding)                              -> _infer_shape_30 input_shapes padding
     | Concatenate axis                               -> _infer_shape_07 input_shapes axis
     | Split (axis, parts)                            -> _infer_shape_08 input_shapes axis parts
     | Draw (axis, n)                                 -> _infer_shape_09 input_shapes axis n

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -165,6 +165,7 @@ module Make
     | AvgPool2dBackward (_padding, _kernel, _stride) -> "AvgPool2dBackward"
     | AvgPool3dBackward (_padding, _kernel, _stride) -> "AvgPool3dBackward"
     | UpSampling2dBackward _size                     -> "UpSampling2dBackward"
+    | Pad (_v, _padding)                             -> "Pad"
     | RowNum                                         -> "RowNum"
     | ColNum                                         -> "ColNum"
     | Row                                            -> "Row"

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -62,6 +62,7 @@ module Make
     | Reverse
     | Tile                          of int array
     | Repeat                        of int array
+    | Pad                           of elt * int list list
     | Concatenate                   of int
     | Split                         of int * int array
     | Draw                          of int * int

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -61,6 +61,7 @@ module type Sig = sig
     | Reverse
     | Tile                          of int array
     | Repeat                        of int array
+    | Pad                           of elt * int list list
     | Concatenate                   of int
     | Split                         of int * int array
     | Draw                          of int * int

--- a/src/base/dense/owl_base_dense_ndarray_c.mli
+++ b/src/base/dense/owl_base_dense_ndarray_c.mli
@@ -79,6 +79,8 @@ val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array
 
+val pad : ?v:elt -> int list list -> arr -> arr
+
 val one_hot : int -> arr -> arr
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -79,6 +79,8 @@ val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array
 
+val pad : ?v:elt -> int list list -> arr -> arr
+
 val one_hot : int -> arr -> arr
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -595,7 +595,7 @@ let split ?(axis=0) parts varr =
   (Array.map (fun def -> get_slice def varr) slices_defs)
 
 
-(*TODO : ensure this is desired behaviour *)
+(* TODO : ensure this is desired behaviour *)
 (* Similar to draw rows for matrices *)
 let draw ?(axis=0) varr count =
   let dims = shape varr in
@@ -606,6 +606,76 @@ let draw ?(axis=0) varr count =
         (fun i -> if i = axis then (Array.to_list indices) else []))
      varr,
    indices)
+
+
+let _expand_padding_index d s =
+  let ls = Array.length s in
+  let ld = Array.length d in
+  let d = Owl_utils.Array.pad `Right [|0;0|] (ls - ld) d in
+  Array.map (function
+    | [||]  -> [|0;0|]
+    | [|x|] -> [|x;x|]
+    | x     -> x
+  ) d
+
+
+let rec _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x0 x1 =
+  if d0 < d1 then (
+    for i = 0 to s0.(d0) - 1 do
+      i0.(d0) <- i;
+      i1.(d0) <- i + p1.(d0).(0);
+      _copy_to_padding p1 ls l0 l1 i0 i1 (d0 + 1) d1 s0 s1 x0 x1;
+      i0.(d0) <- 0;
+      i1.(d0) <- p1.(d0).(0);
+    done
+  )
+  else (
+    let j0 = Owl_utils.index_nd_1d i0 l0 in
+    let j1 = Owl_utils.index_nd_1d i1 l1 in
+    (* _owl_copy (kind x0) ls.(d0) ~ofsx:j0 ~incx:1 ~ofsy:j1 ~incy:1 x0 x1 *)
+    Printf.fprintf stderr "sub:: %d, %d, (%d)\n" j0 j1 ls.(d0);
+    let subx = Genarray.sub_left x0 j0 ls.(d0) in
+    let suby = Genarray.sub_left x1 j1 ls.(d0) in
+    Genarray.blit subx suby
+  )
+
+
+let _highest_padding_dimension p =
+  let l = Array.length p - 1 in
+  let d = ref l in
+  (try for i = l downto 0 do
+    d := i;
+    if p.(i) <> [|0;0|] then failwith "stop"
+  done with _exn -> ());
+  !d
+
+
+let pad ?v d x =
+  let k = kind x in
+  let v = match v with
+    | Some v -> v
+    | None   -> Owl_const.zero k
+  in
+  let s0 = shape x in
+  let x' = flatten x in
+  let p1 = _expand_padding_index (Owl_utils.llss2aarr d) s0 in
+  let s1 = Array.map2 (fun m n -> m + n.(0) + n.(1)) s0 p1 in
+  let s' = Owl_utils_array.fold_right ( * ) s1 1 in
+  let y' = create k [|s'|] v in
+  let ls = Owl_utils.calc_slice s0 in
+  Printf.fprintf stderr "ls: %s\n" (Owl_utils_array.to_string string_of_int ls);
+  let l0 = Owl_utils.calc_stride s0 in
+  Printf.fprintf stderr "l0: %s\n" (Owl_utils_array.to_string string_of_int l0);
+  let l1 = Owl_utils.calc_stride s1 in
+  Printf.fprintf stderr "s1: %s\n" (Owl_utils_array.to_string string_of_int s1);
+  let i0 = Array.make (num_dims x) 0 in
+  let i1 = Array.map (fun a -> a.(0)) p1 in
+  Printf.fprintf stderr "i1: %s\n" (Owl_utils_array.to_string string_of_int i1);
+  let d0 = 0 in
+  let d1 = _highest_padding_dimension p1 in
+  Printf.fprintf stderr "d1: %d\n" d1;
+  _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x' y';
+  reshape y' s1
 
 
 (* TODO: optimise? *)

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -611,7 +611,7 @@ let draw ?(axis=0) varr count =
 let _expand_padding_index d s =
   let ls = Array.length s in
   let ld = Array.length d in
-  let d = Owl_utils.Array.pad `Right [|0;0|] (ls - ld) d in
+  let d  = Owl_utils.Array.pad `Right [|0;0|] (ls - ld) d in
   Array.map (function
     | [||]  -> [|0;0|]
     | [|x|] -> [|x;x|]
@@ -632,8 +632,6 @@ let rec _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x0 x1 =
   else (
     let j0 = Owl_utils.index_nd_1d i0 l0 in
     let j1 = Owl_utils.index_nd_1d i1 l1 in
-    (* _owl_copy (kind x0) ls.(d0) ~ofsx:j0 ~incx:1 ~ofsy:j1 ~incy:1 x0 x1 *)
-    Printf.fprintf stderr "sub:: %d, %d, (%d)\n" j0 j1 ls.(d0);
     let subx = Genarray.sub_left x0 j0 ls.(d0) in
     let suby = Genarray.sub_left x1 j1 ls.(d0) in
     Genarray.blit subx suby
@@ -645,7 +643,7 @@ let _highest_padding_dimension p =
   let d = ref l in
   (try for i = l downto 0 do
     d := i;
-    if p.(i) <> [|0;0|] then failwith "stop"
+    if p.(i) <> [|0;0|] then failwith "pad:highest_padding_dimension"
   done with _exn -> ());
   !d
 
@@ -663,17 +661,12 @@ let pad ?v d x =
   let s' = Owl_utils_array.fold_right ( * ) s1 1 in
   let y' = create k [|s'|] v in
   let ls = Owl_utils.calc_slice s0 in
-  Printf.fprintf stderr "ls: %s\n" (Owl_utils_array.to_string string_of_int ls);
   let l0 = Owl_utils.calc_stride s0 in
-  Printf.fprintf stderr "l0: %s\n" (Owl_utils_array.to_string string_of_int l0);
   let l1 = Owl_utils.calc_stride s1 in
-  Printf.fprintf stderr "s1: %s\n" (Owl_utils_array.to_string string_of_int s1);
   let i0 = Array.make (num_dims x) 0 in
   let i1 = Array.map (fun a -> a.(0)) p1 in
-  Printf.fprintf stderr "i1: %s\n" (Owl_utils_array.to_string string_of_int i1);
   let d0 = 0 in
   let d1 = _highest_padding_dimension p1 in
-  Printf.fprintf stderr "d1: %d\n" d1;
   _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x' y';
   reshape y' s1
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -133,6 +133,9 @@ val tile : ('a, 'b) t -> int array -> ('a, 'b) t
 val repeat : ('a, 'b) t -> int array -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+val pad : ?v:'a -> int list list -> ('a, 'b) t -> ('a, 'b) t
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
 val concatenate : ?axis:int -> ('a, 'b) t array -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
@@ -789,6 +792,9 @@ val repeat_ : out:('a, 'b) t -> ('a, 'b) t -> int array -> unit
 (** TODO *)
 
 val tile_ : out:('a, 'b) t -> ('a, 'b) t -> int array -> unit
+(** TODO *)
+
+val pad_ : out:('a, 'b) t  -> ?v:'a -> int list list -> ('a, 'b) t -> unit
 (** TODO *)
 
 val sum_ : out:('a, 'b) t -> axis:int -> ('a, 'b) t -> unit

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -79,6 +79,8 @@ val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array
 
+val pad : ?v:elt -> int list list -> arr -> arr
+
 val one_hot : int -> arr -> arr
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit

--- a/src/base/dense/owl_base_dense_ndarray_z.mli
+++ b/src/base/dense/owl_base_dense_ndarray_z.mli
@@ -79,6 +79,8 @@ val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array
 
+val pad : ?v:elt -> int list list -> arr -> arr
+
 val one_hot : int -> arr -> arr
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -499,6 +499,13 @@ module Make
     add_node ?act_typ nn [|input_node|] n
 
 
+  let padding2d ?name ?act_typ padding input_node =
+    let neuron = Padding2D (Padding2D.create padding) in
+    let nn = get_network input_node in
+    let n = make_node ?name [||] [||] neuron None nn in
+    add_node ?act_typ nn [|input_node|] n
+
+
   let dropout ?name rate input_node =
     let neuron = Dropout (Dropout.create rate) in
     let nn = get_network input_node in

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -355,7 +355,7 @@ Arguments:
 ``padding2d ~act_typ padding node`` adds rows and columns of zeros at the top, bottom, left and right side of an image tensor.
 
 Arguments:
-  * ``padding``: array of 2 arrays of 2 integers, interpreted as  ((top_pad, bottom_pad), (left_pad, right_pad)).
+  * ``padding``: array of 2 arrays of 2 integers, interpreted as  [| [|top_pad; bottom_pad|]; [|left_pad; right_pad|]|].
   *)
 
   val dropout : ?name:string -> float -> node -> node

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -350,6 +350,14 @@ Arguments:
   * ``size``: array of two integers, namely the upsampling factors for columns and rows.
   *)
 
+  val padding2d : ?name:string -> ?act_typ:Activation.typ -> int array array -> node -> node
+  (**
+``padding2d ~act_typ padding node`` adds rows and columns of zeros at the top, bottom, left and right side of an image tensor.
+
+Arguments:
+  * ``padding``: array of 2 arrays of 2 integers, interpreted as  ((top_pad, bottom_pad), (left_pad, right_pad)).
+  *)
+
   val dropout : ?name:string -> float -> node -> node
   (**
 ``dropout rate node`` applies Dropout to the input to prevent overfitting.

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -3035,7 +3035,7 @@ module Make
     | GlobalAvgPool1D l -> GlobalAvgPool1D.(l.in_shape, l.out_shape)
     | GlobalAvgPool2D l -> GlobalAvgPool2D.(l.in_shape, l.out_shape)
     | UpSampling2D l    -> UpSampling2D.(l.in_shape, l.out_shape)
-    | Padding2D l   -> Padding2D.(l.in_shape, l.out_shape)
+    | Padding2D l       -> Padding2D.(l.in_shape, l.out_shape)
     | Dropout l         -> Dropout.(l.in_shape, l.out_shape)
     | Reshape l         -> Reshape.(l.in_shape, l.out_shape)
     | Flatten l         -> Flatten.(l.in_shape, l.out_shape)

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2202,9 +2202,9 @@ module Make
 
     let to_string l =
       Printf.sprintf "    Padding2D : tensor in:[*,%i,%i,%i] out:[*,%i,%i,%i]\n" l.in_shape.(0) l.in_shape.(1) l.in_shape.(2) l.out_shape.(0) l.out_shape.(1) l.out_shape.(2) ^
-      Printf.sprintf "    padding2d : [|%s; %s|]\n"
-        (Owl_utils_array.to_string string_of_int l.padding.(0))
-        (Owl_utils_array.to_string string_of_int l.padding.(1))
+      Printf.sprintf "    padding   : [| [|%s|]; [|%s|] |]\n"
+        (Owl_utils_array.to_string ~sep:";" string_of_int l.padding.(0))
+        (Owl_utils_array.to_string ~sep:";" string_of_int l.padding.(1))
 
     let to_name () = "padding2d"
 

--- a/src/base/neural/owl_neural_neuron_sig.ml
+++ b/src/base/neural/owl_neural_neuron_sig.ml
@@ -1313,7 +1313,34 @@ module Padding1D : sig  end
 
   (** {6 Padding2D neuron} *)
 
-module Padding2D : sig  end
+module Padding2D : sig
+  type neuron_typ = {
+    (* array of 2 arrays of 2 ints *)
+    mutable padding   : int array array;
+    mutable in_shape  : int array;
+    mutable out_shape : int array;
+  }
+  (** Neuron type definition. *)
+
+  val create : int array array -> neuron_typ
+  (** Create the neuron. *)
+
+  val connect : int array -> neuron_typ -> unit
+  (** Connect this neuron to others in a neural network. *)
+
+  val copy : neuron_typ -> neuron_typ
+  (** Make a deep copy of the neuron and its parameters. *)
+
+  val run : t -> neuron_typ -> t
+  (** Execute the computation in this neuron. *)
+
+  val to_string : neuron_typ -> string
+  (** Convert the neuron to its string representation. The string is often a summary of the parameters defined in the neuron. *)
+
+  val to_name : unit -> string
+  (** Return the name of the neuron. *)
+
+end
 
 
   (** {6 Padding3D neuron} *)
@@ -1910,6 +1937,7 @@ type neuron =
   | GlobalAvgPool1D of GlobalAvgPool1D.neuron_typ
   | GlobalAvgPool2D of GlobalAvgPool2D.neuron_typ
   | UpSampling2D    of UpSampling2D.neuron_typ
+  | Padding2D       of Padding2D.neuron_typ
   | Dropout         of Dropout.neuron_typ
   | Reshape         of Reshape.neuron_typ
   | Flatten         of Flatten.neuron_typ

--- a/src/base/optimise/owl_algodiff_generic.ml
+++ b/src/base/optimise/owl_algodiff_generic.ml
@@ -1397,13 +1397,13 @@ module Make
       let r a = PAD_D (a, p) in
       op_d_d a ff fd df r
 
-    (* TODO: sources required for the backward op *)
+    (* TODO: sources required to confirm this backward op *)
     (* o:outut'; p: padding index *)
     and pad_backward o p =
       (* assume p is full legal index for pad operation *)
-      let o = unpack_arr o in
+      let o  = unpack_arr o in
       let os = A.shape o in
-      let q = Owl_utils.llss2aarr p in
+      let q  = Owl_utils.llss2aarr p in
       Array.iteri (fun i x ->
         x.(1) <- Pervasives.(os.(i) - 1 - x.(1));
       ) q;

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -242,6 +242,9 @@ module type Sig = sig
     val upsampling2d : t -> int array -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val pad : ?v:A.elt -> int list list -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
     val reshape : t -> int array -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -78,6 +78,8 @@ module type Sig = sig
 
   val one_hot : int -> arr -> arr
 
+  val pad : ?v:elt -> int list list -> arr -> arr
+
   val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
 

--- a/src/base/types/owl_types_ndarray_mutable.ml
+++ b/src/base/types/owl_types_ndarray_mutable.ml
@@ -41,6 +41,8 @@ module type Sig = sig
 
   val tile_ : out:arr -> arr -> int array -> unit
 
+  val pad_ : out:arr -> ?v:elt -> int list list -> arr -> unit
+
   val hypot : arr -> arr -> arr
 
   val fmod : arr -> arr -> arr

--- a/src/owl/dense/owl_dense_ndarray_c.mli
+++ b/src/owl/dense/owl_dense_ndarray_c.mli
@@ -650,6 +650,8 @@ val repeat_ : out:arr -> arr -> int array -> unit
 
 val tile_ : out:arr -> arr -> int array -> unit
 
+val pad_ : out:arr -> ?v:elt -> int list list -> arr -> unit
+
 val sum_ : out:arr -> axis:int -> arr -> unit
 
 val min_ : out:arr -> axis:int -> arr -> unit

--- a/src/owl/dense/owl_dense_ndarray_d.mli
+++ b/src/owl/dense/owl_dense_ndarray_d.mli
@@ -680,6 +680,8 @@ val repeat_ : out:arr -> arr -> int array -> unit
 
 val tile_ : out:arr -> arr -> int array -> unit
 
+val pad_ : out:arr -> ?v:elt -> int list list -> arr -> unit
+
 val sum_ : out:arr -> axis:int -> arr -> unit
 
 val min_ : out:arr -> axis:int -> arr -> unit

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1934,6 +1934,26 @@ let pad ?v d x =
   y
 
 
+let pad_ ~out ?v d x =
+  let k = kind x in
+  let v = match v with
+    | Some v -> v
+    | None   -> Owl_const.zero k
+  in
+  let s0 = shape x in
+  let p1 = _expand_padding_index (Owl_utils.llss2aarr d) s0 in
+  let s1 = shape out in
+  fill out v;
+  (* prepare variables for block copying *)
+  let ls = Owl_utils.calc_slice s0 in
+  let l0 = Owl_utils.calc_stride s0 in
+  let l1 = Owl_utils.calc_stride s1 in
+  let i0 = Array.make (num_dims x) 0 in
+  let i1 = Array.map (fun a -> a.(0)) p1 in
+  let d0 = 0 in
+  let d1 = _highest_padding_dimension p1 in
+  _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x out
+
 
 (* NOTE
   The following functions (i.e., conv2d* and conv3d* and etc.) are for neural

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -521,7 +521,7 @@ along the low dimension (by setting ``false``). The default value is ``false``.
 
 val pad : ?v:'a -> int list list -> ('a, 'b) t -> ('a, 'b) t
 (**
-``pad ~v:0. [[1;1]] x`` ... TODO
+``pad ~v p x`` pads a ndarray ``x`` with a constant value ``v``. The padding index ``p`` is a list of list of 2 integers. These two integers denote padding width at both edges of one dimension of ``x``.
  *)
 
 val dropout : ?rate:float -> ('a, 'b) t -> ('a, 'b) t
@@ -2106,6 +2106,12 @@ val tile_ : out:('a, 'b) t -> ('a, 'b) t -> int array -> unit
 (**
 ``tile_ ~out x reps`` is similar to ``tile x reps`` but the output is written to ``out``.
  *)
+
+val pad_ : out:('a, 'b) t -> ?v:'a -> int list list -> ('a, 'b) t -> unit
+(**
+``pad_ x`` is similar to ``pad`` but output is written to ``x``
+ *)
+
 
 val sum_ : out:('a, 'b) t -> axis:int -> ('a, 'b) t -> unit
 (** TODO *)

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -2109,9 +2109,8 @@ val tile_ : out:('a, 'b) t -> ('a, 'b) t -> int array -> unit
 
 val pad_ : out:('a, 'b) t -> ?v:'a -> int list list -> ('a, 'b) t -> unit
 (**
-``pad_ x`` is similar to ``pad`` but output is written to ``x``
+``pad_ ~out ?v p x`` is similar to ``pad ?v p x`` but the output is written to ``out``.
  *)
-
 
 val sum_ : out:('a, 'b) t -> axis:int -> ('a, 'b) t -> unit
 (** TODO *)

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -521,7 +521,7 @@ along the low dimension (by setting ``false``). The default value is ``false``.
 
 val pad : ?v:'a -> int list list -> ('a, 'b) t -> ('a, 'b) t
 (**
-``pad ~v p x`` pads a ndarray ``x`` with a constant value ``v``. The padding index ``p`` is a list of list of 2 integers. These two integers denote padding width at both edges of one dimension of ``x``.
+``pad ~v p x`` pads a ndarray ``x`` with a constant value ``v``. The padding index ``p`` is a list of lists of 2 integers. These two integers denote padding width at both edges of one dimension of ``x``.
  *)
 
 val dropout : ?rate:float -> ('a, 'b) t -> ('a, 'b) t

--- a/src/owl/dense/owl_dense_ndarray_s.mli
+++ b/src/owl/dense/owl_dense_ndarray_s.mli
@@ -680,6 +680,8 @@ val repeat_ : out:arr -> arr -> int array -> unit
 
 val tile_ : out:arr -> arr -> int array -> unit
 
+val pad_ : out:arr -> ?v:elt -> int list list -> arr -> unit
+
 val sum_ : out:arr -> axis:int -> arr -> unit
 
 val min_ : out:arr -> axis:int -> arr -> unit

--- a/src/owl/dense/owl_dense_ndarray_z.mli
+++ b/src/owl/dense/owl_dense_ndarray_z.mli
@@ -650,6 +650,8 @@ val repeat_ : out:arr -> arr -> int array -> unit
 
 val tile_ : out:arr -> arr -> int array -> unit
 
+val pad_ : out:arr -> ?v:elt -> int list list -> arr -> unit
+
 val sum_ : out:arr -> axis:int -> arr -> unit
 
 val min_ : out:arr -> axis:int -> arr -> unit


### PR DESCRIPTION
This PR updates the existing `pad` operation in Owl, including:
- mutable operation in core ndarray
- operation in base ndarray
- operation in Algodiff and cgraph modules
- `Padding2D` neuron