### PR TITLE
New memory optimisation algorithm for CG (+ block attribute, multimap)

### DIFF
--- a/src/base/compute/owl_computation_cpu_device.ml
+++ b/src/base/compute/owl_computation_cpu_device.ml
@@ -45,4 +45,14 @@ module Make (A : Ndarray_Mutable) = struct
   let value_to_float x = A.elt_to_float (value_to_elt x)
 
 
+  let is_arr = function
+    | ArrVal _ -> true
+    | EltVal _ -> false
+
+
+  let is_elt = function
+    | ArrVal _ -> false
+    | EltVal _ -> true
+
+
 end

--- a/src/base/compute/owl_computation_cpu_engine.ml
+++ b/src/base/compute/owl_computation_cpu_engine.ml
@@ -25,8 +25,9 @@ module Make_Nested
 
   (* core interface *)
 
+  (* ! Make sure the order of evaluation of init and eval is always the same. *)
   let eval_gen nodes =
-    Array.iter CG_Init._init_term nodes;
+    CG_Init._init_terms nodes;
     Array.iter CG_Eval._eval_term nodes
 
 

--- a/src/base/compute/owl_computation_cpu_engine.ml
+++ b/src/base/compute/owl_computation_cpu_engine.ml
@@ -28,7 +28,7 @@ module Make_Nested
   (* ! Make sure the order of evaluation of init and eval is always the same. *)
   let eval_gen nodes =
     CG_Init._init_terms nodes;
-    Array.iter CG_Eval._eval_term nodes
+    CG_Eval._eval_terms nodes
 
 
   let eval_elt xs = Array.map elt_to_node xs |> eval_gen

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -19,11 +19,7 @@ module Make
 
   (* utility functions *)
 
-  let invalidate_opt x_option =
-    match x_option with
-    | Some x -> invalidate x
-    | None   -> ()
-
+  let invalidate_opt = function Some x -> invalidate x | None -> ()
 
   let update_validity x b =
     invalidate_opt (get_active_node b);

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -33,214 +33,216 @@ module Make
 
   (* core evaluation function *)
 
-  let rec _eval_term x =
-    Owl_log.debug "eval %s ..." (node_to_str x);
+  let rec _eval_terms nodes =
+    let eval x =
+      Owl_log.debug "eval %s ..." (node_to_str x);
 
-    if is_valid x = false then
-      let () = try
-        match get_operator x with
-        | Noop                                          -> _eval_map_00 x (fun x -> x.(0))
-        | Var                                           -> check_assigned x
-        | Const                                         -> check_assigned x
-        | Empty _shape                                  -> _eval_map_01 x (fun ~out _x -> ()) [@warning "-27"]
-        | Zeros _shape                                  -> _eval_map_01 x (fun ~out _x -> A.zeros_ ~out)
-        | Ones _shape                                   -> _eval_map_01 x (fun ~out _x -> A.ones_ ~out)
-        | Create _shape                                 -> _eval_map_02 x (fun ~out x -> A.create_ ~out x.(0))
-        | Sequential _shape                             -> _eval_map_02 x (fun ~out x -> A.sequential_ ~a:x.(0) ~step:x.(1) ~out)
-        | Uniform _shape                                -> _eval_map_02 x (fun ~out x -> A.uniform_ ~a:x.(0) ~b:x.(1) ~out)
-        | Gaussian _shape                               -> _eval_map_02 x (fun ~out x -> A.gaussian_ ~mu:x.(0) ~sigma:x.(1) ~out)
-        | Bernoulli _shape                              -> _eval_map_02 x (fun ~out x -> A.bernoulli_ ~p:x.(0) ~out)
-        | Init (_shape, _f)                             -> failwith "Init"
-        | Get i                                         -> _eval_map_06 x (fun x -> A.get x i)
-        | Set _i                                        -> failwith "Set"
-        | GetSlice slice                                -> _eval_map_01 x (fun ~out x -> A.get_slice_ ~out slice x.(0))
-        | SetSlice slice                                -> _eval_map_01 x (fun ~out x -> A.set_slice_ ~out slice x.(0) x.(1))
-        | Copy                                          -> _eval_map_01 x (fun ~out x -> A.copy_ ~out x.(0)) [@warning "-27"]
-        | Reset                                         -> _eval_map_01 x (fun ~out _x -> A.reset out)
-        | Reshape _shape                                -> _eval_map_01 x (fun ~out x -> A.reshape_ ~out x.(0))
-        | Reverse                                       -> _eval_map_01 x (fun ~out x -> A.reverse_ ~out x.(0))
-        | Tile repeats                                  -> _eval_map_01 x (fun ~out x -> A.tile_ ~out x.(0) repeats)
-        | Repeat repeats                                -> _eval_map_01 x (fun ~out x -> A.repeat_ ~out x.(0) repeats)
-        | Pad (v, padding)                              -> _eval_map_01 x (fun ~out x -> A.pad_ ~out ~v:(unpack_elt v) padding x.(0))
-        | Concatenate axis                              -> _eval_map_00 x A.(concatenate ~axis)
-        | Split (_axis, _parts)                         -> failwith "Split"
-        | Draw (_axis, _n)                              -> failwith "Draw"
-        | Map _f                                        -> failwith "Map"
-        | Fold (_axis, _f)                              -> failwith "Fold"
-        | Scan (_axis, _f)                              -> failwith "Scan"
-        | OneHot depth                                  -> _eval_map_01 x (fun ~out x -> A.one_hot_ ~out depth x.(0))
-        | Delay f                                       -> _eval_map_08 x f
-        | DelayArray (_shape, f)                        -> _eval_map_00 x f
-        | Abs                                           -> _eval_map_01 x (fun ~out x -> A.abs_ ~out x.(0))
-        | Neg                                           -> _eval_map_01 x (fun ~out x -> A.neg_ ~out x.(0))
-        | Floor                                         -> _eval_map_01 x (fun ~out x -> A.floor_ ~out x.(0))
-        | Ceil                                          -> _eval_map_01 x (fun ~out x -> A.ceil_ ~out x.(0))
-        | Round                                         -> _eval_map_01 x (fun ~out x -> A.round_ ~out x.(0))
-        | Sqr                                           -> _eval_map_01 x (fun ~out x -> A.sqr_ ~out x.(0))
-        | Sqrt                                          -> _eval_map_01 x (fun ~out x -> A.sqrt_ ~out x.(0))
-        | Log                                           -> _eval_map_01 x (fun ~out x -> A.log_ ~out x.(0))
-        | Log2                                          -> _eval_map_01 x (fun ~out x -> A.log2_ ~out x.(0))
-        | Log10                                         -> _eval_map_01 x (fun ~out x -> A.log10_ ~out x.(0))
-        | Exp                                           -> _eval_map_01 x (fun ~out x -> A.exp_ ~out x.(0))
-        | Sin                                           -> _eval_map_01 x (fun ~out x -> A.sin_ ~out x.(0))
-        | Cos                                           -> _eval_map_01 x (fun ~out x -> A.cos_ ~out x.(0))
-        | Tan                                           -> _eval_map_01 x (fun ~out x -> A.tan_ ~out x.(0))
-        | Sinh                                          -> _eval_map_01 x (fun ~out x -> A.sinh_ ~out x.(0))
-        | Cosh                                          -> _eval_map_01 x (fun ~out x -> A.cosh_ ~out x.(0))
-        | Tanh                                          -> _eval_map_01 x (fun ~out x -> A.tanh_ ~out x.(0))
-        | Asin                                          -> _eval_map_01 x (fun ~out x -> A.asin_ ~out x.(0))
-        | Acos                                          -> _eval_map_01 x (fun ~out x -> A.acos_ ~out x.(0))
-        | Atan                                          -> _eval_map_01 x (fun ~out x -> A.atan_ ~out x.(0))
-        | Asinh                                         -> _eval_map_01 x (fun ~out x -> A.asinh_ ~out x.(0))
-        | Acosh                                         -> _eval_map_01 x (fun ~out x -> A.acosh_ ~out x.(0))
-        | Atanh                                         -> _eval_map_01 x (fun ~out x -> A.atanh_ ~out x.(0))
-        | Min axis                                      -> _eval_map_01 x (fun ~out x -> A.min_ ~out ~axis x.(0))
-        | Max axis                                      -> _eval_map_01 x (fun ~out x -> A.max_ ~out ~axis x.(0))
-        | Sum axis                                      -> _eval_map_01 x (fun ~out x -> A.sum_ ~out ~axis x.(0))
-        | SumReduce axis                                -> _eval_map_00 x (fun x -> A.sum_reduce ~axis x.(0))
-        | Signum                                        -> _eval_map_01 x (fun ~out x -> A.signum_ ~out x.(0))
-        | Sigmoid                                       -> _eval_map_01 x (fun ~out x -> A.sigmoid_ ~out x.(0))
-        | Relu                                          -> _eval_map_01 x (fun ~out x -> A.relu_ ~out x.(0))
-        | Min'                                          -> _eval_map_06 x A.min'
-        | Max'                                          -> _eval_map_06 x A.max'
-        | Sum'                                          -> _eval_map_06 x A.sum'
-        | L1norm'                                       -> _eval_map_06 x A.l1norm'
-        | L2norm'                                       -> _eval_map_06 x A.l2norm'
-        | L2NormSqr'                                    -> _eval_map_06 x A.l2norm_sqr'
-        | ClipByValue                                   -> _eval_map_07 x (fun ~out a e -> A.clip_by_value_ ~out ~amin:e.(0) ~amax:e.(1) a.(0))
-        | ClipByL2norm                                  -> _eval_map_07 x (fun ~out a e -> A.clip_by_l2norm_ ~out e.(0) a.(0))
-        | Pow                                           -> _eval_map_01 x (fun ~out x -> A.pow_ ~out x.(0) x.(1))
-        | ScalarPow                                     -> _eval_map_05 x A.scalar_pow_
-        | PowScalar                                     -> _eval_map_04 x A.pow_scalar_
-        | Atan2                                         -> _eval_map_01 x (fun ~out x -> A.atan2_ ~out x.(0) x.(1))
-        | ScalarAtan2                                   -> _eval_map_05 x A.scalar_atan2_
-        | Atan2Scalar                                   -> _eval_map_04 x A.atan2_scalar_
-        | Hypot                                         -> _eval_map_01 x (fun ~out x -> A.hypot_ ~out x.(0) x.(1))
-        | Min2                                          -> _eval_map_01 x (fun ~out x -> A.min2_ ~out x.(0) x.(1))
-        | Max2                                          -> _eval_map_01 x (fun ~out x -> A.max2_ ~out x.(0) x.(1))
-        | Add                                           -> _eval_map_01 x (fun ~out x -> A.add_ ~out x.(0) x.(1))
-        | Sub                                           -> _eval_map_01 x (fun ~out x -> A.sub_ ~out x.(0) x.(1))
-        | Mul                                           -> _eval_map_01 x (fun ~out x -> A.mul_ ~out x.(0) x.(1))
-        | Div                                           -> _eval_map_01 x (fun ~out x -> A.div_ ~out x.(0) x.(1))
-        | AddScalar                                     -> _eval_map_04 x A.add_scalar_
-        | SubScalar                                     -> _eval_map_04 x A.sub_scalar_
-        | MulScalar                                     -> _eval_map_04 x A.mul_scalar_
-        | DivScalar                                     -> _eval_map_04 x A.div_scalar_
-        | ScalarAdd                                     -> _eval_map_05 x A.scalar_add_
-        | ScalarSub                                     -> _eval_map_05 x A.scalar_sub_
-        | ScalarMul                                     -> _eval_map_05 x A.scalar_mul_
-        | ScalarDiv                                     -> _eval_map_05 x A.scalar_div_
-        | FMA                                           -> _eval_map_01 x (fun ~out x -> A.fma_ ~out x.(0) x.(1) x.(2))
-        | EltEqual                                      -> _eval_map_01 x (fun ~out x -> A.elt_equal_ ~out x.(0) x.(1))
-        | EltNotEqual                                   -> _eval_map_01 x (fun ~out x -> A.elt_not_equal_ ~out x.(0) x.(1))
-        | EltLess                                       -> _eval_map_01 x (fun ~out x -> A.elt_less_ ~out x.(0) x.(1))
-        | EltGreater                                    -> _eval_map_01 x (fun ~out x -> A.elt_greater_ ~out x.(0) x.(1))
-        | EltLessEqual                                  -> _eval_map_01 x (fun ~out x -> A.elt_less_equal_ ~out x.(0) x.(1))
-        | EltGreaterEqual                               -> _eval_map_01 x (fun ~out x -> A.elt_greater_equal_ ~out x.(0) x.(1))
-        | EltEqualScalar                                -> _eval_map_04 x A.elt_equal_scalar_
-        | EltNotEqualScalar                             -> _eval_map_04 x A.elt_not_equal_scalar_
-        | EltLessScalar                                 -> _eval_map_04 x A.elt_less_scalar_
-        | EltGreaterScalar                              -> _eval_map_04 x A.elt_greater_scalar_
-        | EltLessEqualScalar                            -> _eval_map_04 x A.elt_less_equal_scalar_
-        | EltGreaterEqualScalar                         -> _eval_map_04 x A.elt_greater_equal_scalar_
-        | Conv1d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv1d_ ~out ~padding x.(0) x.(1) stride)
-        | Conv2d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv2d_ ~out ~padding x.(0) x.(1) stride)
-        | Conv3d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv3d_ ~out ~padding x.(0) x.(1) stride)
-        | TransposeConv1d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_ ~out ~padding x.(0) x.(1) stride)
-        | TransposeConv2d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_ ~out ~padding x.(0) x.(1) stride)
-        | TransposeConv3d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_ ~out ~padding x.(0) x.(1) stride)
-        | DilatedConv1d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_ ~out ~padding x.(0) x.(1) stride rate)
-        | DilatedConv2d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_ ~out ~padding x.(0) x.(1) stride rate)
-        | DilatedConv3d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_ ~out ~padding x.(0) x.(1) stride rate)
-        | MaxPool1d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool1d_ ~out ~padding x.(0) kernel stride)
-        | MaxPool2d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool2d_ ~out ~padding x.(0) kernel stride)
-        | MaxPool3d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool3d_ ~out ~padding x.(0) kernel stride)
-        | AvgPool1d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool1d_ ~out ~padding x.(0) kernel stride)
-        | AvgPool2d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool2d_ ~out ~padding x.(0) kernel stride)
-        | AvgPool3d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool3d_ ~out ~padding x.(0) kernel stride)
-        | UpSampling2d size                             -> _eval_map_01 x (fun ~out x -> A.upsampling2d_ ~out x.(0) size)
-        | Conv1dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv1d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | Conv1dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv1d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | Conv2dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv2d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | Conv2dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv2d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | Conv3dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv3d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | Conv3dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv3d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv1dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv1dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv2dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv2dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv3dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_backward_input_ ~out x.(0) x.(1) stride x.(2))
-        | TransposeConv3dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
-        | DilatedConv1dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
-        | DilatedConv1dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
-        | DilatedConv2dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
-        | DilatedConv2dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
-        | DilatedConv3dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
-        | DilatedConv3dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
-        | MaxPool1dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool1d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | MaxPool2dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool2d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | MaxPool3dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool3d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | AvgPool1dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool1d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | AvgPool2dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool2d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | AvgPool3dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool3d_backward_ ~out padding x.(0) kernel stride x.(1))
-        | UpSampling2dBackward size                     -> _eval_map_01 x (fun ~out x -> A.upsampling2d_backward_ ~out x.(0) size x.(1))
-        | Row                                           -> failwith "Row"
-        | Rows _i                                       -> failwith "Rows"
-        | CopyRowTo                                     -> failwith "CopyRowTo"
-        | CopyColTo                                     -> failwith "CopyColTo"
-        | Dot (transa, transb, alpha, beta)             -> _eval_map_01 x (fun ~out x -> A.dot_ ~transa ~transb ~alpha:(unpack_elt alpha) ~beta:(unpack_elt beta) ~c:out x.(0) x.(1))
-        | Inv                                           -> _eval_map_00 x (fun x -> A.inv x.(0))
-        | Trace                                         -> _eval_map_06 x A.trace
-        | Transpose axis                                -> _eval_map_01 x (fun ~out x -> A.transpose_ ~out ~axis x.(0))
-        | ToRows                                        -> failwith "ToRows"
-        | OfRows                                        -> failwith "OfRows"
-        | Scalar_Add                                    -> _eval_map_03 x (fun x -> A.Scalar.add x.(0) x.(1))
-        | Scalar_Sub                                    -> _eval_map_03 x (fun x -> A.Scalar.sub x.(0) x.(1))
-        | Scalar_Mul                                    -> _eval_map_03 x (fun x -> A.Scalar.mul x.(0) x.(1))
-        | Scalar_Div                                    -> _eval_map_03 x (fun x -> A.Scalar.div x.(0) x.(1))
-        | Scalar_Pow                                    -> _eval_map_03 x (fun x -> A.Scalar.pow x.(0) x.(1))
-        | Scalar_Atan2                                  -> _eval_map_03 x (fun x -> A.Scalar.atan2 x.(0) x.(1))
-        | Scalar_Abs                                    -> _eval_map_03 x (fun x -> A.Scalar.abs x.(0))
-        | Scalar_Neg                                    -> _eval_map_03 x (fun x -> A.Scalar.neg x.(0))
-        | Scalar_Sqr                                    -> _eval_map_03 x (fun x -> A.Scalar.sqr x.(0))
-        | Scalar_Sqrt                                   -> _eval_map_03 x (fun x -> A.Scalar.sqrt x.(0))
-        | Scalar_Exp                                    -> _eval_map_03 x (fun x -> A.Scalar.exp x.(0))
-        | Scalar_Log                                    -> _eval_map_03 x (fun x -> A.Scalar.log x.(0))
-        | Scalar_Log2                                   -> _eval_map_03 x (fun x -> A.Scalar.log2 x.(0))
-        | Scalar_Log10                                  -> _eval_map_03 x (fun x -> A.Scalar.log10 x.(0))
-        | Scalar_Signum                                 -> _eval_map_03 x (fun x -> A.Scalar.signum x.(0))
-        | Scalar_Floor                                  -> _eval_map_03 x (fun x -> A.Scalar.floor x.(0))
-        | Scalar_Ceil                                   -> _eval_map_03 x (fun x -> A.Scalar.ceil x.(0))
-        | Scalar_Round                                  -> _eval_map_03 x (fun x -> A.Scalar.round x.(0))
-        | Scalar_Sin                                    -> _eval_map_03 x (fun x -> A.Scalar.sin x.(0))
-        | Scalar_Cos                                    -> _eval_map_03 x (fun x -> A.Scalar.cos x.(0))
-        | Scalar_Tan                                    -> _eval_map_03 x (fun x -> A.Scalar.tan x.(0))
-        | Scalar_Sinh                                   -> _eval_map_03 x (fun x -> A.Scalar.sinh x.(0))
-        | Scalar_Cosh                                   -> _eval_map_03 x (fun x -> A.Scalar.cosh x.(0))
-        | Scalar_Tanh                                   -> _eval_map_03 x (fun x -> A.Scalar.tanh x.(0))
-        | Scalar_Asin                                   -> _eval_map_03 x (fun x -> A.Scalar.asin x.(0))
-        | Scalar_Acos                                   -> _eval_map_03 x (fun x -> A.Scalar.acos x.(0))
-        | Scalar_Atan                                   -> _eval_map_03 x (fun x -> A.Scalar.atan x.(0))
-        | Scalar_Asinh                                  -> _eval_map_03 x (fun x -> A.Scalar.asinh x.(0))
-        | Scalar_Acosh                                  -> _eval_map_03 x (fun x -> A.Scalar.acosh x.(0))
-        | Scalar_Atanh                                  -> _eval_map_03 x (fun x -> A.Scalar.atanh x.(0))
-        | Scalar_Relu                                   -> _eval_map_03 x (fun x -> A.Scalar.relu x.(0))
-        | Scalar_Sigmoid                                -> _eval_map_03 x (fun x -> A.Scalar.sigmoid x.(0))
-        | Fused_Adagrad (rate, eps)                     -> _eval_map_01 x (fun ~out x -> A.fused_adagrad_ ~out ~rate ~eps x.(0))
-        | _                                             -> failwith "owl_computation_eval:_eval_term"
+      if is_valid x = false then
+        let () = try
+          match get_operator x with
+          | Noop                                          -> _eval_map_00 x (fun x -> x.(0))
+          | Var                                           -> check_assigned x
+          | Const                                         -> check_assigned x
+          | Empty _shape                                  -> _eval_map_01 x (fun ~out _x -> ()) [@warning "-27"]
+          | Zeros _shape                                  -> _eval_map_01 x (fun ~out _x -> A.zeros_ ~out)
+          | Ones _shape                                   -> _eval_map_01 x (fun ~out _x -> A.ones_ ~out)
+          | Create _shape                                 -> _eval_map_02 x (fun ~out x -> A.create_ ~out x.(0))
+          | Sequential _shape                             -> _eval_map_02 x (fun ~out x -> A.sequential_ ~a:x.(0) ~step:x.(1) ~out)
+          | Uniform _shape                                -> _eval_map_02 x (fun ~out x -> A.uniform_ ~a:x.(0) ~b:x.(1) ~out)
+          | Gaussian _shape                               -> _eval_map_02 x (fun ~out x -> A.gaussian_ ~mu:x.(0) ~sigma:x.(1) ~out)
+          | Bernoulli _shape                              -> _eval_map_02 x (fun ~out x -> A.bernoulli_ ~p:x.(0) ~out)
+          | Init (_shape, _f)                             -> failwith "Init"
+          | Get i                                         -> _eval_map_06 x (fun x -> A.get x i)
+          | Set _i                                        -> failwith "Set"
+          | GetSlice slice                                -> _eval_map_01 x (fun ~out x -> A.get_slice_ ~out slice x.(0))
+          | SetSlice slice                                -> _eval_map_01 x (fun ~out x -> A.set_slice_ ~out slice x.(0) x.(1))
+          | Copy                                          -> _eval_map_01 x (fun ~out x -> A.copy_ ~out x.(0)) [@warning "-27"]
+          | Reset                                         -> _eval_map_01 x (fun ~out _x -> A.reset out)
+          | Reshape _shape                                -> _eval_map_01 x (fun ~out x -> A.reshape_ ~out x.(0))
+          | Reverse                                       -> _eval_map_01 x (fun ~out x -> A.reverse_ ~out x.(0))
+          | Tile repeats                                  -> _eval_map_01 x (fun ~out x -> A.tile_ ~out x.(0) repeats)
+          | Repeat repeats                                -> _eval_map_01 x (fun ~out x -> A.repeat_ ~out x.(0) repeats)
+          | Pad (v, padding)                              -> _eval_map_01 x (fun ~out x -> A.pad_ ~out ~v:(unpack_elt v) padding x.(0))
+          | Concatenate axis                              -> _eval_map_00 x A.(concatenate ~axis)
+          | Split (_axis, _parts)                         -> failwith "Split"
+          | Draw (_axis, _n)                              -> failwith "Draw"
+          | Map _f                                        -> failwith "Map"
+          | Fold (_axis, _f)                              -> failwith "Fold"
+          | Scan (_axis, _f)                              -> failwith "Scan"
+          | OneHot depth                                  -> _eval_map_01 x (fun ~out x -> A.one_hot_ ~out depth x.(0))
+          | Delay f                                       -> _eval_map_08 x f
+          | DelayArray (_shape, f)                        -> _eval_map_00 x f
+          | Abs                                           -> _eval_map_01 x (fun ~out x -> A.abs_ ~out x.(0))
+          | Neg                                           -> _eval_map_01 x (fun ~out x -> A.neg_ ~out x.(0))
+          | Floor                                         -> _eval_map_01 x (fun ~out x -> A.floor_ ~out x.(0))
+          | Ceil                                          -> _eval_map_01 x (fun ~out x -> A.ceil_ ~out x.(0))
+          | Round                                         -> _eval_map_01 x (fun ~out x -> A.round_ ~out x.(0))
+          | Sqr                                           -> _eval_map_01 x (fun ~out x -> A.sqr_ ~out x.(0))
+          | Sqrt                                          -> _eval_map_01 x (fun ~out x -> A.sqrt_ ~out x.(0))
+          | Log                                           -> _eval_map_01 x (fun ~out x -> A.log_ ~out x.(0))
+          | Log2                                          -> _eval_map_01 x (fun ~out x -> A.log2_ ~out x.(0))
+          | Log10                                         -> _eval_map_01 x (fun ~out x -> A.log10_ ~out x.(0))
+          | Exp                                           -> _eval_map_01 x (fun ~out x -> A.exp_ ~out x.(0))
+          | Sin                                           -> _eval_map_01 x (fun ~out x -> A.sin_ ~out x.(0))
+          | Cos                                           -> _eval_map_01 x (fun ~out x -> A.cos_ ~out x.(0))
+          | Tan                                           -> _eval_map_01 x (fun ~out x -> A.tan_ ~out x.(0))
+          | Sinh                                          -> _eval_map_01 x (fun ~out x -> A.sinh_ ~out x.(0))
+          | Cosh                                          -> _eval_map_01 x (fun ~out x -> A.cosh_ ~out x.(0))
+          | Tanh                                          -> _eval_map_01 x (fun ~out x -> A.tanh_ ~out x.(0))
+          | Asin                                          -> _eval_map_01 x (fun ~out x -> A.asin_ ~out x.(0))
+          | Acos                                          -> _eval_map_01 x (fun ~out x -> A.acos_ ~out x.(0))
+          | Atan                                          -> _eval_map_01 x (fun ~out x -> A.atan_ ~out x.(0))
+          | Asinh                                         -> _eval_map_01 x (fun ~out x -> A.asinh_ ~out x.(0))
+          | Acosh                                         -> _eval_map_01 x (fun ~out x -> A.acosh_ ~out x.(0))
+          | Atanh                                         -> _eval_map_01 x (fun ~out x -> A.atanh_ ~out x.(0))
+          | Min axis                                      -> _eval_map_01 x (fun ~out x -> A.min_ ~out ~axis x.(0))
+          | Max axis                                      -> _eval_map_01 x (fun ~out x -> A.max_ ~out ~axis x.(0))
+          | Sum axis                                      -> _eval_map_01 x (fun ~out x -> A.sum_ ~out ~axis x.(0))
+          | SumReduce axis                                -> _eval_map_00 x (fun x -> A.sum_reduce ~axis x.(0))
+          | Signum                                        -> _eval_map_01 x (fun ~out x -> A.signum_ ~out x.(0))
+          | Sigmoid                                       -> _eval_map_01 x (fun ~out x -> A.sigmoid_ ~out x.(0))
+          | Relu                                          -> _eval_map_01 x (fun ~out x -> A.relu_ ~out x.(0))
+          | Min'                                          -> _eval_map_06 x A.min'
+          | Max'                                          -> _eval_map_06 x A.max'
+          | Sum'                                          -> _eval_map_06 x A.sum'
+          | L1norm'                                       -> _eval_map_06 x A.l1norm'
+          | L2norm'                                       -> _eval_map_06 x A.l2norm'
+          | L2NormSqr'                                    -> _eval_map_06 x A.l2norm_sqr'
+          | ClipByValue                                   -> _eval_map_07 x (fun ~out a e -> A.clip_by_value_ ~out ~amin:e.(0) ~amax:e.(1) a.(0))
+          | ClipByL2norm                                  -> _eval_map_07 x (fun ~out a e -> A.clip_by_l2norm_ ~out e.(0) a.(0))
+          | Pow                                           -> _eval_map_01 x (fun ~out x -> A.pow_ ~out x.(0) x.(1))
+          | ScalarPow                                     -> _eval_map_05 x A.scalar_pow_
+          | PowScalar                                     -> _eval_map_04 x A.pow_scalar_
+          | Atan2                                         -> _eval_map_01 x (fun ~out x -> A.atan2_ ~out x.(0) x.(1))
+          | ScalarAtan2                                   -> _eval_map_05 x A.scalar_atan2_
+          | Atan2Scalar                                   -> _eval_map_04 x A.atan2_scalar_
+          | Hypot                                         -> _eval_map_01 x (fun ~out x -> A.hypot_ ~out x.(0) x.(1))
+          | Min2                                          -> _eval_map_01 x (fun ~out x -> A.min2_ ~out x.(0) x.(1))
+          | Max2                                          -> _eval_map_01 x (fun ~out x -> A.max2_ ~out x.(0) x.(1))
+          | Add                                           -> _eval_map_01 x (fun ~out x -> A.add_ ~out x.(0) x.(1))
+          | Sub                                           -> _eval_map_01 x (fun ~out x -> A.sub_ ~out x.(0) x.(1))
+          | Mul                                           -> _eval_map_01 x (fun ~out x -> A.mul_ ~out x.(0) x.(1))
+          | Div                                           -> _eval_map_01 x (fun ~out x -> A.div_ ~out x.(0) x.(1))
+          | AddScalar                                     -> _eval_map_04 x A.add_scalar_
+          | SubScalar                                     -> _eval_map_04 x A.sub_scalar_
+          | MulScalar                                     -> _eval_map_04 x A.mul_scalar_
+          | DivScalar                                     -> _eval_map_04 x A.div_scalar_
+          | ScalarAdd                                     -> _eval_map_05 x A.scalar_add_
+          | ScalarSub                                     -> _eval_map_05 x A.scalar_sub_
+          | ScalarMul                                     -> _eval_map_05 x A.scalar_mul_
+          | ScalarDiv                                     -> _eval_map_05 x A.scalar_div_
+          | FMA                                           -> _eval_map_01 x (fun ~out x -> A.fma_ ~out x.(0) x.(1) x.(2))
+          | EltEqual                                      -> _eval_map_01 x (fun ~out x -> A.elt_equal_ ~out x.(0) x.(1))
+          | EltNotEqual                                   -> _eval_map_01 x (fun ~out x -> A.elt_not_equal_ ~out x.(0) x.(1))
+          | EltLess                                       -> _eval_map_01 x (fun ~out x -> A.elt_less_ ~out x.(0) x.(1))
+          | EltGreater                                    -> _eval_map_01 x (fun ~out x -> A.elt_greater_ ~out x.(0) x.(1))
+          | EltLessEqual                                  -> _eval_map_01 x (fun ~out x -> A.elt_less_equal_ ~out x.(0) x.(1))
+          | EltGreaterEqual                               -> _eval_map_01 x (fun ~out x -> A.elt_greater_equal_ ~out x.(0) x.(1))
+          | EltEqualScalar                                -> _eval_map_04 x A.elt_equal_scalar_
+          | EltNotEqualScalar                             -> _eval_map_04 x A.elt_not_equal_scalar_
+          | EltLessScalar                                 -> _eval_map_04 x A.elt_less_scalar_
+          | EltGreaterScalar                              -> _eval_map_04 x A.elt_greater_scalar_
+          | EltLessEqualScalar                            -> _eval_map_04 x A.elt_less_equal_scalar_
+          | EltGreaterEqualScalar                         -> _eval_map_04 x A.elt_greater_equal_scalar_
+          | Conv1d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv1d_ ~out ~padding x.(0) x.(1) stride)
+          | Conv2d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv2d_ ~out ~padding x.(0) x.(1) stride)
+          | Conv3d (padding, stride)                      -> _eval_map_01 x (fun ~out x -> A.conv3d_ ~out ~padding x.(0) x.(1) stride)
+          | TransposeConv1d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_ ~out ~padding x.(0) x.(1) stride)
+          | TransposeConv2d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_ ~out ~padding x.(0) x.(1) stride)
+          | TransposeConv3d (padding, stride)             -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_ ~out ~padding x.(0) x.(1) stride)
+          | DilatedConv1d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_ ~out ~padding x.(0) x.(1) stride rate)
+          | DilatedConv2d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_ ~out ~padding x.(0) x.(1) stride rate)
+          | DilatedConv3d (padding, stride, rate)         -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_ ~out ~padding x.(0) x.(1) stride rate)
+          | MaxPool1d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool1d_ ~out ~padding x.(0) kernel stride)
+          | MaxPool2d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool2d_ ~out ~padding x.(0) kernel stride)
+          | MaxPool3d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.max_pool3d_ ~out ~padding x.(0) kernel stride)
+          | AvgPool1d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool1d_ ~out ~padding x.(0) kernel stride)
+          | AvgPool2d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool2d_ ~out ~padding x.(0) kernel stride)
+          | AvgPool3d (padding, kernel, stride)           -> _eval_map_01 x (fun ~out x -> A.avg_pool3d_ ~out ~padding x.(0) kernel stride)
+          | UpSampling2d size                             -> _eval_map_01 x (fun ~out x -> A.upsampling2d_ ~out x.(0) size)
+          | Conv1dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv1d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | Conv1dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv1d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | Conv2dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv2d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | Conv2dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv2d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | Conv3dBackwardInput stride                    -> _eval_map_01 x (fun ~out x -> A.conv3d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | Conv3dBackwardKernel stride                   -> _eval_map_01 x (fun ~out x -> A.conv3d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv1dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv1dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv1d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv2dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv2dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv2d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv3dBackwardInput stride           -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_backward_input_ ~out x.(0) x.(1) stride x.(2))
+          | TransposeConv3dBackwardKernel stride          -> _eval_map_01 x (fun ~out x -> A.transpose_conv3d_backward_kernel_ ~out x.(0) x.(1) stride x.(2))
+          | DilatedConv1dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
+          | DilatedConv1dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv1d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
+          | DilatedConv2dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
+          | DilatedConv2dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv2d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
+          | DilatedConv3dBackwardInput (stride, rate)     -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_backward_input_ ~out x.(0) x.(1) stride rate x.(2))
+          | DilatedConv3dBackwardKernel (stride, rate)    -> _eval_map_01 x (fun ~out x -> A.dilated_conv3d_backward_kernel_ ~out x.(0) x.(1) stride rate x.(2))
+          | MaxPool1dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool1d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | MaxPool2dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool2d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | MaxPool3dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.max_pool3d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | AvgPool1dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool1d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | AvgPool2dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool2d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | AvgPool3dBackward (padding, kernel, stride)   -> _eval_map_01 x (fun ~out x -> A.avg_pool3d_backward_ ~out padding x.(0) kernel stride x.(1))
+          | UpSampling2dBackward size                     -> _eval_map_01 x (fun ~out x -> A.upsampling2d_backward_ ~out x.(0) size x.(1))
+          | Row                                           -> failwith "Row"
+          | Rows _i                                       -> failwith "Rows"
+          | CopyRowTo                                     -> failwith "CopyRowTo"
+          | CopyColTo                                     -> failwith "CopyColTo"
+          | Dot (transa, transb, alpha, beta)             -> _eval_map_01 x (fun ~out x -> A.dot_ ~transa ~transb ~alpha:(unpack_elt alpha) ~beta:(unpack_elt beta) ~c:out x.(0) x.(1))
+          | Inv                                           -> _eval_map_00 x (fun x -> A.inv x.(0))
+          | Trace                                         -> _eval_map_06 x A.trace
+          | Transpose axis                                -> _eval_map_01 x (fun ~out x -> A.transpose_ ~out ~axis x.(0))
+          | ToRows                                        -> failwith "ToRows"
+          | OfRows                                        -> failwith "OfRows"
+          | Scalar_Add                                    -> _eval_map_03 x (fun x -> A.Scalar.add x.(0) x.(1))
+          | Scalar_Sub                                    -> _eval_map_03 x (fun x -> A.Scalar.sub x.(0) x.(1))
+          | Scalar_Mul                                    -> _eval_map_03 x (fun x -> A.Scalar.mul x.(0) x.(1))
+          | Scalar_Div                                    -> _eval_map_03 x (fun x -> A.Scalar.div x.(0) x.(1))
+          | Scalar_Pow                                    -> _eval_map_03 x (fun x -> A.Scalar.pow x.(0) x.(1))
+          | Scalar_Atan2                                  -> _eval_map_03 x (fun x -> A.Scalar.atan2 x.(0) x.(1))
+          | Scalar_Abs                                    -> _eval_map_03 x (fun x -> A.Scalar.abs x.(0))
+          | Scalar_Neg                                    -> _eval_map_03 x (fun x -> A.Scalar.neg x.(0))
+          | Scalar_Sqr                                    -> _eval_map_03 x (fun x -> A.Scalar.sqr x.(0))
+          | Scalar_Sqrt                                   -> _eval_map_03 x (fun x -> A.Scalar.sqrt x.(0))
+          | Scalar_Exp                                    -> _eval_map_03 x (fun x -> A.Scalar.exp x.(0))
+          | Scalar_Log                                    -> _eval_map_03 x (fun x -> A.Scalar.log x.(0))
+          | Scalar_Log2                                   -> _eval_map_03 x (fun x -> A.Scalar.log2 x.(0))
+          | Scalar_Log10                                  -> _eval_map_03 x (fun x -> A.Scalar.log10 x.(0))
+          | Scalar_Signum                                 -> _eval_map_03 x (fun x -> A.Scalar.signum x.(0))
+          | Scalar_Floor                                  -> _eval_map_03 x (fun x -> A.Scalar.floor x.(0))
+          | Scalar_Ceil                                   -> _eval_map_03 x (fun x -> A.Scalar.ceil x.(0))
+          | Scalar_Round                                  -> _eval_map_03 x (fun x -> A.Scalar.round x.(0))
+          | Scalar_Sin                                    -> _eval_map_03 x (fun x -> A.Scalar.sin x.(0))
+          | Scalar_Cos                                    -> _eval_map_03 x (fun x -> A.Scalar.cos x.(0))
+          | Scalar_Tan                                    -> _eval_map_03 x (fun x -> A.Scalar.tan x.(0))
+          | Scalar_Sinh                                   -> _eval_map_03 x (fun x -> A.Scalar.sinh x.(0))
+          | Scalar_Cosh                                   -> _eval_map_03 x (fun x -> A.Scalar.cosh x.(0))
+          | Scalar_Tanh                                   -> _eval_map_03 x (fun x -> A.Scalar.tanh x.(0))
+          | Scalar_Asin                                   -> _eval_map_03 x (fun x -> A.Scalar.asin x.(0))
+          | Scalar_Acos                                   -> _eval_map_03 x (fun x -> A.Scalar.acos x.(0))
+          | Scalar_Atan                                   -> _eval_map_03 x (fun x -> A.Scalar.atan x.(0))
+          | Scalar_Asinh                                  -> _eval_map_03 x (fun x -> A.Scalar.asinh x.(0))
+          | Scalar_Acosh                                  -> _eval_map_03 x (fun x -> A.Scalar.acosh x.(0))
+          | Scalar_Atanh                                  -> _eval_map_03 x (fun x -> A.Scalar.atanh x.(0))
+          | Scalar_Relu                                   -> _eval_map_03 x (fun x -> A.Scalar.relu x.(0))
+          | Scalar_Sigmoid                                -> _eval_map_03 x (fun x -> A.Scalar.sigmoid x.(0))
+          | Fused_Adagrad (rate, eps)                     -> _eval_map_01 x (fun ~out x -> A.fused_adagrad_ ~out ~rate ~eps x.(0))
+          | _                                             -> failwith "owl_computation_eval:_eval_term"
 
-        with exn -> (
-          Owl_log.error "evaluating %s" (node_to_str x);
-          raise exn
-        )
-      in
-      Array.iter (fun b -> update_validity x b) (get_block x)
-
+          with exn -> (
+            Owl_log.error "evaluating %s" (node_to_str x);
+            raise exn
+          )
+        in
+        Array.iter (fun b -> update_validity x b) (get_block x)
+    in
+    Array.iter eval nodes
 
   (* [f] is pure, for [arr array -> arr] *)
   and _eval_map_00 x f =
+    _eval_terms (parents x);
     let inputs = Array.map (fun x ->
-      _eval_term x;
       value_to_arr (get_value x).(0)
     ) (parents x)
     in
@@ -250,8 +252,8 @@ module Make
 
   (* [f] is impure, for [arr array -> arr] *)
   and _eval_map_01 x f =
+    _eval_terms (parents x);
     let inputs = Array.map (fun parent ->
-      _eval_term parent;
       value_to_arr (get_value parent).(0)
     ) (parents x)
     in
@@ -261,8 +263,8 @@ module Make
 
   (* [f] is inpure, for [elt array -> arr] *)
   and _eval_map_02 x f =
+    _eval_terms (parents x);
     let inputs = Array.map (fun parent ->
-      _eval_term parent;
       value_to_elt (get_value parent).(0)
     ) (parents x)
     in
@@ -272,8 +274,8 @@ module Make
 
   (* [f] is pure, for [elt array -> elt] *)
   and _eval_map_03 x f =
+    _eval_terms (parents x);
     let inputs = Array.map (fun parent ->
-      _eval_term parent;
       value_to_elt (get_value parent).(0)
     ) (parents x)
     in
@@ -285,8 +287,7 @@ module Make
   and _eval_map_04 x f =
     let x_parent_0 = (parents x).(0) in
     let x_parent_1 = (parents x).(1) in
-    _eval_term x_parent_0;
-    _eval_term x_parent_1;
+    _eval_terms (parents x);
     let a = value_to_arr (get_value x_parent_0).(0) in
     let b = value_to_elt (get_value x_parent_1).(0) in
     let out = value_to_arr (get_value x).(0) in
@@ -297,8 +298,7 @@ module Make
   and _eval_map_05 x f =
     let x_parent_0 = (parents x).(0) in
     let x_parent_1 = (parents x).(1) in
-    _eval_term x_parent_0;
-    _eval_term x_parent_1;
+    _eval_terms (parents x);
     let a = value_to_elt (get_value x_parent_0).(0) in
     let b = value_to_arr (get_value x_parent_1).(0) in
     let out = value_to_arr (get_value x).(0) in
@@ -308,7 +308,7 @@ module Make
   (* [f] is pure, for [arr -> elt] *)
   and _eval_map_06 x f =
     let x_parent = (parents x).(0) in
-    _eval_term x_parent;
+    _eval_terms (parents x);
     let a = (get_value x_parent).(0) |> value_to_arr |> f in
     set_value x [|elt_to_value a|]
 
@@ -316,9 +316,9 @@ module Make
   (* [f] is impure, for [arr array -> elt array -> arr] *)
   and _eval_map_07 x f =
     let x_parents = parents x in
-    Array.iter _eval_term x_parents;
-    let arr_args = Owl_utils_array.filter is_arr x_parents |> Array.map (fun v -> (get_value v).(0) |> value_to_arr) in
-    let elt_args = Owl_utils_array.filter is_elt x_parents |> Array.map (fun v -> (get_value v).(0) |> value_to_elt) in
+    _eval_terms x_parents;
+    let arr_args = Owl_utils_array.filter is_node_arr x_parents |> Array.map (fun v -> (get_value v).(0) |> value_to_arr) in
+    let elt_args = Owl_utils_array.filter is_node_elt x_parents |> Array.map (fun v -> (get_value v).(0) |> value_to_elt) in
     let out = value_to_arr (get_value x).(0) in
     f ~out arr_args elt_args
 
@@ -326,7 +326,7 @@ module Make
   (* [f] is pure, for [arr -> arr] *)
   and _eval_map_08 x f =
     let x_parent = (parents x).(0) in
-    _eval_term x_parent;
+    _eval_terms (parents x);
     let a = (get_value x_parent).(0) |> value_to_arr |> f in
     set_value x [|arr_to_value a|]
 

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -232,7 +232,7 @@ module Make
             raise exn
           )
         in
-        Array.iter (fun b -> update_validity x b) (get_block x)
+        Array.iter (update_validity x) (get_block x)
     in
     Array.iter eval nodes
 

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -21,6 +21,7 @@ module Make
 
   let invalidate_opt = function Some x -> invalidate x | None -> ()
 
+
   let update_validity x b =
     invalidate_opt (get_active_node b);
     set_active_node b x;

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -215,7 +215,7 @@ module Make
         let pre_par, post_par = split_parents x in
         Array.iter update_parent pre_par;
         (* do not bother sharing the memory of single elements *)
-        if is_reusable x && not (is_node_elt x) then (
+        if get_reuse x && not (is_node_elt x) then (
           Hashtbl.add refs (id x) (refnum x);
           allocate x
         )
@@ -263,7 +263,7 @@ module Make
       let numel_x = node_numel x in
       total_nodes := !total_nodes + 1;
       total_elt := !total_elt + numel_x;
-      if is_reusable x then (
+      if get_reuse x then (
         reusable_nodes := !reusable_nodes + 1;
         shared_elt := !shared_elt + numel_x
       )
@@ -276,7 +276,7 @@ module Make
 
       if not (Hashtbl.mem blocks_seen block_x) then (
         Hashtbl.add blocks_seen block_x None;
-        if is_reusable x then (
+        if get_reuse x then (
           reusable_blocks := !reusable_blocks + 1;
           alloc_reusable := !alloc_reusable + block_x.size
         )

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -215,7 +215,7 @@ module Make
         let pre_par, post_par = split_parents x in
         Array.iter update_parent pre_par;
         (* do not bother sharing the memory of single elements *)
-        if is_reusable x && not (is_elt x) then (
+        if is_reusable x && not (is_node_elt x) then (
           Hashtbl.add refs (id x) (refnum x);
           allocate x
         )

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -14,320 +14,295 @@ module Make
 
   open Graph.Optimiser.Operator.Symbol
 
-  open Graph.Optimiser.Operator.Symbol.Shape.Type.Device
+  open Graph.Optimiser.Operator.Symbol.Shape.Type
+
+  module MultiMap = Owl_utils_multimap.Make(
+                        struct
+                          type t = int
+                          let compare : int -> int -> int = compare
+                        end)
 
 
   (* utility functions *)
 
-  let is_initialised x =
-    let x_val = get_value x in
-    if is_elt x then false
-    else Array.length x_val > 0
+  let is_broadcastable x =
+    match get_operator x with
+    | Pow             -> true
+    | Atan2           -> true
+    | Hypot           -> true
+    | Min2            -> true
+    | Max2            -> true
+    | Add             -> true
+    | Sub             -> true
+    | Mul             -> true
+    | Div             -> true
+    | FMA             -> true
+    | EltEqual        -> true
+    | EltNotEqual     -> true
+    | EltLess         -> true
+    | EltGreater      -> true
+    | EltLessEqual    -> true
+    | EltGreaterEqual -> true
+    | _               -> false
 
 
-  let make_value_from src dst =
-    let dst_shp = node_shape dst in
-    match src with
-    | Some src -> (
-        (* inherit memory from the src node *)
-        let src_val = value_to_arr (get_value src).(0) in
-        let dst_val = arr_to_value (A.reshape src_val dst_shp) in
-        set_value dst [| dst_val |];
-        set_vnode dst [| src |]
-      )
-    | None     -> (
-        (* allocate new memory for dst node *)
-        let dst_val = arr_to_value (A.zeros dst_shp) in
-        set_value dst [| dst_val |];
-        set_vnode dst [| |]
-      )
+  (* written to be as safe as possible, but can probably set to true more
+   * operations. *)
+  let can_overwrite_parents x =
+    match get_operator x with
+    | Create _shape                                  -> false
+    | Sequential _shape                              -> false
+    | Uniform _shape                                 -> false
+    | Gaussian _shape                                -> false
+    | Bernoulli _shape                               -> false
+    | GetSlice _slice                                -> false
+    | Tile _repeats                                  -> false
+    | Repeat _repeats                                -> false
+    | Pad (_v, _padding)                             -> false
+    | Concatenate _axis                              -> false
+    | Map _f                                         -> false
+    | Fold (_axis, _f)                               -> false
+    | Scan (_axis, _f)                               -> false
+    | OneHot _depth                                  -> false
+    | Min _axis                                      -> false
+    | Max _axis                                      -> false
+    | Sum _axis                                      -> false
+    | SumReduce _axis                                -> false
+    | Pow                                            -> false (* Broadcasting *)
+    | Atan2                                          -> false (* Broadcasting *)
+    | Hypot                                          -> false (* Broadcasting *)
+    | Min2                                           -> false (* Broadcasting *)
+    | Max2                                           -> false (* Broadcasting *)
+    | Add                                            -> false (* Broadcasting *)
+    | Sub                                            -> false (* Broadcasting *)
+    | Mul                                            -> false (* Broadcasting *)
+    | Div                                            -> false (* Broadcasting *)
+    | FMA                                            -> false (* Broadcasting *)
+    | EltEqual                                       -> false (* Broadcasting *)
+    | EltNotEqual                                    -> false (* Broadcasting *)
+    | EltLess                                        -> false (* Broadcasting *)
+    | EltGreater                                     -> false (* Broadcasting *)
+    | EltLessEqual                                   -> false (* Broadcasting *)
+    | EltGreaterEqual                                -> false (* Broadcasting *)
+    | Conv1d (_padding, _stride)                     -> false
+    | Conv2d (_padding, _stride)                     -> false
+    | Conv3d (_padding, _stride)                     -> false
+    | TransposeConv2d (_padding, _stride)            -> false
+    | MaxPool1d (_padding, _kernel, _stride)         -> false
+    | MaxPool2d (_padding, _kernel, _stride)         -> false
+    | MaxPool3d (_padding, _kernel, _stride)         -> false
+    | AvgPool1d (_padding, _kernel, _stride)         -> false
+    | AvgPool2d (_padding, _kernel, _stride)         -> false
+    | AvgPool3d (_padding, _kernel, _stride)         -> false
+    | UpSampling2d _size                             -> false
+    | Conv1dBackwardInput _stride                    -> false
+    | Conv1dBackwardKernel _stride                   -> false
+    | Conv2dBackwardInput _stride                    -> false
+    | Conv2dBackwardKernel _stride                   -> false
+    | Conv3dBackwardInput _stride                    -> false
+    | Conv3dBackwardKernel _stride                   -> false
+    | TransposeConv2dBackwardInput _stride           -> false
+    | TransposeConv2dBackwardKernel _stride          -> false
+    | MaxPool1dBackward (_padding, _kernel, _stride) -> false
+    | MaxPool2dBackward (_padding, _kernel, _stride) -> false
+    | MaxPool3dBackward (_padding, _kernel, _stride) -> false
+    | AvgPool1dBackward (_padding, _kernel, _stride) -> false
+    | AvgPool2dBackward (_padding, _kernel, _stride) -> false
+    | AvgPool3dBackward (_padding, _kernel, _stride) -> false
+    | UpSampling2dBackward _size                     -> false
+    | Dot (_transa, _transb, _alpha, _beta)          -> false
+    | Inv                                            -> false
+    | Transpose _axis                                -> false
+    | _                                              -> true
 
 
-  (* functions of allocating memory space *)
-
-  let allocate_from_parent_0 x = make_value_from None x
-
-
-  let allocate_from_parent_1 x parent =
-    if refnum parent = 1 && get_reuse parent then
-      make_value_from (Some parent) x
-    else
-      make_value_from None x
-
-
-  let allocate_from_parent_2 x parent_0 parent_1 =
-    let parent_0_val = value_to_arr (get_value parent_0).(0) in
-    let parent_1_val = value_to_arr (get_value parent_1).(0) in
-
-    let shp_0 = A.shape parent_0_val in
-    let shp_1 = A.shape parent_1_val in
-    let shp_0, shp_1 = Owl_utils_array.align `Left 1 shp_0 shp_1 in
-    let shp_x = Owl_utils_infer_shape.broadcast1 shp_0 shp_1 in
-
-    if shp_0 = shp_x && refnum parent_0 = 1 && get_reuse parent_0 then
-      make_value_from (Some parent_0) x
-    else if shp_1 = shp_x && refnum parent_1 = 1 && get_reuse parent_1 then
-      make_value_from (Some parent_1) x
-    else
-      make_value_from None x
+  (* return a partition of the parents in two arrays: the parents that the node
+   * can safely overwrite during its computation and the others. *)
+  let split_parents x =
+    let par = Owl_utils.Array.unique (parents x) in
+    (* Broadcastable operations can only overwrite the parents that have the
+     * same shape *)
+    if is_broadcastable x then
+      let sx = node_shape x in
+      Owl_utils.Array.filter (fun p -> node_shape p = sx) par,
+      Owl_utils.Array.filter (fun p -> node_shape p <> sx) par
+    else if can_overwrite_parents x then par, [||]
+    else [||], par
 
 
-  let allocate_from_parent_3 x parent_0 parent_1 parent_2 =
-    let parent_0_val = value_to_arr (get_value parent_0).(0) in
-    let parent_1_val = value_to_arr (get_value parent_1).(0) in
-    let parent_2_val = value_to_arr (get_value parent_2).(0) in
+  (* Core initialisation function. Inspired by
+   * https://mxnet.incubator.apache.org/architecture/note_memory.html. *)
+  let _init_terms nodes =
+    (* hashtable: node -> its number of references left to use *)
+    let refs = Hashtbl.create 256 in
+    (* number of elements -> id of a reusable block of corresponding size *)
+    let reusable = ref MultiMap.empty in
+    (* node id -> id of a block that was assigned to it *)
+    let node_to_block = Hashtbl.create 256 in
+    (* block id -> its size *)
+    let block_to_size = Hashtbl.create 16 in
+    (* node id -> the corresponding node *)
+    let id_to_node = Hashtbl.create 256 in
 
-    let shp_0 = A.shape parent_0_val in
-    let shp_1 = A.shape parent_1_val in
-    let shp_2 = A.shape parent_2_val in
-    let shp_0, shp_1, shp_2 = Owl_utils_array.align3 `Left 1 shp_0 shp_1 shp_2 in
-    let shp_x = Owl_utils_infer_shape.broadcast2 shp_0 shp_1 shp_2 in
+    (* already has a block or is already associated to a block id during the
+     * execution of the algorithm *)
+    let is_initialised x =
+      is_assigned x || Hashtbl.mem node_to_block (id x)
+    in
 
-    if shp_0 = shp_x && refnum parent_0 = 1 && get_reuse parent_0 then
-      make_value_from (Some parent_0) x
-    else if shp_1 = shp_x && refnum parent_1 = 1 && get_reuse parent_1 then
-      make_value_from (Some parent_1) x
-    else if shp_2 = shp_x && refnum parent_2 = 1 && get_reuse parent_2 then
-      make_value_from (Some parent_2) x
-    else
-      make_value_from None x
-
-
-  let allocate_from_parent_arr x parents =
-    let parents_val = Array.map
-                        (fun par -> value_to_arr (get_value par).(0)) parents in
-    let shp_x = node_shape x in
-    let id_shaped_par, _ = Owl_utils.Array.filter2_split
-                             (fun par par_val -> A.shape par_val = shp_x
-                                                 && refnum par = 1
-                                                 && get_reuse par)
-                             parents parents_val in
-    if Array.length id_shaped_par > 0 then
-      make_value_from (Some id_shaped_par.(0)) x
-    else
-      make_value_from None x
-
-
-  (* core initialisation function *)
-
-  let rec _init_term x =
-    Owl_log.debug "init %s ..." (node_to_str x);
-
-    if is_initialised x = false then
-      try
-        match (get_operator x) with
-        | Noop                                           -> _init_05 x
-        | Var                                            -> _init_05 x
-        | Const                                          -> _init_05 x
-        | Empty _shape                                   -> _init_00 x
-        | Zeros _shape                                   -> _init_00 x
-        | Ones _shape                                    -> _init_00 x
-        | Create _shape                                  -> _init_00 x
-        | Sequential _shape                              -> _init_00 x
-        | Uniform _shape                                 -> _init_00 x
-        | Gaussian _shape                                -> _init_00 x
-        | Bernoulli _shape                               -> _init_00 x
-        | Init (_shape, _f)                              -> _init_00 x
-        | Get _i                                         -> _init_05 x
-        | Set _i                                         -> failwith "Set"
-        | GetSlice _slice                                -> _init_00 x
-        | SetSlice _slice                                -> _init_01 x
-        | Copy                                           -> _init_01 x
-        | Reset                                          -> _init_01 x
-        | Reshape _shape                                 -> _init_01 x
-        | Reverse                                        -> _init_01 x
-        | Tile _repeats                                  -> _init_00 x
-        | Repeat _repeats                                -> _init_00 x
-        | Pad (_v, _padding)                             -> _init_00 x
-        | Concatenate _axis                              -> _init_00 x
-        | Split (_axis, _parts)                          -> failwith "Split"
-        | Draw (_axis, _n)                               -> failwith "Draw"
-        | Map _f                                         -> _init_00 x
-        | Fold (_axis, _f)                               -> _init_00 x
-        | Scan (_axis, _f)                               -> _init_00 x
-        | OneHot _depth                                  -> _init_00 x
-        | Delay _f                                       -> _init_01 x
-        | DelayArray (_shape, _f)                        -> _init_06 x
-        | Abs                                            -> _init_01 x
-        | Neg                                            -> _init_01 x
-        | Floor                                          -> _init_01 x
-        | Ceil                                           -> _init_01 x
-        | Round                                          -> _init_01 x
-        | Sqr                                            -> _init_01 x
-        | Sqrt                                           -> _init_01 x
-        | Log                                            -> _init_01 x
-        | Log2                                           -> _init_01 x
-        | Log10                                          -> _init_01 x
-        | Exp                                            -> _init_01 x
-        | Sin                                            -> _init_01 x
-        | Cos                                            -> _init_01 x
-        | Tan                                            -> _init_01 x
-        | Sinh                                           -> _init_01 x
-        | Cosh                                           -> _init_01 x
-        | Tanh                                           -> _init_01 x
-        | Asin                                           -> _init_01 x
-        | Acos                                           -> _init_01 x
-        | Atan                                           -> _init_01 x
-        | Asinh                                          -> _init_01 x
-        | Acosh                                          -> _init_01 x
-        | Atanh                                          -> _init_01 x
-        | Min _axis                                      -> _init_00 x
-        | Max _axis                                      -> _init_00 x
-        | Sum _axis                                      -> _init_00 x
-        | SumReduce _axis                                -> _init_00 x
-        | Signum                                         -> _init_01 x
-        | Sigmoid                                        -> _init_01 x
-        | Relu                                           -> _init_01 x
-        | Min'                                           -> _init_05 x
-        | Max'                                           -> _init_05 x
-        | Sum'                                           -> _init_05 x
-        | L1norm'                                        -> _init_05 x
-        | L2norm'                                        -> _init_05 x
-        | L2NormSqr'                                     -> _init_05 x
-        | ClipByValue                                    -> _init_01 x
-        | ClipByL2norm                                   -> _init_01 x
-        | Pow                                            -> _init_02 x
-        | ScalarPow                                      -> _init_04 x
-        | PowScalar                                      -> _init_01 x
-        | Atan2                                          -> _init_02 x
-        | ScalarAtan2                                    -> _init_04 x
-        | Atan2Scalar                                    -> _init_01 x
-        | Hypot                                          -> _init_02 x
-        | Min2                                           -> _init_02 x
-        | Max2                                           -> _init_02 x
-        | Add                                            -> _init_02 x
-        | Sub                                            -> _init_02 x
-        | Mul                                            -> _init_02 x
-        | Div                                            -> _init_02 x
-        | AddScalar                                      -> _init_01 x
-        | SubScalar                                      -> _init_01 x
-        | MulScalar                                      -> _init_01 x
-        | DivScalar                                      -> _init_01 x
-        | ScalarAdd                                      -> _init_04 x
-        | ScalarSub                                      -> _init_04 x
-        | ScalarMul                                      -> _init_04 x
-        | ScalarDiv                                      -> _init_04 x
-        | FMA                                            -> _init_03 x
-        | EltEqual                                       -> _init_02 x
-        | EltNotEqual                                    -> _init_02 x
-        | EltLess                                        -> _init_02 x
-        | EltGreater                                     -> _init_02 x
-        | EltLessEqual                                   -> _init_02 x
-        | EltGreaterEqual                                -> _init_02 x
-        | EltEqualScalar                                 -> _init_01 x
-        | EltNotEqualScalar                              -> _init_01 x
-        | EltLessScalar                                  -> _init_01 x
-        | EltGreaterScalar                               -> _init_01 x
-        | EltLessEqualScalar                             -> _init_01 x
-        | EltGreaterEqualScalar                          -> _init_01 x
-        | Conv1d (_padding, _stride)                     -> _init_00 x
-        | Conv2d (_padding, _stride)                     -> _init_00 x
-        | Conv3d (_padding, _stride)                     -> _init_00 x
-        | TransposeConv2d (_padding, _stride)            -> _init_00 x
-        | MaxPool1d (_padding, _kernel, _stride)         -> _init_00 x
-        | MaxPool2d (_padding, _kernel, _stride)         -> _init_00 x
-        | MaxPool3d (_padding, _kernel, _stride)         -> _init_00 x
-        | AvgPool1d (_padding, _kernel, _stride)         -> _init_00 x
-        | AvgPool2d (_padding, _kernel, _stride)         -> _init_00 x
-        | AvgPool3d (_padding, _kernel, _stride)         -> _init_00 x
-        | UpSampling2d _size                             -> _init_00 x
-        | Conv1dBackwardInput _stride                    -> _init_00 x
-        | Conv1dBackwardKernel _stride                   -> _init_00 x
-        | Conv2dBackwardInput _stride                    -> _init_00 x
-        | Conv2dBackwardKernel _stride                   -> _init_00 x
-        | Conv3dBackwardInput _stride                    -> _init_00 x
-        | Conv3dBackwardKernel _stride                   -> _init_00 x
-        | TransposeConv2dBackwardInput _stride           -> _init_00 x
-        | TransposeConv2dBackwardKernel _stride          -> _init_00 x
-        | MaxPool1dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | MaxPool2dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | MaxPool3dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | AvgPool1dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | AvgPool2dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | AvgPool3dBackward (_padding, _kernel, _stride) -> _init_00 x
-        | UpSampling2dBackward _size                     -> _init_00 x
-        | Row                                            -> failwith "Row"
-        | Rows _i                                        -> failwith "Rows"
-        | CopyRowTo                                      -> failwith "CopyRowTo"
-        | CopyColTo                                      -> failwith "CopyColTo"
-        | Dot (_transa, _transb, _alpha, _beta)          -> _init_00 x
-        | Inv                                            -> _init_00 x
-        | Trace                                          -> _init_05 x
-        | Transpose _axis                                -> _init_00 x
-        | ToRows                                         -> failwith "ToRows"
-        | OfRows                                         -> failwith "OfRows"
-        | Scalar_Add                                     -> _init_05 x
-        | Scalar_Sub                                     -> _init_05 x
-        | Scalar_Mul                                     -> _init_05 x
-        | Scalar_Div                                     -> _init_05 x
-        | Scalar_Pow                                     -> _init_05 x
-        | Scalar_Atan2                                   -> _init_05 x
-        | Scalar_Abs                                     -> _init_05 x
-        | Scalar_Neg                                     -> _init_05 x
-        | Scalar_Sqr                                     -> _init_05 x
-        | Scalar_Sqrt                                    -> _init_05 x
-        | Scalar_Exp                                     -> _init_05 x
-        | Scalar_Log                                     -> _init_05 x
-        | Scalar_Log2                                    -> _init_05 x
-        | Scalar_Log10                                   -> _init_05 x
-        | Scalar_Signum                                  -> _init_05 x
-        | Scalar_Floor                                   -> _init_05 x
-        | Scalar_Ceil                                    -> _init_05 x
-        | Scalar_Round                                   -> _init_05 x
-        | Scalar_Sin                                     -> _init_05 x
-        | Scalar_Cos                                     -> _init_05 x
-        | Scalar_Tan                                     -> _init_05 x
-        | Scalar_Sinh                                    -> _init_05 x
-        | Scalar_Cosh                                    -> _init_05 x
-        | Scalar_Tanh                                    -> _init_05 x
-        | Scalar_Asin                                    -> _init_05 x
-        | Scalar_Acos                                    -> _init_05 x
-        | Scalar_Atan                                    -> _init_05 x
-        | Scalar_Asinh                                   -> _init_05 x
-        | Scalar_Acosh                                   -> _init_05 x
-        | Scalar_Atanh                                   -> _init_05 x
-        | Scalar_Relu                                    -> _init_05 x
-        | Scalar_Sigmoid                                 -> _init_05 x
-        | Fused_Adagrad (_rate, _eps)                    -> _init_01 x
-        | _                                              -> failwith "owl_computation_init:"
-
-        with exn -> (
-          Owl_log.error "initialising %s" (node_to_str x);
-          raise exn
+    (* Notifies a node that it has been used by one of its children.
+     * If no more children have to use the node, assumes that the memory of the
+     * node can be reused by another node. *)
+    let update_parent p =
+      let id_p = id p in
+      if not (is_assigned p) && Hashtbl.mem refs id_p then (
+        let num = Hashtbl.find refs id_p in
+        assert (num > 0);
+        if num - 1 = 0 then (* can be reused *) (
+          Hashtbl.remove refs id_p;
+          let block_id = Hashtbl.find node_to_block id_p in
+          let block_size = Hashtbl.find block_to_size block_id in
+          reusable := MultiMap.add block_size block_id !reusable
         )
+        else Hashtbl.replace refs id_p (num - 1)
+      )
+    in
+
+    (* Heuristic: return the smallest block that is greater than [numel].
+     * If no such block exists, return the biggest one and make it bigger.
+     * Time complexity: [O(log b)] where [b] is the size of [reusable]. *)
+    let best_block_to_reuse numel =
+      if MultiMap.is_empty !reusable then None
+      else (
+        let to_reuse = MultiMap.find_first_opt (fun k -> k >= numel) !reusable in
+        let size, b_id = match to_reuse with
+          | Some x -> x
+          | None   -> MultiMap.max_binding !reusable
+        in
+        reusable := MultiMap.remove size !reusable;
+        if size < numel then (
+          Hashtbl.replace block_to_size b_id numel
+        );
+        Some b_id
+      )
+    in
+
+    (* Links node [x] to a new block. *)
+    let allocate_new x =
+      let numel_x = node_numel x in
+      let b_id = new_block_id () in
+      Hashtbl.add node_to_block (id x) b_id;
+      Hashtbl.add block_to_size b_id numel_x
+    in
+
+    (* Links the node [x] to the best reusable block if such a block exists.
+     * Otherwise, links [x] to a new block. *)
+    let allocate x =
+      let numel_x = node_numel x in
+      let block_id_to_reuse = best_block_to_reuse numel_x in
+      match block_id_to_reuse with
+      | Some b_id -> Hashtbl.add node_to_block (id x) b_id
+      | None      -> allocate_new x
+    in
+
+    (* assume the parents of an initialised node are always initialised *)
+    let rec init x =
+      Owl_log.debug "init %s ..." (node_to_str x);
+
+      if not (is_initialised x) then (
+        Hashtbl.add id_to_node (id x) x;
+        Array.iter init (parents x);
+        let pre_par, post_par = split_parents x in
+        Array.iter update_parent pre_par;
+        (* do not bother sharing the memory of single elements *)
+        if is_reusable x && not (is_elt x) then (
+          Hashtbl.add refs (id x) (refnum x);
+          allocate x
+        )
+        else (
+          (* a node that cannot be reused cannot reuse either *)
+          allocate_new x
+        );
+        Array.iter update_parent post_par;
+      )
+    in
+    (* link all the nodes to a block id and all the blocks to a size *)
+    Array.iter init nodes;
+
+    (* create the blocks and initialise the relevant attributes of the nodes *)
+    let id_to_block = Hashtbl.create 16 in
+    Hashtbl.iter
+      (fun x_id b_id ->
+        let x = Hashtbl.find id_to_node x_id in
+        if Hashtbl.mem id_to_block b_id then (
+          let block = Hashtbl.find id_to_block b_id in
+          add_node_to_block x block
+        )
+        else (
+          let size = Hashtbl.find block_to_size b_id in
+          let block = make_empty_block ~block_id:b_id size in
+          Hashtbl.add id_to_block b_id block;
+          add_node_to_block x block
+        )
+      ) node_to_block
 
 
-  and _init_00 x =
-    Array.iter _init_term (parents x);
-    allocate_from_parent_0 x
+  (* display some statistics about the number of blocks and the number of
+   * allocated elements *)
+  let init_stats nodes =
+    let total_elt = ref 0
+    and shared_elt = ref 0
+    and non_shared_elt = ref 0 in
+    let total_nodes = ref 0
+    and reusable_nodes = ref 0
+    and non_reusable_nodes = ref 0 in
+    let blocks_seen = Hashtbl.create 256 in
+    let reusable_blocks = ref 0
+    and alloc_reusable = ref 0 in
+    let update_stats x =
+      let numel_x = node_numel x in
+      total_nodes := !total_nodes + 1;
+      total_elt := !total_elt + numel_x;
+      if is_reusable x then (
+        reusable_nodes := !reusable_nodes + 1;
+        shared_elt := !shared_elt + numel_x
+      )
+      else (
+        non_reusable_nodes := !non_reusable_nodes + 1;
+        non_shared_elt := !non_shared_elt + numel_x
+      );
 
+      let block_x = (get_block x).(0) in
 
-  and _init_01 x =
-    let par = Array.map (fun p -> _init_term p; p) (parents x) in
-    allocate_from_parent_1 x par.(0)
+      if not (Hashtbl.mem blocks_seen block_x) then (
+        Hashtbl.add blocks_seen block_x None;
+        if is_reusable x then (
+          reusable_blocks := !reusable_blocks + 1;
+          alloc_reusable := !alloc_reusable + block_x.size
+        )
+      )
+    in
 
+    Owl_graph.iter_ancestors update_stats nodes;
 
-  and _init_02 x =
-    let par = Array.map (fun p -> _init_term p; p) (parents x) in
-    allocate_from_parent_2 x par.(0) par.(1)
+    let b = Buffer.create 170 in
+    Buffer.add_string b "*** INITIALISATION STATISTICS ***\n";
+    Buffer.add_string b
+      (Printf.sprintf "  %d nodes, %d elements\n" !total_nodes !total_elt);
+    Buffer.add_string b
+      (Printf.sprintf "  %d reusable nodes, %d elements\n"
+         !reusable_nodes !shared_elt);
+    Buffer.add_string b
+      (Printf.sprintf "  %d non-reusable nodes, %d elements\n"
+         !non_reusable_nodes !non_shared_elt);
+    Buffer.add_string b
+      (Printf.sprintf "  %d shared blocks, %d elements\n"
+         !reusable_blocks !alloc_reusable);
+    Buffer.add_string b
+      (Printf.sprintf "  TOTAL NUMBER OF ALLOCATED ELEMENTS: %d\n"
+         (!alloc_reusable + !non_shared_elt));
+    Owl_log.info "%s" (Buffer.contents b)
 
-
-  and _init_03 x =
-    let par = Array.map (fun p -> _init_term p; p) (parents x) in
-    allocate_from_parent_3 x par.(0) par.(1) par.(2)
-
-
-  and _init_04 x =
-    let par = Array.map (fun p -> _init_term p; p) (parents x) in
-    allocate_from_parent_1 x par.(1)
-
-
-  and _init_05 x = Array.iter _init_term (parents x)
-
-
-  and _init_06 x =
-    let par = Array.map (fun p -> _init_term p; p) (parents x) in
-    allocate_from_parent_arr x par
 
 end
 

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -250,15 +250,15 @@ module Make
   (* display some statistics about the number of blocks and the number of
    * allocated elements *)
   let init_stats nodes =
-    let total_elt = ref 0
-    and shared_elt = ref 0
-    and non_shared_elt = ref 0 in
-    let total_nodes = ref 0
-    and reusable_nodes = ref 0
-    and non_reusable_nodes = ref 0 in
+    let total_elt = ref 0 in
+    let shared_elt = ref 0 in
+    let non_shared_elt = ref 0 in
+    let total_nodes = ref 0 in
+    let reusable_nodes = ref 0 in
+    let non_reusable_nodes = ref 0 in
     let blocks_seen = Hashtbl.create 256 in
-    let reusable_blocks = ref 0
-    and alloc_reusable = ref 0 in
+    let reusable_blocks = ref 0 in
+    let alloc_reusable = ref 0 in
     let update_stats x =
       let numel_x = node_numel x in
       total_nodes := !total_nodes + 1;

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -17,10 +17,10 @@ module Make
   open Graph.Optimiser.Operator.Symbol.Shape.Type
 
   module MultiMap = Owl_utils_multimap.Make(
-                        struct
-                          type t = int
-                          let compare : int -> int -> int = compare
-                        end)
+                      struct
+                        type t = int
+                        let compare : int -> int -> int = compare
+                      end)
 
 
   (* utility functions *)

--- a/src/base/compute/owl_computation_graph.ml
+++ b/src/base/compute/owl_computation_graph.ml
@@ -213,7 +213,7 @@ module Make
 
   let update_iopair graph =
     Array.iteri (fun idx (i, o) ->
-      if is_arr i = true then (
+      if is_node_arr i = true then (
         let o_val = get_node_arr_val o in
         let i_arr = node_to_arr i in
         (* make sure the original data will never be modified. *)

--- a/src/base/compute/owl_computation_graph.ml
+++ b/src/base/compute/owl_computation_graph.ml
@@ -69,7 +69,7 @@ module Make
       let b_id = get_block_id n in
       Printf.sprintf "%s%i [ label=\"{{#%i | { %s | %s }} | r:%i; %s; b:%i }\""
         a (id n) (id n) (name n) (op_to_str (attr n).op) (refnum n) svs b_id ^
-        (if is_reusable n && b_id <> -1 then
+        (if get_reuse n && b_id <> -1 then
            let col = _block_colour b_id in
            Printf.sprintf "style=filled fillcolor=\"%s\"" col
          else "") ^

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -259,7 +259,7 @@ module Make
     let parent = (parents x).(0) in
     _optimise_term parent;
     let op = get_operator x in
-    let reusable = is_reusable x in
+    let reusable = get_reuse x in
     if op = Noop && reusable then (
       let x_children = children x in
       let parent_children = children parent in

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -259,8 +259,8 @@ module Make
     let parent = (parents x).(0) in
     _optimise_term parent;
     let op = get_operator x in
-    let resuable = get_reuse x in
-    if op = Noop && resuable then (
+    let reusable = is_reusable x in
+    if op = Noop && reusable then (
       let x_children = children x in
       let parent_children = children parent in
       let merged_children = Owl_utils_array.merge x_children parent_children in

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -441,7 +441,7 @@ module Make
       (attr x).reuse <- reuse
 
 
-  let is_reusable x = (attr x).reuse
+  let get_reuse x = (attr x).reuse
 
 
   let is_shared x = match get_block_opt x with
@@ -465,6 +465,7 @@ module Make
   let is_const x = (attr x).op = Const
 
 
+  (* TODO: change it to rely on the operator. *)
   let is_node_arr x =
     match (attr x).shape.(0) with
     | Some [||] -> false

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -297,7 +297,8 @@ module Make
   let make_empty_block ?block_id size =
     let block_id = match block_id with
       | Some block_id -> block_id
-      | None          -> new_block_id () in
+      | None          -> new_block_id ()
+    in
     (* allocate a one-dimensional array *)
     let memory = arr_to_value (A.empty [|size|]) in
     { size; block_id; active = None; memory; nodes = []; }
@@ -411,9 +412,9 @@ module Make
     if is_arr v.(0) then (
       match get_block_opt x with
       | Some _ ->
-         let xv = value_to_arr (attr x).value.(0) in
-         let vv = value_to_arr v.(0) in
-         A.copy_ ~out:xv vv
+          let xv = value_to_arr (attr x).value.(0) in
+          let vv = value_to_arr v.(0) in
+          A.copy_ ~out:xv vv
       | None   -> make_value_block v.(0) x
     )
     else (
@@ -444,10 +445,11 @@ module Make
 
 
   let is_shared x = match get_block_opt x with
-    | Some bs -> (match get_nodes_using_block bs.(0) with
-                  | _ :: _ :: _ -> true (* at least 2 elements *)
-                  | _           -> false
-                 )
+    | Some bs -> (
+        match get_nodes_using_block bs.(0) with
+        | _ :: _ :: _ -> true (* at least 2 elements *)
+        | _           -> false
+      )
     | None    -> false
 
 

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -19,7 +19,6 @@ module Make
 
   open Shape.Type.Device
 
-
   (* string representation of symbols *)
 
   let op_to_str = function
@@ -239,7 +238,7 @@ module Make
   let node_numel x = Array.fold_left ( * ) 1 (node_shape x)
 
 
-  let is_shape_unkown x =
+  let is_shape_unknown x =
     let x_shape = (attr x).shape in
     match x_shape.(0) with
     | Some _ -> true
@@ -248,7 +247,7 @@ module Make
 
   let infer_shape_graph xs =
     iter_descendants (fun x ->
-      if is_shape_unkown x = false then (
+      if is_shape_unknown x = false then (
         let x_attr = attr x in
         let x_parents = parents x in
         x_attr.shape <- infer_shape x_attr.op x_parents
@@ -260,7 +259,7 @@ module Make
     assert (Array.length shp > 0);
     let s = match shp.(0) with
       | Some s -> Owl_utils_array.to_string string_of_int s
-      | None   -> "unkown"
+      | None   -> "unknown"
     in
     Printf.sprintf "[%s]" s
 
@@ -287,14 +286,46 @@ module Make
   let elt_to_node = function Elt x -> x
 
 
+  let new_block_id =
+    let _global_block_id = ref 0 in
+    (fun () ->
+      _global_block_id := !_global_block_id + 1;
+      !_global_block_id)
+
+
+  (* Meant for reusable nodes. *)
+  let make_empty_block ?block_id size =
+    let block_id = match block_id with
+      | Some block_id -> block_id
+      | None          -> new_block_id () in
+    (* allocate a one-dimensional array *)
+    let memory = arr_to_value (A.empty [|size|]) in
+    { size; block_id; active = None; memory; nodes = []; }
+
+
+  (* This is meant for nodes that are not reusable: memory is not reshaped. *)
+  let make_value_block memory x =
+    let block_id = new_block_id () in
+    let size = match memory with
+      | EltVal _ -> 1
+      | ArrVal x -> A.numel x in
+    let block = { size; block_id; active = Some x; memory; nodes = [ x ]; } in
+    (attr x).value <- [| memory |];
+    (attr x).block <- Some [| block |]
+
+
   let make_node ?name ?value ?shape ?freeze ?reuse ?state op =
-    let value = match value with Some v -> v | None -> [| |] in
     let shape = match shape with Some s -> s | None -> [| None |] in
     let state = match state with Some s -> s | None -> Invalid in
     let reuse = match reuse with Some s -> s | None -> true in
     let freeze = match freeze with Some s -> s | None -> false in
-    let vnode = [| (* used by the computation engine only *) |] in
-    Owl_graph.node ?name { op; freeze; reuse; state; shape; value; vnode }
+    let value = match value with Some v -> v | None -> [| |] in
+    let attr = { op; freeze; reuse; state; shape; value; block = None; } in
+    let node = Owl_graph.node ?name attr in
+    if value <> [| |] then (
+      make_value_block value.(0) node
+    );
+    node
 
 
   let make_then_connect ?shape op parents =
@@ -338,7 +369,59 @@ module Make
     |> node_to_elt
 
 
-  let set_value x v = (attr x).value <- v
+  let get_nodes_using_block b = b.nodes
+
+
+  let _get_value_block b = b.memory
+
+
+  let get_block_opt x = (attr x).block
+
+
+  let get_block x = match get_block_opt x with
+    | Some b -> b
+    | None   -> failwith "Symbol:get_block_exn: block not assigned"
+
+
+  let _set_block x b = (attr x).block <- Some b
+
+
+  let add_node_to_block x block =
+    let dst_shp = node_shape x in
+    let dst_numel = node_numel x in
+    let src_val = value_to_arr (_get_value_block block) in
+    (* allocate the first [dst_numel] elements for the memory of the node *)
+    let dst_val = arr_to_value (A.reshape (A.sub_left src_val 0 dst_numel) dst_shp) in
+    block.nodes <- x :: block.nodes;
+    _set_block x [| block |];
+    (attr x).value <- [| dst_val |]
+
+
+  let get_active_node b = b.active
+
+
+  let set_active_node b x = b.active <- Some x
+
+
+  let get_block_id x = match get_block_opt x with
+    | Some bs -> bs.(0).block_id
+    | None    -> -1
+
+
+  let set_value x v =
+    match v.(0) with
+    | ArrVal vv ->
+       (match get_block_opt x with
+        | Some _ ->
+           let xv = value_to_arr (attr x).value.(0) in
+           A.copy_ ~out:xv vv
+        | None    -> make_value_block v.(0) x
+       )
+    | EltVal _ ->
+       (match get_block_opt x with
+        | Some bs -> (attr x).value <- v; bs.(0).memory <- v.(0)
+        | None    -> make_value_block v.(0) x
+       )
 
 
   let get_value x = (attr x).value
@@ -358,16 +441,21 @@ module Make
       (attr x).reuse <- reuse
 
 
-  let get_reuse x = (attr x).reuse
+  let is_reusable x = (attr x).reuse
 
 
-  let set_vnode x v = (attr x).vnode <- v
+  let is_shared x = match get_block_opt x with
+    | Some bs -> (match get_nodes_using_block bs.(0) with
+                  | _ :: _ :: _ -> true (* at least 2 elements *)
+                  | _           -> false
+                 )
+    | None    -> false
 
 
-  let get_vnode x = (attr x).vnode
-
-
-  let is_inherited x = Array.length (get_vnode x) > 0
+  (* contains itself *)
+  let get_shared_nodes x = match get_block_opt x with
+    | Some bs -> Array.of_list (get_nodes_using_block bs.(0))
+    | None    -> [| x |]
 
 
   let is_var x = (attr x).op = Var
@@ -391,17 +479,15 @@ module Make
 
 
   let is_assigned x =
-    let value = (attr x).value in
-    let valen = Array.length value in
-    valen > 0
+    match get_block_opt x with
+    | Some _ -> true
+    | None   -> false
 
 
   let check_assigned x =
-    let value = (attr x).value in
-    let valen = Array.length value in
-    if valen = 0 then (
+    if not (is_assigned x) then (
       Owl_log.error "value not assigned: %s" (node_to_str x);
-      assert (valen > 0)
+      failwith "owl_computation_symbol:check_assigned"
     )
 
 
@@ -433,7 +519,7 @@ module Make
 
 
   let unpack_arr x =
-    let value = (arr_to_node x |> attr).value in
+    let value = arr_to_node x |> get_value in
     let valen = Array.length value in
     if valen = 0 then (
       Owl_log.error "not evaluated: %s" (arr_to_node x |> node_to_str);
@@ -446,7 +532,7 @@ module Make
 
 
   let unpack_elt x =
-    let value = (elt_to_node x |> attr).value in
+    let value = elt_to_node x |> get_value in
     let valen = Array.length value in
     if valen = 0 then (
       Owl_log.error "not evaluated: %s" (elt_to_node x |> node_to_str);

--- a/src/base/compute/owl_computation_symbol_sig.ml
+++ b/src/base/compute/owl_computation_symbol_sig.ml
@@ -143,10 +143,10 @@ module type Sig = sig
   val is_const : attr Owl_graph.node -> bool
   (** TODO *)
 
-  val is_arr : attr Owl_graph.node -> bool
+  val is_node_arr : attr Owl_graph.node -> bool
   (** TODO *)
 
-  val is_elt : attr Owl_graph.node -> bool
+  val is_node_elt : attr Owl_graph.node -> bool
   (** TODO *)
 
   val is_assigned : attr Owl_graph.node -> bool

--- a/src/base/compute/owl_computation_symbol_sig.ml
+++ b/src/base/compute/owl_computation_symbol_sig.ml
@@ -32,7 +32,7 @@ module type Sig = sig
   val node_numel : attr Owl_graph.node -> int
   (** TODO *)
 
-  val is_shape_unkown : attr Owl_graph.node -> bool
+  val is_shape_unknown : attr Owl_graph.node -> bool
   (** TODO *)
 
   val infer_shape_graph : attr Owl_graph.node array -> unit
@@ -74,6 +74,42 @@ module type Sig = sig
   val const_elt : string -> A.elt -> elt
   (** TODO *)
 
+  val new_block_id : unit -> int
+  (** ``new_block_id ()`` returns an unused block id. *)
+
+  val make_empty_block : ?block_id:int -> int -> block
+  (** ``make_empty_block s`` returns an empty block of memory of size ``s``. *)
+
+  val make_value_block : value -> attr Owl_graph.node -> unit
+  (**
+  ``make_value_block value node`` creates a block of memory initialised with
+  ``value`` and links the new block to ``node``.
+   *)
+
+  val get_block : attr Owl_graph.node -> block array
+  (**
+  ``get_block node`` returns the memory block allocated to ``node``.
+  If no block is allocated, throws an exception.
+   *)
+
+  val add_node_to_block : attr Owl_graph.node -> block -> unit
+  (**
+  Link a node to a reusable block and initialises its memory on the memory of
+  the block.
+   *)
+
+  val get_active_node : block -> (attr Owl_graph.node) option
+  (** Return the node that is currently using the memory of the block. *)
+
+  val set_active_node : block -> attr Owl_graph.node -> unit
+  (** Update the node that is currently using the block of memory. *)
+
+  val get_block_id : attr Owl_graph.node -> int
+  (**
+  ``get_block_id node`` returns the id of the block assigned to ``node``. If
+  ``node`` has not been assigned yet, returns ``-1``.
+   *)
+
   val set_value : attr Owl_graph.node -> value array -> unit
   (** TODO *)
 
@@ -89,17 +125,17 @@ module type Sig = sig
   val set_reuse : attr Owl_graph.node -> bool -> unit
   (** TODO *)
 
-  val get_reuse : attr Owl_graph.node -> bool
+  val is_reusable : attr Owl_graph.node -> bool
   (** TODO *)
 
-  val set_vnode : attr Owl_graph.node -> t array -> unit
+  val is_shared : attr Owl_graph.node -> bool
   (** TODO *)
 
-  val get_vnode : attr Owl_graph.node -> t array
-  (** TODO *)
-
-  val is_inherited : attr Owl_graph.node -> bool
-  (** TODO *)
+  val get_shared_nodes : attr Owl_graph.node -> (attr Owl_graph.node) array
+  (**
+  ``get_shared_nodes node`` returns the nodes sharing the same block of memory
+  as ``node``.
+   *)
 
   val is_var : attr Owl_graph.node -> bool
   (** TODO *)
@@ -114,10 +150,16 @@ module type Sig = sig
   (** TODO *)
 
   val is_assigned : attr Owl_graph.node -> bool
-  (** TODO *)
+  (**
+  ``is_assigned node`` checks if a block of memory has been assigned to
+  ``node``.
+   *)
 
   val check_assigned : attr Owl_graph.node -> unit
-  (** TODO *)
+  (**
+  ``check_assigned node`` throws an exception if ``node`` has not been
+  assigned to a block.
+   *)
 
   val is_valid : attr Owl_graph.node -> bool
   (** TODO *)

--- a/src/base/compute/owl_computation_symbol_sig.ml
+++ b/src/base/compute/owl_computation_symbol_sig.ml
@@ -125,7 +125,7 @@ module type Sig = sig
   val set_reuse : attr Owl_graph.node -> bool -> unit
   (** TODO *)
 
-  val is_reusable : attr Owl_graph.node -> bool
+  val get_reuse : attr Owl_graph.node -> bool
   (** TODO *)
 
   val is_shared : attr Owl_graph.node -> bool

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -25,6 +25,17 @@ module Make
 
   type t = attr Owl_graph.node
 
+  and block = {
+    (* The [size] field assumes that all the elements have the same size. If
+     * different types of elements are mixed in the same CG, should replace it
+     * with a size in bytes. *)
+    size           : int;       (* the number of elements stored in the block *)
+    block_id       : int;       (* id of the block *)
+    mutable active : t option;  (* the node whose memory is being stored (if any) *)
+    mutable memory : value;     (* the placeholder for the value *)
+    mutable nodes  : t list;    (* the nodes sharing the memory block *)
+  }
+
   and attr = {
     mutable op     : op;                        (* operation stored in this node *)
     mutable freeze : bool;                      (* whether or not a node can link to other nodes *)
@@ -32,7 +43,7 @@ module Make
     mutable state  : state;                     (* state to show whether re-evaluation is needed *)
     mutable shape  : (int array option) array;  (* shape of the output values stored in the node *)
     mutable value  : value array;               (* output values of the node *)
-    mutable vnode  : t array;                   (* where current node inherits its value memory. *)
+    mutable block  : (block array) option;      (* the memory blocks to store the node values *)
   }
 
   and arr = Arr of t

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -22,6 +22,18 @@ module type Sig = sig
   type t = attr Owl_graph.node
   (** TODO *)
 
+  and block = {
+    size           : int;      (* the number of elements of the block *)
+    block_id       : int;      (* id of the block *)
+    mutable active : t option; (* the node whose memory is being stored (if any) *)
+    mutable memory : value;    (* the value of the active node *)
+    mutable nodes  : t list;   (* the nodes sharing the memory block *)
+  }
+  (**
+  ``block`` type keeps a reference to a block of memory and to the nodes
+  sharing that block.
+   *)
+
   and attr = {
     mutable op     : op;                        (* operation stored in this node *)
     mutable freeze : bool;                      (* whether or not a node can link to other nodes *)
@@ -29,7 +41,7 @@ module type Sig = sig
     mutable state  : state;                     (* state to show whether re-evaluation is needed *)
     mutable shape  : (int array option) array;  (* shape of the output values stored in the node *)
     mutable value  : value array;               (* output values of the node *)
-    mutable vnode  : t array;                   (* where current node inherits its value memory. *)
+    mutable block  : (block array) option;      (* the memory blocks to store the node values *)
   }
   (** TODO *)
 

--- a/src/base/misc/owl_utils_multimap.ml
+++ b/src/base/misc/owl_utils_multimap.ml
@@ -78,9 +78,11 @@ module Make (Ord : Map.OrderedType) = struct
 
   let find_first_opt f map =
     match Map.find_first_opt f map with
-    | Some (k, s) -> (match Stack.peek s with
-                      | Some v -> Some (k, v)
-                      | None   -> _fail "find_first_opt")
+    | Some (k, s) -> (
+        match Stack.peek s with
+        | Some v -> Some (k, v)
+        | None   -> _fail "find_first_opt"
+      )
     | None        -> None
 
 

--- a/src/base/misc/owl_utils_multimap.ml
+++ b/src/base/misc/owl_utils_multimap.ml
@@ -1,0 +1,87 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2018 Liang Wang <liang.wang@cl.cam.ac.uk>
+ *)
+
+(* An implementation of an ordered multimap for Owl's internal use.
+ * Simulates an ordered multimap using Map and Owl_utils.Stack values.
+ * Functions behave in the same way as those in Map, with the difference that
+ * one key can be bound to multiple values.
+ * Access and removals are O(log n). *)
+module Make (Ord : Map.OrderedType) = struct
+
+  module Stack = Owl_utils.Stack
+
+  module Map = Map.Make(Ord)
+
+  type key = Ord.t
+
+  type 'a t = ('a Stack.t) Map.t
+
+
+  let _fail f_name = failwith ("owl_utils_multimap: " ^ f_name ^
+                                 ": no stack should be empty")
+
+
+  let empty = Map.empty
+
+
+  let is_empty = Map.is_empty
+
+
+  let mem = Map.mem
+
+
+  let add k v map =
+    if Map.mem k map then (
+      let stack_k = Map.find k map in
+      Stack.push stack_k v;
+      map
+    )
+    else (
+      let stack_k = Stack.make () in
+      Stack.push stack_k v;
+      Map.add k stack_k map
+    )
+
+
+  let remove k map =
+    let stack_k = match Map.find_opt k map with
+      | Some s -> s
+      | None   -> raise Not_found in
+    let () = match Stack.pop stack_k with
+      | Some _ -> ()
+      | None   -> _fail "remove" in
+    if Stack.is_empty stack_k then Map.remove k map
+    else map
+
+
+  let find k map =
+    let stack_k = match Map.find_opt k map with
+      | Some s -> s
+      | None   -> raise Not_found in
+    match Stack.peek stack_k with
+      | Some v -> v
+      | None   -> _fail "find"
+
+
+  let max_binding map =
+    let k, stack = match Map.max_binding_opt map with
+      | Some (k, s) -> k, s
+      | None        -> raise Not_found in
+    let v = match Stack.peek stack with
+      | Some v -> v
+      | None   -> _fail "max_binding"
+    in
+    k, v
+
+
+  let find_first_opt f map =
+    match Map.find_first_opt f map with
+    | Some (k, s) -> (match Stack.peek s with
+                      | Some v -> Some (k, v)
+                      | None   -> _fail "find_first_opt")
+    | None        -> None
+
+
+end

--- a/src/base/misc/owl_utils_multimap.mli
+++ b/src/base/misc/owl_utils_multimap.mli
@@ -1,0 +1,65 @@
+(*
+ * OWL - OCaml Scientific and Engineering Computing
+ * Copyright (c) 2016-2018 Liang Wang <liang.wang@cl.cam.ac.uk>
+ *)
+
+
+module Make (Ord : Map.OrderedType) : sig
+
+  (** {6 Type definition} *)
+
+  type key = Ord.t
+  (** Type of the multimap keys. *)
+
+  type 'a t
+  (** Type of a multimap. *)
+
+
+  (** {6 Basic functions} *)
+
+  val empty : 'a t
+  (** The empty multimap. *)
+
+  val is_empty : 'a t -> bool
+  (** Check whether the multimap is empty. *)
+
+  val mem : key -> 'a t -> bool
+  (**
+  ``mem k m`` returns true is the multimap ``m`` contains at least one binding
+  for ``k``, false otherwise.
+   *)
+
+  val add : key -> 'a -> 'a t -> 'a t
+  (**
+  ``add k v m`` returns a multimap containing the same bindings as ``m``, plus a
+  binding from ``k`` to ``v``. Previous bindings for ``k`` are hidden by the new
+  binding (they can be restored by calling ``remove k m``).
+   *)
+
+  val remove : key -> 'a t -> 'a t
+  (**
+  ``remove k v m`` returns a multimap with the same bindings as ``m``, except
+  for the binding of ``k``: the last value that was bound to it is removed. If
+  there is no binding for ``k`` in ``m``, raises `Not_found`.
+   *)
+
+  val find : key -> 'a t -> 'a
+  (**
+  ``find k m`` returns the last added binding of ``k`` in ``m``, or raises
+  ``Not_found`` if there is no such binding.
+   *)
+
+  val max_binding : 'a t -> key * 'a
+  (**
+  ``max_binding m`` returns the greatest binding in ``m``. Raises ``Not_found``
+  if ``m`` is empty.
+   *)
+
+  val find_first_opt : (key -> bool) -> 'a t -> (key * 'a) option
+  (**
+  ``find_first_opt f m`` returns the first binding ``(k, v)`` such that ``f k``,
+  or ``None`` if no such binding exists. The function ``f`` has to be
+  nondecreasing. Time complexity is O(log n).
+   *)
+
+end

--- a/src/base/misc/owl_utils_stack.ml
+++ b/src/base/misc/owl_utils_stack.ml
@@ -31,13 +31,13 @@ let push s x =
 
 let pop s = match s.used with
   | 0 -> None
-  | i -> s.used <- i - 1; Some s.data.(i)
+  | i -> s.used <- i - 1; Some s.data.(s.used)
 
 let peek s = match s.used with
   | 0 -> None
-  | i -> Some s.data.(i)
+  | i -> Some s.data.(i - 1)
 
-let is_empty s = s.size = 0
+let is_empty s = s.used = 0
 
 let mem s x = Array.mem x s.data
 

--- a/src/base/neural/owl_neural_compiler.ml
+++ b/src/base/neural/owl_neural_compiler.ml
@@ -433,11 +433,12 @@ module Make
       (* put the results back together *)
       let slice i = Array.init nb_iterations (fun j -> result.(j).(i)) in
       let result = Array.init (Array.length result.(0))
-                     (fun i -> A.concatenate (slice i)) in
+                     (fun i -> A.concatenate ~axis:0 (slice i)) in
       Engine.eval_arr result;
       Array.map Algodiff.pack_arr result
     in
     results
+
 
   (* ``model network`` transforms the network into a computation graph and
   optimises it. Returns a function that takes the input of the network as an

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -668,7 +668,7 @@ module Make
   (* training functions *)
 
   (* generic minimisation functions
-     forward: fucntion to run the forward pass
+     forward: function to run the forward pass
      backward: function to run the backward pass
      update: function to update the weights according to the gradient
      save: function to save the model for checkpoint

--- a/src/base/types/owl_types_computation_device.ml
+++ b/src/base/types/owl_types_computation_device.ml
@@ -14,7 +14,7 @@ module type Sig = sig
   type device
   (** TODO *)
 
-  type value
+  type value = ArrVal of A.arr | EltVal of A.elt
   (** TODO *)
 
 

--- a/src/base/types/owl_types_computation_device.ml
+++ b/src/base/types/owl_types_computation_device.ml
@@ -14,7 +14,7 @@ module type Sig = sig
   type device
   (** TODO *)
 
-  type value = ArrVal of A.arr | EltVal of A.elt
+  type value
   (** TODO *)
 
 
@@ -36,6 +36,12 @@ module type Sig = sig
   (** TODO *)
 
   val value_to_float : value -> float
+  (** TODO *)
+
+  val is_arr : value -> bool
+  (** TODO *)
+
+  val is_elt : value -> bool
   (** TODO *)
 
 

--- a/src/base/types/owl_types_ndarray_mutable.ml
+++ b/src/base/types/owl_types_ndarray_mutable.ml
@@ -31,6 +31,8 @@ module type Sig = sig
 
   val set_slice_ : out:arr -> int list list -> arr -> arr -> unit
 
+  val sub_left : arr -> int -> int -> arr
+
   val reshape_ : out:arr -> arr -> unit
 
   val reverse_ : out:arr -> arr -> unit

--- a/test/test_runner.ml
+++ b/test/test_runner.ml
@@ -6,6 +6,7 @@ let () =
     "stats",                Unit_stats.test_set;
     "maths",                Unit_maths.test_set;
     "graph",                Unit_graph.test_set;
+    "multimap",             Unit_multimap.test_set;
     "algodiff diff",        Unit_algodiff_diff.test_set;
     "algodiff grad",        Unit_algodiff_grad.test_set;
     "dense matrix",         Unit_dense_matrix.test_set;

--- a/test/unit_multimap.ml
+++ b/test/unit_multimap.ml
@@ -1,0 +1,48 @@
+(** Unit test for Owl_utils_multimap module *)
+
+module Multimap = Owl_utils_multimap.Make(struct
+                      type t = int
+                      let compare : int -> int -> int = compare
+                    end)
+
+
+(* a module with functions to test *)
+module To_test = struct
+
+  let multimap0 () =
+    let map = Multimap.empty in
+    let map = Multimap.add 0 0 map in
+    let map = Multimap.add 0 1 map in
+    let map = Multimap.add 2 (-1) map in
+    let map = Multimap.remove 0 map in
+    let zero = Multimap.find 0 map in
+    let (_, mone) = Multimap.max_binding map in
+    let map = Multimap.remove 2 map in
+    let map = Multimap.remove 0 map in
+    zero = 0 && mone = -1 && Multimap.is_empty map
+
+  let multimap1 () =
+    let map = Multimap.empty in
+    let map = Multimap.add 0 0 map in
+    let map = Multimap.add 1 1 map in
+    let map = Multimap.add 3 3 map in
+    let map = Multimap.add 4 4 map in
+    let gt n k = k > n in
+    let gt4 = Multimap.find_first_opt (gt 4) map in
+    let gt2 = Multimap.find_first_opt (gt 2) map in
+    gt4 = None && gt2 = Some (3, 3)
+
+end
+
+let multimap0 () =
+  Alcotest.(check bool) "multimap0" true (To_test.multimap0 ())
+
+let multimap1 () =
+  Alcotest.(check bool) "multimap1" true (To_test.multimap1 ())
+
+(* the tests *)
+
+let test_set = [
+  "multimap0", `Slow, multimap0;
+  "multimap1", `Slow, multimap1;
+]

--- a/test/unit_multimap.ml
+++ b/test/unit_multimap.ml
@@ -1,9 +1,9 @@
 (** Unit test for Owl_utils_multimap module *)
 
 module Multimap = Owl_utils_multimap.Make(struct
-                      type t = int
-                      let compare : int -> int -> int = compare
-                    end)
+                    type t = int
+                    let compare : int -> int -> int = compare
+                  end)
 
 
 (* a module with functions to test *)


### PR DESCRIPTION
This PR consists of:
- A Multimap implementation in `Owl_utils` (extension of OCaml's `Map` which allows the same key to be bound to multiple values) and one small test file for this structure (+ a small fix of `owl_utils_stack.ml`).
- A change of the `vnode` parameter of CG's nodes to a more general type `block`. A `block` holds the reference to an ndarray of fixed size. Multiple nodes can share the same block.
- A new algorithm to initialise the memory of the computation graph (inspired by [the one used by MxNet](https://mxnet.incubator.apache.org/architecture/note_memory.html#memory-allocation-algorithm)). The main idea is that during a graph traversal in evaluation order, we can spot a node which doesn't need its value anymore by keeping a counter of how many children still have to use that node. The block of memory used by that node can thus be tagged as reusable. When allocating the memory to a node, we then know which blocks can be reused. To select a block to allocate to a node, the following heuristic is used: the smallest available block that is larger than the size of the node is chosen. If such a block does not exist, the largest block is chosen and its size is increased. A multimap is needed to do this efficiently.
We can note that the allocation strategy depends on the order of the traversal, and the evaluation **must** be done in the same order as the initialisation. This implementation uses a DFS order (shorter to implement and BFS was not necessarily better).
The time complexity is `O(n * log(b))`, where `n` is the number of nodes of the computation graph and `b` is the number of blocks allocated at the end of the algorithm (in theory, `b <= n` but in practice, `b << n`). The space complexity is `O(n + b)`.

You can find **[here](https://drive.google.com/open?id=12KCY9OC6GjuHiH2pRiAjqNi-pz2sNcc1)** some visual examples of the allocation performed by the algorithm (I recommend opening the big `.svg` files with Chrome or Firefox). Each reusable node is coloured depending on the block used (if the colours are too hard to distinguish, the `b` attribute is the id of the block). InceptionV3 needs only 6 shared blocks and the inference for `lazy_mnist` only 3.