### PR TITLE
Batch inference with CG

### DIFF
--- a/examples/lazy_mnist.ml
+++ b/examples/lazy_mnist.ml
@@ -38,7 +38,7 @@ let test network =
   let imgs, _, labels = Dataset.load_mnist_test_data () in
   let m = Dense.Matrix.S.row_num imgs in
   let imgs = Dense.Ndarray.S.reshape imgs [|m;28;28;1|] in
-  let eval = CGCompiler.model ~batch_size:m network in
+  let eval = CGCompiler.model ~batch_size:100 network in
 
   let mat2num x = Dense.Matrix.S.of_array (
       x |> Dense.Matrix.Generic.max_rows


### PR DESCRIPTION
Improvement of a previous PR for inference with the computation graph. The parameter `batch_slice` of `model_inputs` was misleading, but it now really performs inference batch by batch. This greatly reduces the memory used for the inference part of the `lazy_mnist.ml` example.

Two notes:
- the memory used at the end of `lazy_mnist.ml` is the sum of the memory for training and the memory for inference (roughly 800Mb + 100Mb). Calling `Gc.full_major ()` after training solves that problem, but I don't know if you estimate that this is a problem and what would a clean way of solving it.
- if `batch_slice` does not divide the input's first dimension, then the inference for the last batch performs useless calculations (because the size of the network is fixed, so I can't perform a calculation on a smaller chunk). Another solution would be to create a separate network solely for that final batch but that's usually a bigger waste of memory. We could also enforce that the batch_size divides the input's first dimension, but that would make it less flexible and can be annoying if your input size is a big prime number (also, other frameworks don't require this). Let me know if you want to opt for another solution to that problem.