### PR TITLE
Copy node optimisation and small fixes

### DIFF
--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -551,10 +551,8 @@ module Make
   and pattern_018 x =
     let a = (parents x).(0) in
     _optimise_term a;
-    if refnum a = 1 then (
-      set_operator x Noop;
-      pattern_003 x
-    )
+    set_operator x Noop;
+    pattern_003 x
 
 
   (* Mul pattern *)

--- a/src/base/core/owl_graph.ml
+++ b/src/base/core/owl_graph.ml
@@ -148,6 +148,9 @@ let dfs_iter traversal f x next =
    [next node -> node array] returns the next set of nodes to iterate.
 *)
 let bfs_iter traversal f x next =
+  match traversal with
+  | PostOrder -> Owl_log.warn "PostOrder BFS not implemented. PreOrder is used."
+  | PreOrder  -> ();
   let h = Hashtbl.create 512 in
   let q = Queue.create () in
   let relax y =
@@ -157,10 +160,7 @@ let bfs_iter traversal f x next =
                   Queue.push z q))
       (next y)
   in
-  let update = match traversal with
-    | PreOrder -> (fun y -> f y; relax y)
-    | PostOrder -> (fun y -> relax y; f y)
-  in
+  let update y = f y; relax y in
 
   Array.iter (fun y -> Queue.push y q) x;
   Array.iter (fun y -> Hashtbl.add h y.id None) x;

--- a/src/base/neural/owl_neural_compiler.ml
+++ b/src/base/neural/owl_neural_compiler.ml
@@ -360,10 +360,6 @@ module Make
 
   (* Multi-input/output version of ``model``. *)
   let model_inputs ?(optimise=true) ?(batch_size=1) network =
-    (* TOFIX: the next line creates useless Copy nodes for constant values,
-     * because Copy is an operation in CG *)
-    (* compile network into static graph *)
-    let network = Graph.copy network in
     let network_name = Graph.get_network_name network in
     Owl_log.info "compile network %s into static graph ..." network_name;
 
@@ -373,7 +369,7 @@ module Make
                        ~shape:(Array.append [|batch_size|] sh)
                      |> pack_arr) input_shapes
     in
-    let outputs, _ = Graph.forward_inputs network inputs in
+    let outputs = Graph.run_inputs inputs network in
 
     let _to_nodes = Array.map (fun v -> unpack_arr v |> Engine.arr_to_node) in
     let i, o = _to_nodes inputs, _to_nodes outputs in

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -111,6 +111,9 @@ module type Sig = sig
   val run : t -> network -> t
   (** Execute the computations in all the neurons in a network with the given input. *)
 
+  val run_inputs : t array -> network -> t array
+  (** Execute the computations in all the neurons in a network with the given inputs. *)
+
   val forward : network -> t -> t * t array array
   (** Run the forward pass of a network. *)
 


### PR DESCRIPTION
- Modified the optimisation for the `Copy` nodes in CG module: by design, these nodes are always useless (not only when their parent has only one child) since memory allocation is handled by the engine and no operation actually mutates an output value.
- Removed a useless network copy in `model_inputs` (inference with CG).
- The function `graph_to_dot` had quadratic time complexity, it is now linear (`lazy_lstm.ml` dot graph used to take more than 10 seconds to be generated, it now takes less than one second).
- The 'PostOrder BFS' from a previous PR is actually not working because PostOrder evaluation requires a recursive implementation which is not suited for a BFS.