### PR TITLE
Print node in CG module

### DIFF
--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -69,6 +69,7 @@ module Make
           | OneHot depth                                  -> _eval_map_01 x (fun ~out x -> A.one_hot_ ~out depth x.(0))
           | Delay f                                       -> _eval_map_08 x f
           | DelayArray (_shape, f)                        -> _eval_map_00 x f
+          | LazyPrint (max_col, max_row, header, fmt)     -> _eval_map_00 x (fun x -> A.print ?max_col ?max_row ?header ?fmt x.(0); x.(0))
           | Abs                                           -> _eval_map_01 x (fun ~out x -> A.abs_ ~out x.(0))
           | Neg                                           -> _eval_map_01 x (fun ~out x -> A.neg_ ~out x.(0))
           | Floor                                         -> _eval_map_01 x (fun ~out x -> A.floor_ ~out x.(0))

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -158,6 +158,9 @@ module Make
     make_then_connect ~shape:[|Some shape|] (DelayArray (shape, f))
       (Array.map arr_to_node x) |> node_to_arr
 
+  let lazy_print ?max_row ?max_col ?header ?fmt x =
+    make_then_connect (LazyPrint (max_row, max_col, header, fmt)) [|arr_to_node x|] |> node_to_arr
+
   let print ?max_row ?max_col ?header ?fmt x = ()  [@@warning "-27"]
 
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -115,14 +115,21 @@ module type Sig = sig
 ``delay f x`` returns ``f x``. It allows to use a function that is not tracked
 by the computation graph and delay its evaluation. The output must have the
 same shape as the input.
-  *)
+   *)
 
   val delay_array : int array -> (Device.A.arr array -> Device.A.arr) ->
                     arr array -> arr
   (**
 ``delay_array out_shape f x`` works in the same way as ``delay`` but is applied
 on an array of ndarrays. Needs the shape of the output as an argument.
-  *)
+   *)
+
+  val lazy_print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(Device.A.elt -> string) -> arr -> arr
+  (**
+``lazy_print x`` prints the output of ``x`` when it is evaluated. Is implemented
+as an identity node. For information about the optional parameters, refer to the
+``print`` function of the ``Ndarray`` module.
+   *)
 
   val print : ?max_row:'a -> ?max_col:'b -> ?header:'c -> ?fmt:'d -> 'e -> unit
   (** TODO *)

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -59,6 +59,7 @@ module Make
         | OneHot _depth                                  -> pattern_000 x
         | Delay _f                                       -> pattern_000 x
         | DelayArray (_shape, _f)                        -> pattern_000 x
+        | LazyPrint (_max_row, _max_col, _header, _fmt)  -> pattern_000 x
         | Abs                                            -> pattern_000 x
         | Neg                                            -> pattern_000 x
         | Floor                                          -> pattern_000 x

--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -267,6 +267,7 @@ module Make
     | Abs                                            -> _infer_shape_01 input_shapes
     | Delay _f                                       -> _infer_shape_01 input_shapes
     | DelayArray (shape, _f)                         -> [| Some shape |]
+    | LazyPrint (_max_row, _max_col, _header, _fmt)  -> _infer_shape_01 input_shapes
     | Neg                                            -> _infer_shape_01 input_shapes
     | Floor                                          -> _infer_shape_01 input_shapes
     | Ceil                                           -> _infer_shape_01 input_shapes

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -53,6 +53,7 @@ module Make
     | OneHot depth                                   -> Printf.sprintf "OneHot d:%i" depth
     | Delay _f                                       -> "Delay"
     | DelayArray (_shape, _f)                        -> "DelayArray"
+    | LazyPrint (_max_row, _max_col, _header, _fmt)  -> "LazyPrint"
     | Abs                                            -> "Abs"
     | Neg                                            -> "Neg"
     | Floor                                          -> "Floor"

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -83,6 +83,7 @@ module Make
     | OneHot                        of int
     | Delay                         of (A.arr -> A.arr)
     | DelayArray                    of int array * (A.arr array -> A.arr)
+    | LazyPrint                     of int option * int option * bool option * (A.elt -> string) option
     | Abs
     | Neg
     | Floor
@@ -241,6 +242,7 @@ module Make
     | Scalar_Relu
     | Scalar_Sigmoid
     | Fused_Adagrad                 of float * float
+
 
 
 end

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -83,6 +83,7 @@ module type Sig = sig
     | OneHot                        of int
     | Delay                         of (A.arr -> A.arr)
     | DelayArray                    of int array * (A.arr array -> A.arr)
+    | LazyPrint                     of int option * int option * bool option * (A.elt -> string) option
     | Abs
     | Neg
     | Floor

--- a/src/base/core/owl_lazy.mli
+++ b/src/base/core/owl_lazy.mli
@@ -203,6 +203,9 @@ module Make (A : Ndarray_Mutable) : sig
   val one_hot : int -> arr -> arr
   (** TODO *)
 
+  val lazy_print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(A.elt -> string) -> arr -> arr
+  (** TODO *)
+
   val print : ?max_row:'a -> ?max_col:'b -> ?header:'c -> ?fmt:'d -> 'e -> unit
   (** TODO *)
 


### PR DESCRIPTION
Printing the outputs of intermediate nodes in a computation graph is not possible because there is currently no way to make the print lazy, which makes debugging quite hard. I've added a `LazyPrint` node which is an identity node having the side effect of printing the output of its parent when evaluated (same trick as [TensorFlow Print()](https://www.tensorflow.org/versions/r1.11/api_docs/python/tf/Print)).

The way to use it is to insert it after the node whose output you want to print, for instance
```
module Engine = Owl_computation_cpu_engine.Make(Dense.Ndarray.S)

let x =
  Engine.gaussian [|100; 100|]
  |> Engine.sqr
  |> Engine.lazy_print ~max_row:5 ~max_col:5
  |> Engine.floor
in
Engine.eval_arr [|x|]
```

You can also use it in a neural network using CG quite easily, by putting it in a Lambda layer:
```
  |> lambda (fun x -> unpack_arr x
                      |> Engine.lazy_print ~max_row:5 ~max_col:5
                      |> pack_arr)
```
where unpacking the CG node and standard printing would not work because the node is not evaluated when the graph is built.

Note that it needs to be a different function from `print` because it has to return an `arr` to work, but `print` has to return `unit`.
