### PR TITLE
simpler way to deal with multi-output functions in reverse-mode + expose gradient test to user

### DIFF
--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -18,11 +18,11 @@ module type Sig = sig
   (** Trace type *)
 
   type t =
-    | F    of A.elt                                  (* constructor of float numbers *)
-    | Arr  of A.arr                                  (* constructor of ndarrays *)
-    | Pair of t * t                                  (* functions with multiple outputs *)
-    | DF   of t * t * int                            (* primal, tangent, tag *)
-    | DR   of t * t ref * trace_op * int ref * int   (* primal, adjoint, op, fanout, tag *)
+    | F    of A.elt                                           (* constructor of float numbers *)
+    | Arr  of A.arr                                           (* constructor of ndarrays *)
+    | Pair of t * t                                           (* functions with multiple outputs *)
+    | DF   of t * t * int                                     (* primal, tangent, tag *)
+    | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
 
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -21,6 +21,7 @@ module type Sig = sig
     | F    of A.elt                                           (* constructor of float numbers *)
     | Arr  of A.arr                                           (* constructor of ndarrays *)
     | Pair of t * t                                           (* functions with multiple outputs *)
+    | AR    of t array                                             (* to allow for computations that return an array of outputs *)
     | DF   of t * t * int                                     (* primal, tangent, tag *)
     | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
@@ -81,7 +82,7 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val qr : t -> t
+    val qr : t -> t 
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val lyapunov : t -> t -> t

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -20,8 +20,6 @@ module type Sig = sig
   type t =
     | F    of A.elt                                           (* constructor of float numbers *)
     | Arr  of A.arr                                           (* constructor of ndarrays *)
-    | Pair of t * t                                           (* functions with multiple outputs *)
-    | AR    of t array                                             (* to allow for computations that return an array of outputs *)
     | DF   of t * t * int                                     (* primal, tangent, tag *)
     | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
@@ -82,7 +80,7 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val qr : t -> t 
+    val qr : t -> t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val lyapunov : t -> t -> t

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -75,6 +75,12 @@ module Make
           | _ -> assert false  in
         test_func f
 
+    let split () =
+      let f x = 
+        let a = Maths.split 0 [| 1; 1; 1|] x |> extract_ar in
+        Maths.(a.(0) + a.(1) * a.(2)) in
+      test_func f
+
     let lyapunov () =
       let q = Arr Owl.Mat.(neg (eye n)) in
       let f x = Maths.lyapunov x q in
@@ -111,6 +117,8 @@ module Make
   let inv () = alco_fun "inv" To_test.inv
 
   let qr () = alco_fun "qr" To_test.qr
+      
+  let split () = alco_fun "split" To_test.split
 
 
   let test_set = [
@@ -127,6 +135,7 @@ module Make
     "triu",  `Slow,   triu;
     "inv",   `Slow,   inv;
     "qr",    `Slow,   qr;
+    "split", `Slow,   split;
   ]
 
 end

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -42,15 +42,15 @@ module Make
   let test_func f  =
     let f x = Maths.(sum' (f x)) in
     Array.map (fun x ->
-      let max_err, check =
-        Array.map (fun d ->
-          let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
-            let r_fd = (fd_g ~f x d)  |> unpack_flt in
-            r_ad, r_fd
-          ) ds
-        |> check_grads in
-      check
-    ) xs 
+        let max_err, check =
+          Array.map (fun d ->
+              let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
+              let r_fd = (fd_g ~f x d)  |> unpack_flt in
+              r_ad, r_fd
+            ) ds
+          |> check_grads in
+        check
+      ) xs 
     |> (Array.fold_left (fun (a, c) b -> a && b, (if b then (succ c) else c) ) (true, 0) )
 
 
@@ -69,21 +69,23 @@ module Make
     let triu  () = test_func Maths.triu
     let inv   () = test_func Maths.inv
     let qr  () =
-      let f x =
-        match (Maths.qr x) with
-          | Pair (q, r) -> Maths.(q + r)
-          | _ -> assert false  in
-        test_func f
+      let f x = 
+        let q, r = Maths.qr x in
+        Maths.(q + r)
+      in test_func f
 
     let split () =
       let f x = 
-        let a = Maths.split 0 [| 1; 1; 1|] x |> extract_ar in
+        let a = Maths.split 0 [| 1; 1; 1|] x in
         Maths.(a.(0) + a.(1) * a.(2)) in
       test_func f
 
     let lyapunov () =
-      let q = Arr Owl.Mat.(neg (eye n)) in
-      let f x = Maths.lyapunov x q in
+      let f x = 
+        let q = Arr Owl.Mat.((gaussian n n)) in
+        let q = Maths.(q + x) in
+        let q = Maths.(neg (transpose q *@ q)) in
+        Maths.lyapunov x q in
       test_func f
 
   end
@@ -117,7 +119,7 @@ module Make
   let inv () = alco_fun "inv" To_test.inv
 
   let qr () = alco_fun "qr" To_test.qr
-      
+
   let split () = alco_fun "split" To_test.split
 
 


### PR DESCRIPTION
1. modified type `DR` in algodiff to track when to update adjval of inputs in reverse-mode e.g. `Algodiff.D.Maths.qr` now has type `t ->  t*t`
2. `FDGrad_test`: a new functor in algodiff that takes a module of user-specified parameters and can be used to test gradients (i.e. compare reverse-mode gradients with finite difference approximations)
