### PR TITLE
Switch to dune.configurator

### DIFF
--- a/owl.opam
+++ b/owl.opam
@@ -21,7 +21,6 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}
-  "configurator" {build}
   "ctypes"
   "dune" {build}
   "eigen" {>= "0.0.3"}

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -3,7 +3,7 @@
  * Copyright (c) 2016-2018 Liang Wang <liang.wang@cl.cam.ac.uk>
  *)
 
-module C = Configurator
+module C = Configurator.V1
 
 
 let write_sexp fn sexp =

--- a/src/owl/config/dune
+++ b/src/owl/config/dune
@@ -2,6 +2,6 @@
  (name configure)
  (libraries
   base
-  configurator
+  dune.configurator
   stdio
   ))

--- a/src/owl/dune
+++ b/src/owl/dune
@@ -185,6 +185,6 @@
    (setenv ENABLE_EXPMODE 0 ;; turn on experiment features like flto
            (setenv ENABLE_DEVMODE 0 ;; turn on all the warnings in development
                    (setenv ENABLE_OPENMP  0 ;; turn on OpenMP support in core module
-                           (run %{deps} -ocamlc %{ocamlc})
+                           (run %{deps})
                            ))))
 )


### PR DESCRIPTION
The `configurator` package has been replaced by the `dune.configurator` library. This PR changes owl to use the latter.
