### PR TITLE
Topological sort fixed, BFS, tests

### DIFF
--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -316,7 +316,7 @@ module Make
     f ~out arr_args elt_args
 
 
-  (* f is pure, for [arr -> arr] *)
+  (* [f] is pure, for [arr -> arr] *)
   and _eval_map_08 x f =
     let x_parent = (parents x).(0) in
     _eval_term x_parent;

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -92,11 +92,11 @@ module Make
     else
       make_value_from None x
 
+
   let allocate_from_parent_arr x parents =
     let parents_val = Array.map
                         (fun par -> value_to_arr (get_value par).(0)) parents in
     let shp_x = node_shape x in
-    (* an imperative version could be slightly more efficient? *)
     let id_shaped_par, _ = Owl_utils.Array.filter2_split
                              (fun par par_val -> A.shape par_val = shp_x
                                                  && refnum par = 1
@@ -106,6 +106,7 @@ module Make
       make_value_from (Some id_shaped_par.(0)) x
     else
       make_value_from None x
+
 
   (* core initialisation function *)
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -115,14 +115,14 @@ module type Sig = sig
 ``delay f x`` returns ``f x``. It allows to use a function that is not tracked
 by the computation graph and delay its evaluation. The output must have the
 same shape as the input.
-   *)
+  *)
 
   val delay_array : int array -> (Device.A.arr array -> Device.A.arr) ->
                     arr array -> arr
-(**
+  (**
 ``delay_array out_shape f x`` works in the same way as ``delay`` but is applied
 on an array of ndarrays. Needs the shape of the output as an argument.
- *)
+  *)
 
   val print : ?max_row:'a -> ?max_col:'b -> ?header:'c -> ?fmt:'d -> 'e -> unit
   (** TODO *)

--- a/src/base/core/owl_graph.mli
+++ b/src/base/core/owl_graph.mli
@@ -11,6 +11,9 @@
 type order = BFS | DFS
 (** Order to traverse a graph, BFS or DFS. *)
 
+type traversal = PreOrder | PostOrder
+(** Order of the function evaluation. *)
+
 type dir = Ancestor | Descendant
 (** Iteration direction, i.e. ancestors or descendants *)
 
@@ -142,10 +145,10 @@ original graph.
 
 (** {6 Iterators} *)
 
-val iter_ancestors : ?order:order -> ('a node -> unit) -> 'a node array -> unit
+val iter_ancestors : ?order:order -> ?traversal:traversal -> ('a node -> unit) -> 'a node array -> unit
 (** Iterate the ancestors of a given node. *)
 
-val iter_descendants : ?order:order -> ('a node -> unit) -> 'a node array -> unit
+val iter_descendants : ?order:order -> ?traversal:traversal -> ('a node -> unit) -> 'a node array -> unit
 (** Iterate the descendants of a given node. *)
 
 val filter_ancestors : ('a node -> bool) -> 'a node array -> 'a node array
@@ -176,7 +179,10 @@ val fold_out_edges : ('b -> 'a node -> 'a node -> 'b) -> 'b -> 'a node array -> 
 (** {6 Helper functions} *)
 
 val topo_sort : 'a node array -> 'a node array
-(* BFS topological sort of a given graph. *)
+(**
+Topological sort of a given graph using a DFS order. Assumes that the graph is
+acyclic.
+ *)
 
 val pp_node : Format.formatter -> 'a node -> unit
 (** Pretty print a given node. *)

--- a/test/test_runner.ml
+++ b/test/test_runner.ml
@@ -5,6 +5,7 @@ let () =
     "stats_rvs",            Unit_stats_rvs.test_set;
     "stats",                Unit_stats.test_set;
     "maths",                Unit_maths.test_set;
+    "graph",                Unit_graph.test_set;
     "algodiff diff",        Unit_algodiff_diff.test_set;
     "algodiff grad",        Unit_algodiff_grad.test_set;
     "dense matrix",         Unit_dense_matrix.test_set;

--- a/test/unit_graph.ml
+++ b/test/unit_graph.ml
@@ -1,0 +1,82 @@
+(** Unit test for Owl_graph module *)
+
+module M = Owl_graph
+
+let to_array order traversal nodes =
+  let s = Owl_utils.Stack.make () in
+  let f u = Owl_utils.Stack.push s u in
+  M.iter_descendants ~order ~traversal f nodes;
+  Array.map M.attr (Owl_utils.Stack.to_array s)
+
+let graph () =
+  let n0, n1, n2, n3, n4 = M.node 0, M.node 1, M.node 2, M.node 3, M.node 4 in
+  M.connect [|n0|] [|n1; n2; n3|];
+  M.connect [|n1|] [|n2|];
+  M.connect [|n2; n3|] [|n4|];
+  n0, n1, n2, n3, n4
+
+(* a module with functions to test *)
+module To_test = struct
+
+  let topo0 () =
+    let _, _, _, _, n4 = graph () in
+    Array.map M.attr (M.topo_sort [|n4|]) = [|0; 1; 2; 3; 4|]
+
+  let topo1 () =
+    let _, _, n2, n3, _ = graph () in
+    Array.map M.attr (M.topo_sort [|n2; n3|]) = [|0; 1; 2; 3|]
+
+  (* cyclic graph *)
+  let dfs0 () =
+    let n0, n1, n2 = M.node 0, M.node 1, M.node 2 in
+    M.connect [|n0|] [|n1|];
+    M.connect [|n1|] [|n2|];
+    M.connect [|n2|] [|n0|];
+    to_array DFS PostOrder [|n0|] = [|2; 1; 0|]
+
+  let dfs1 () =
+    let n0 = M.node 0 in
+    to_array DFS PreOrder [|n0|] = [|0|]
+
+  let bfs0 () =
+    let n0, n1, n2, n3, n4 = M.node 0, M.node 1, M.node 2, M.node 3, M.node 4 in
+    M.connect [|n0|] [|n1; n3|];
+    M.connect [|n1|] [|n2; n3|];
+    M.connect [|n2|] [|n3|];
+    M.connect [|n2; n3|] [|n4|];
+    to_array BFS PreOrder [|n0|] = [|0; 1; 3; 2; 4|]
+
+  let num0 () =
+    let _, _, n2, _, _ = graph () in
+    M.num_ancestor [|n2|] = 3 && M.num_descendant [|n2|] = 2
+
+end
+
+let topo0 () =
+  Alcotest.(check bool) "topo0" true (To_test.topo0 ())
+
+let topo1 () =
+  Alcotest.(check bool) "topo1" true (To_test.topo1 ())
+
+let dfs0 () =
+  Alcotest.(check bool) "dfs0" true (To_test.dfs0 ())
+
+let dfs1 () =
+  Alcotest.(check bool) "dfs1" true (To_test.dfs1 ())
+
+let bfs0 () =
+  Alcotest.(check bool) "bfs0" true (To_test.bfs0 ())
+
+let num0 () =
+  Alcotest.(check bool) "num0" true (To_test.num0 ())
+
+(* the tests *)
+
+let test_set = [
+  "topo0", `Slow, topo0;
+  "topo1", `Slow, topo1;
+  "dfs0", `Slow, dfs0;
+  "dfs1", `Slow, dfs1;
+  "bfs0", `Slow, bfs0;
+  "num0", `Slow, num0;
+]


### PR DESCRIPTION
- Added BFS traversal
- Added `traversal = PreOrder | PostOrder` parameter to traversal functions (allows to factorise other graph functions)
- Fixed performance of `topo_sort` (the same node could be visited exponentially many times), using a post-order DFS (it was already a DFS topo sort despite the previous comment)
- Added a test suite for `Owl_graph.ml`
- Fixed comments of previous PR