### PR TITLE
Add Delay operation to CG and optimised inference to neural_compiler.ml

### DIFF
--- a/examples/lazy_mnist.ml
+++ b/examples/lazy_mnist.ml
@@ -21,20 +21,40 @@ let make_network input_shape =
   |> linear 10 ~act_typ:Activation.(Softmax 1)
   |> get_network ~name:"mnist"
 
+let pack x = CGCompiler.Engine.pack_arr x |> Algodiff.pack_arr
+let unpack x = Algodiff.unpack_arr x |> CGCompiler.Engine.unpack_arr
 
 let train network =
   let x, _, y = Dataset.load_mnist_train_data_arr () in
-  let x = CGCompiler.Engine.pack_arr x |> Algodiff.pack_arr in
-  let y = CGCompiler.Engine.pack_arr y |> Algodiff.pack_arr in
+  let x = pack x in
+  let y = pack y in
   let params = Params.config
     ~batch:(Batch.Mini 100) ~learning_rate:(Learning_Rate.Adagrad 0.005) 0.1
     (* ~momentum:(Momentum.Standard 0.1) *)
   in
   CGCompiler.train ~params network x y
 
+let test network =
+  let imgs, _, labels = Dataset.load_mnist_test_data () in
+  let m = Dense.Matrix.S.row_num imgs in
+  let imgs = Dense.Ndarray.S.reshape imgs [|m;28;28;1|] in
+  let eval = CGCompiler.model ~batch_size:m network in
 
-let _ =
+  let mat2num x = Dense.Matrix.S.of_array (
+      x |> Dense.Matrix.Generic.max_rows
+        |> Array.map (fun (_,_,num) -> float_of_int num)
+    ) 1 m
+  in
+
+  let result = unpack (eval (pack imgs)) in
+  let pred = mat2num result in
+  let fact = mat2num labels in
+  let accu = Dense.Matrix.S.(elt_equal pred fact |> sum') in
+  Owl_log.info "Accuracy on test set: %f" (accu /. (float_of_int m))
+
+let () =
   Owl_log.(set_level INFO);
   let network = make_network [|28;28;1|] in
   Graph.print network; flush_all ();
-  train network
+  let _ = train network in
+  test network

--- a/src/base/compute/owl_computation_cpu_device.ml
+++ b/src/base/compute/owl_computation_cpu_device.ml
@@ -11,7 +11,7 @@ open Owl_types
 module Make (A : Ndarray_Mutable) = struct
 
   module A = A
-  
+
   type device = {
     device_type : device_type;
     initialised : bool;

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -62,6 +62,8 @@ module Make
         | Fold (_axis, _f)                              -> failwith "Fold"
         | Scan (_axis, _f)                              -> failwith "Scan"
         | OneHot depth                                  -> _eval_map_01 x (fun ~out x -> A.one_hot_ ~out depth x.(0))
+        | Delay f                                       -> _eval_map_08 x f
+        | DelayArray (_shape, f)                        -> _eval_map_00 x f
         | Abs                                           -> _eval_map_01 x (fun ~out x -> A.abs_ ~out x.(0))
         | Neg                                           -> _eval_map_01 x (fun ~out x -> A.neg_ ~out x.(0))
         | Floor                                         -> _eval_map_01 x (fun ~out x -> A.floor_ ~out x.(0))
@@ -312,6 +314,14 @@ module Make
     let elt_args = Owl_utils_array.filter is_elt x_parents |> Array.map (fun v -> (get_value v).(0) |> value_to_elt) in
     let out = value_to_arr (get_value x).(0) in
     f ~out arr_args elt_args
+
+
+  (* f is pure, for [arr -> arr] *)
+  and _eval_map_08 x f =
+    let x_parent = (parents x).(0) in
+    _eval_term x_parent;
+    let a = (get_value x_parent).(0) |> value_to_arr |> f in
+    set_value x [|arr_to_value a|]
 
 
 end

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -151,6 +151,13 @@ module Make
   let one_hot depth x =
     make_then_connect (OneHot depth) [|arr_to_node x|] |> node_to_arr
 
+  let delay f x =
+    make_then_connect (Delay f) [|arr_to_node x|] |> node_to_arr
+
+  let delay_array shape f x =
+    make_then_connect ~shape:[|Some shape|] (DelayArray (shape, f))
+      (Array.map arr_to_node x) |> node_to_arr
+
   let print ?max_row ?max_col ?header ?fmt x = ()  [@@warning "-27"]
 
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -110,6 +110,20 @@ module type Sig = sig
   val one_hot : int -> arr -> arr
   (** TODO *)
 
+  val delay : (Device.A.arr -> Device.A.arr) -> arr -> arr
+  (**
+``delay f x`` returns ``f x``. It allows to use a function that is not tracked
+by the computation graph and delay its evaluation. The output must have the
+same shape as the input.
+   *)
+
+  val delay_array : int array -> (Device.A.arr array -> Device.A.arr) ->
+                    arr array -> arr
+(**
+``delay_array out_shape f x`` works in the same way as ``delay`` but is applied
+on an array of ndarrays. Needs the shape of the output as an argument.
+ *)
+
   val print : ?max_row:'a -> ?max_col:'b -> ?header:'c -> ?fmt:'d -> 'e -> unit
   (** TODO *)
 

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -57,6 +57,8 @@ module Make
         | Fold (_axis,_f)                                -> pattern_000 x
         | Scan (_axis,_f)                                -> pattern_000 x
         | OneHot _depth                                  -> pattern_000 x
+        | Delay _f                                       -> pattern_000 x
+        | DelayArray (_shape, _f)                        -> pattern_000 x
         | Abs                                            -> pattern_000 x
         | Neg                                            -> pattern_000 x
         | Floor                                          -> pattern_000 x

--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -265,6 +265,8 @@ module Make
     | Scan (_axis, _f)                               -> _infer_shape_01 input_shapes
     | OneHot depth                                   -> _infer_shape_22 input_shapes depth
     | Abs                                            -> _infer_shape_01 input_shapes
+    | Delay _f                                       -> _infer_shape_01 input_shapes
+    | DelayArray (shape, _f)                         -> [| Some shape |]
     | Neg                                            -> _infer_shape_01 input_shapes
     | Floor                                          -> _infer_shape_01 input_shapes
     | Ceil                                           -> _infer_shape_01 input_shapes

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -52,6 +52,8 @@ module Make
     | Fold (_axis, _f)                               -> "Fold"
     | Scan (_axis, _f)                               -> "Scan"
     | OneHot depth                                   -> Printf.sprintf "OneHot d:%i" depth
+    | Delay _f                                       -> "Delay"
+    | DelayArray (_shape, _f)                        -> "DelayArray"
     | Abs                                            -> "Abs"
     | Neg                                            -> "Neg"
     | Floor                                          -> "Floor"

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -70,6 +70,8 @@ module Make
     | Fold                          of int * (elt -> elt -> elt)
     | Scan                          of int * (elt -> elt -> elt)
     | OneHot                        of int
+    | Delay                         of (A.arr -> A.arr)
+    | DelayArray                    of int array * (A.arr array -> A.arr)
     | Abs
     | Neg
     | Floor

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -25,7 +25,7 @@ module type Sig = sig
   and attr = {
     mutable op     : op;                        (* operation stored in this node *)
     mutable freeze : bool;                      (* whether or not a node can link to other nodes *)
-    mutable reuse  : bool;                      (* whether others can resuse the allocated memory *)
+    mutable reuse  : bool;                      (* whether others can reuse the allocated memory *)
     mutable state  : state;                     (* state to show whether re-evaluation is needed *)
     mutable shape  : (int array option) array;  (* shape of the output values stored in the node *)
     mutable value  : value array;               (* output values of the node *)
@@ -69,6 +69,8 @@ module type Sig = sig
     | Fold                          of int * (elt -> elt -> elt)
     | Scan                          of int * (elt -> elt -> elt)
     | OneHot                        of int
+    | Delay                         of (A.arr -> A.arr)
+    | DelayArray                    of int array * (A.arr array -> A.arr)
     | Abs
     | Neg
     | Floor

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -229,6 +229,9 @@ module Make
   let forward nn x = mktag (tag ()) nn; run x nn, mkpar nn
 
 
+  let forward_inputs nn x = mktag (tag ()) nn; run_inputs x nn, mkpar nn
+
+
   let backward nn y = reverse_prop (_f 1.) y; mkpri nn, mkadj nn
 
 

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -114,6 +114,9 @@ module type Sig = sig
   val forward : network -> t -> t * t array array
   (** Run the forward pass of a network. *)
 
+  val forward_inputs : network -> t array -> t array * t array array
+  (** Run the forward pass of a network (multi-input/output version). *)
+
   val backward : network -> t -> t array array * t array array
   (** Run the backward pass of a network. *)
 
@@ -130,7 +133,8 @@ module type Sig = sig
 
   val input : ?name:string -> int array -> node
   (**
-``input shape`` creates an input node for input data.
+``input shape`` creates an input node for input data. Note that if your network
+has multiple inputs, you should use ``inputs`` instead.
 
 Arguments:
   * ``shape``: shape of input data.

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2190,7 +2190,7 @@ module Make
       l.in_shape.(1)  <- out_shape.(1);
       l.in_shape.(2)  <- out_shape.(2);
       l.out_shape.(0) <- l.in_shape.(0) + l.padding.(0).(0) + l.padding.(0).(1);
-      l.out_shape.(1) <- l.in_shape.(1) * l.padding.(1).(0) + l.padding.(1).(1);
+      l.out_shape.(1) <- l.in_shape.(1) + l.padding.(1).(0) + l.padding.(1).(1);
       l.out_shape.(2) <- out_shape.(2)
 
     let copy l = create l.padding


### PR DESCRIPTION
This PR adds
- `Delay`/`DelayArray` operations to the Computation Graph, to delay the evaluation of a function that is not tracked by CG. It would work to just call them `Lambda`/`LambdaArray` - however, in case the argument of the `Lambda` layer contains only supported operations, it would hide that function from CG (for example, the `lazy_mnist.ml` example would be slightly less efficient), so I think it is good to keep both kinds of operations.
- `model`/`model_inputs` functions in `owl_neural_compiler.ml` to provide an interface to optimise inference with CG as well. Note: something I don't like is that after copying the network (just like the standard `model` function in `owl_neural_graph.ml`), `Copy` nodes are created in the graph for every constant values. I am unsure if this is necessary and if there is a clean way around it.
- a test function to the `lazy_mnist.ml` with this new optimised inference to be more similar to `mnist_cnn.ml`. Optimised inference is not super useful for such a small example but for Mask R-CNN, it decreased the memory consumption from 11 Go to 7 Go.
