### PR TITLE
Thin SVD and Chol reverse-mode gradient + minor changes in algodiff unit test

### DIFF
--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -461,6 +461,8 @@ module Make
 
   let inv x = make_then_connect Inv [|arr_to_node x|] |> node_to_arr
 
+  let chol ?(upper=true) _x = upper |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
   let qr _x = raise Owl_exception.NOT_IMPLEMENTED 
   
   let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED 

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -84,6 +84,8 @@ module Make
   let init shape f =
     make_node ~shape:[|Some shape|] (Init (shape, f)) |> node_to_arr
 
+  let init_nd _shape _f = raise Owl_exception.NOT_IMPLEMENTED 
+
   let shape x = arr_to_node x |> node_shape
 
   let numel x = Array.fold_left ( * ) 1 (shape x)
@@ -463,11 +465,15 @@ module Make
 
   let chol ?(upper=true) _x = upper |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
+  let svd ?(thin=true) _x = thin |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
   let qr _x = raise Owl_exception.NOT_IMPLEMENTED 
   
   let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED 
   
   let diag ?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED 
+
+  let diagm ?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED 
 
   let tril?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED 
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -494,6 +494,9 @@ as an identity node. For information about the optional parameters, refer to the
   val inv : arr -> arr
   (** TODO *)
 
+  val chol: ?upper:bool -> arr -> arr
+  (** TODO *)
+
   val qr : arr -> arr * arr
   (** TODO *)
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -47,6 +47,9 @@ module type Sig = sig
   val init : int array -> (int -> elt) -> arr
   (** TODO *)
 
+  val init_nd : int array -> (int array -> elt) -> arr
+  (** TODO *)
+
   val shape : arr -> int array
   (** TODO *)
 
@@ -112,24 +115,24 @@ module type Sig = sig
 
   val delay : (Device.A.arr -> Device.A.arr) -> arr -> arr
   (**
-``delay f x`` returns ``f x``. It allows to use a function that is not tracked
-by the computation graph and delay its evaluation. The output must have the
-same shape as the input.
-   *)
+     ``delay f x`` returns ``f x``. It allows to use a function that is not tracked
+     by the computation graph and delay its evaluation. The output must have the
+     same shape as the input.
+  *)
 
   val delay_array : int array -> (Device.A.arr array -> Device.A.arr) ->
-                    arr array -> arr
+    arr array -> arr
   (**
-``delay_array out_shape f x`` works in the same way as ``delay`` but is applied
-on an array of ndarrays. Needs the shape of the output as an argument.
-   *)
+     ``delay_array out_shape f x`` works in the same way as ``delay`` but is applied
+     on an array of ndarrays. Needs the shape of the output as an argument.
+  *)
 
   val lazy_print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(Device.A.elt -> string) -> arr -> arr
   (**
-``lazy_print x`` prints the output of ``x`` when it is evaluated. Is implemented
-as an identity node. For information about the optional parameters, refer to the
-``print`` function of the ``Ndarray`` module.
-   *)
+     ``lazy_print x`` prints the output of ``x`` when it is evaluated. Is implemented
+     as an identity node. For information about the optional parameters, refer to the
+     ``print`` function of the ``Ndarray`` module.
+  *)
 
   val print : ?max_row:'a -> ?max_col:'b -> ?header:'c -> ?fmt:'d -> 'e -> unit
   (** TODO *)
@@ -500,10 +503,16 @@ as an identity node. For information about the optional parameters, refer to the
   val qr : arr -> arr * arr
   (** TODO *)
 
+  val svd : ?thin:bool -> arr -> arr * arr * arr
+  (** TODO *)
+
   val lyapunov : arr -> arr -> arr
   (** TODO *)
-  
+
   val diag: ?k:int -> arr -> arr
+  (** TODO *)
+
+  val diagm: ?k:int -> arr -> arr
   (** TODO *)
 
   val triu: ?k:int -> arr -> arr
@@ -538,100 +547,100 @@ as an identity node. For information about the optional parameters, refer to the
 
   module Scalar : sig
     val add : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sub : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val mul : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val div : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val pow : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val atan2 : elt -> elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val abs : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val neg : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sqr : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sqrt : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val exp : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val log : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val log2 : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val log10 : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val signum : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val floor : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val ceil : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val round : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sin : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val cos : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val tan : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sinh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val cosh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val tanh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val asin : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val acos : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val atan : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val asinh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val acosh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val atanh : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val relu : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
     val sigmoid : elt -> elt
-  (** TODO *)
+    (** TODO *)
 
   end
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -410,6 +410,8 @@ val dot : arr -> arr -> arr
 
 val inv : arr -> arr
 
+val svd : ?thin:bool -> arr -> arr * arr * arr
+
 val qr : arr -> arr * arr
                 
 val chol : ?upper:bool -> arr -> arr 
@@ -417,6 +419,8 @@ val chol : ?upper:bool -> arr -> arr
 val lyapunov : arr -> arr -> arr
 
 val diag: ?k:int -> arr -> arr 
+
+val diagm: ?k:int -> arr -> arr 
 
 val triu: ?k:int -> arr -> arr 
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -411,6 +411,8 @@ val dot : arr -> arr -> arr
 val inv : arr -> arr
 
 val qr : arr -> arr * arr
+                
+val chol : ?upper:bool -> arr -> arr 
 
 val lyapunov : arr -> arr -> arr
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -4196,6 +4196,8 @@ let inv varr =
 
 let qr _x = raise Owl_exception.NOT_IMPLEMENTED
 
+let chol ?(upper=true) _x = upper |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
 let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED
 
 let diag ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -4198,9 +4198,13 @@ let qr _x = raise Owl_exception.NOT_IMPLEMENTED
 
 let chol ?(upper=true) _x = upper |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
+let svd ?(thin=true) _x = thin |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
 let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED
 
 let diag ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
+let diagm ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
 let tril ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -723,10 +723,16 @@ val chol : ?upper:bool -> (float, 'b) t -> (float, 'b) t
 val qr : (float, 'b) t -> (float, 'b) t * (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+val svd : ?thin:bool -> (float, 'b) t -> (float, 'b) t * (float, 'b) t * (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 val lyapunov : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
 val diag: ?k:int -> (float, 'b) t -> (float, 'b) t 
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
+val diagm: ?k:int -> (float, 'b) t -> (float, 'b) t 
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
 val tril: ?k:int -> (float, 'b) t -> (float, 'b) t 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -716,6 +716,10 @@ val dot : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 val inv : (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+(* TODO: change float to 'a *)
+val chol : ?upper:bool -> (float, 'b) t -> (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 val qr : (float, 'b) t -> (float, 'b) t * (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -410,6 +410,8 @@ val dot : arr -> arr -> arr
 
 val inv : arr -> arr
 
+val chol : ?upper:bool -> arr -> arr 
+
 val qr : arr -> arr * arr
 
 val lyapunov : arr -> arr -> arr

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -410,6 +410,8 @@ val dot : arr -> arr -> arr
 
 val inv : arr -> arr
 
+val svd: ?thin:bool -> arr -> arr * arr * arr
+
 val chol : ?upper:bool -> arr -> arr 
 
 val qr : arr -> arr * arr
@@ -417,6 +419,8 @@ val qr : arr -> arr * arr
 val lyapunov : arr -> arr -> arr
 
 val diag : ?k:int -> arr -> arr
+
+val diagm : ?k:int -> arr -> arr
 
 val tril : ?k:int -> arr -> arr
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -85,6 +85,9 @@ module type Sig = sig
 
     val qr : t -> t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
+                  
+    val svd : ?thin:bool -> t -> t * t * t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val lyapunov : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
@@ -270,6 +273,9 @@ module type Sig = sig
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val diag : ?k:int -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val diagm : ?k:int -> t -> t 
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val trace : t -> t

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -18,11 +18,11 @@ module type Sig = sig
   (** Trace type *)
 
   type t =
-    | F    of A.elt                                  (* constructor of float numbers *)
-    | Arr  of A.arr                                  (* constructor of ndarrays *)
-    | Pair of t * t                                  (* functions with multiple outputs *)
-    | DF   of t * t * int                            (* primal, tangent, tag *)
-    | DR   of t * t ref * trace_op * int ref * int   (* primal, adjoint, op, fanout, tag *)
+    | F    of A.elt                                           (* constructor of float numbers *)
+    | Arr  of A.arr                                           (* constructor of ndarrays *)
+    | Pair of t * t                                           (* functions with multiple outputs *)
+    | DF   of t * t * int                                     (* primal, tangent, tag *)
+    | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
 
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -21,6 +21,7 @@ module type Sig = sig
     | F    of A.elt                                           (* constructor of float numbers *)
     | Arr  of A.arr                                           (* constructor of ndarrays *)
     | Pair of t * t                                           (* functions with multiple outputs *)
+    | AR    of t array                                             (* to allow for computations that return an array of outputs *)
     | DF   of t * t * int                                     (* primal, tangent, tag *)
     | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
@@ -81,7 +82,7 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val qr : t -> t
+    val qr : t -> t 
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val lyapunov : t -> t -> t

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -80,6 +80,9 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val chol : ?upper:bool -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
     val qr : t -> t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -18,11 +18,11 @@ module type Sig = sig
   (** Trace type *)
 
   type t =
-    | F   of A.elt                                  (* constructor of float numbers *)
-    | Arr of A.arr                                  (* constructor of ndarrays *)
-    | Pair of t * t
-    | DF  of t * t * int                            (* primal, tangent, tag *)
-    | DR  of t * t ref * trace_op * int ref * int   (* primal, adjoint, op, fanout, tag *)
+    | F    of A.elt                                  (* constructor of float numbers *)
+    | Arr  of A.arr                                  (* constructor of ndarrays *)
+    | Pair of t * t                                  (* functions with multiple outputs *)
+    | DF   of t * t * int                            (* primal, tangent, tag *)
+    | DR   of t * t ref * trace_op * int ref * int   (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
 
 
@@ -81,9 +81,9 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val qr : t -> t 
+    val qr : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
-    
+
     val lyapunov : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -20,8 +20,6 @@ module type Sig = sig
   type t =
     | F    of A.elt                                           (* constructor of float numbers *)
     | Arr  of A.arr                                           (* constructor of ndarrays *)
-    | Pair of t * t                                           (* functions with multiple outputs *)
-    | AR    of t array                                             (* to allow for computations that return an array of outputs *)
     | DF   of t * t * int                                     (* primal, tangent, tag *)
     | DR   of t * t ref * trace_op * int ref * int * int ref  (* primal, adjoint, op, fanout, tag *)
   (** Abstract number type *)
@@ -82,7 +80,7 @@ module type Sig = sig
     val inv : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val qr : t -> t 
+    val qr : t -> t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val lyapunov : t -> t -> t

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -38,6 +38,8 @@ module type Sig = sig
 
   val init : int array -> (int -> elt) -> arr
 
+  val init_nd : int array -> (int array -> elt) -> arr
+
   val shape : arr -> int array
 
   val numel : arr -> int
@@ -305,11 +307,15 @@ module type Sig = sig
 
   val chol : ?upper:bool -> arr -> arr
 
+  val svd : ?thin:bool -> arr -> arr * arr * arr
+
   val qr : arr -> arr * arr
 
   val lyapunov: arr -> arr -> arr
 
   val diag : ?k:int -> arr -> arr
+
+  val diagm : ?k:int -> arr -> arr
 
   val triu: ?k:int -> arr -> arr
 

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -303,6 +303,8 @@ module type Sig = sig
 
   val inv : arr -> arr
 
+  val chol : ?upper:bool -> arr -> arr
+
   val qr : arr -> arr * arr
 
   val lyapunov: arr -> arr -> arr

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -20,7 +20,7 @@ module Generic = struct
   (* inject function aliases *)
 
   let inv = Owl_linalg_generic.inv
-
+              
   let mpow = Owl_linalg_generic.mpow
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
@@ -45,9 +45,13 @@ module S = struct
 
   let inv = Owl_linalg_s.inv
 
+  let svd ?(thin=true) = Owl_linalg_s.svd ~thin
+
   let chol = Owl_linalg_s.chol 
 
   let mpow = Owl_linalg_s.mpow
+
+  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 
@@ -70,10 +74,14 @@ module D = struct
   (* inject function aliases *)
 
   let inv = Owl_linalg_d.inv
+
+  let svd ?(thin=true) = Owl_linalg_d.svd ~thin
               
   let chol = Owl_linalg_d.chol 
 
   let mpow = Owl_linalg_d.mpow
+
+  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -45,6 +45,8 @@ module S = struct
 
   let inv = Owl_linalg_s.inv
 
+  let chol = Owl_linalg_s.chol 
+
   let mpow = Owl_linalg_s.mpow
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
@@ -68,6 +70,8 @@ module D = struct
   (* inject function aliases *)
 
   let inv = Owl_linalg_d.inv
+              
+  let chol = Owl_linalg_d.chol 
 
   let mpow = Owl_linalg_d.mpow
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -32,6 +32,11 @@ module Make
     let tril  () = test_func Maths.tril
     let triu  () = test_func Maths.triu
     let inv   () = test_func Maths.inv
+    let chol  () = 
+      let f x = 
+        let s = Maths.(transpose x *@ x) in
+        Maths.( (chol ~upper:true s) + (chol ~upper:false s))
+      in test_func f 
     let qr  () =
       let f x = 
         let q, r = Maths.qr x in
@@ -81,6 +86,8 @@ module Make
   let triu () = alco_fun "triu" To_test.triu
 
   let inv () = alco_fun "inv" To_test.inv
+      
+  let chol () = alco_fun "chol" To_test.chol
 
   let qr () = alco_fun "qr" To_test.qr
 
@@ -100,6 +107,7 @@ module Make
     "tril",  `Slow,   tril;
     "triu",  `Slow,   triu;
     "inv",   `Slow,   inv;
+    "chol",  `Slow,   chol;
     "qr",    `Slow,   qr;
     "split", `Slow,   split;
   ]

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -75,6 +75,12 @@ module Make
           | _ -> assert false  in
         test_func f
 
+    let split () =
+      let f x = 
+        let a = Maths.split 0 [| 1; 1; 1|] x |> extract_ar in
+        Maths.(a.(0) + a.(1) * a.(2)) in
+      test_func f
+
     let lyapunov () =
       let q = Arr Owl.Mat.(neg (eye n)) in
       let f x = Maths.lyapunov x q in
@@ -111,6 +117,8 @@ module Make
   let inv () = alco_fun "inv" To_test.inv
 
   let qr () = alco_fun "qr" To_test.qr
+      
+  let split () = alco_fun "split" To_test.split
 
 
   let test_set = [
@@ -127,6 +135,7 @@ module Make
     "triu",  `Slow,   triu;
     "inv",   `Slow,   inv;
     "qr",    `Slow,   qr;
+    "split", `Slow,   split;
   ]
 
 end

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -42,15 +42,15 @@ module Make
   let test_func f  =
     let f x = Maths.(sum' (f x)) in
     Array.map (fun x ->
-      let max_err, check =
-        Array.map (fun d ->
-          let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
-            let r_fd = (fd_g ~f x d)  |> unpack_flt in
-            r_ad, r_fd
-          ) ds
-        |> check_grads in
-      check
-    ) xs 
+        let max_err, check =
+          Array.map (fun d ->
+              let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
+              let r_fd = (fd_g ~f x d)  |> unpack_flt in
+              r_ad, r_fd
+            ) ds
+          |> check_grads in
+        check
+      ) xs 
     |> (Array.fold_left (fun (a, c) b -> a && b, (if b then (succ c) else c) ) (true, 0) )
 
 
@@ -69,21 +69,23 @@ module Make
     let triu  () = test_func Maths.triu
     let inv   () = test_func Maths.inv
     let qr  () =
-      let f x =
-        match (Maths.qr x) with
-          | Pair (q, r) -> Maths.(q + r)
-          | _ -> assert false  in
-        test_func f
+      let f x = 
+        let q, r = Maths.qr x in
+        Maths.(q + r)
+      in test_func f
 
     let split () =
       let f x = 
-        let a = Maths.split 0 [| 1; 1; 1|] x |> extract_ar in
+        let a = Maths.split 0 [| 1; 1; 1|] x in
         Maths.(a.(0) + a.(1) * a.(2)) in
       test_func f
 
     let lyapunov () =
-      let q = Arr Owl.Mat.(neg (eye n)) in
-      let f x = Maths.lyapunov x q in
+      let f x = 
+        let q = Arr Owl.Mat.((gaussian n n)) in
+        let q = Maths.(q + x) in
+        let q = Maths.(neg (transpose q *@ q)) in
+        Maths.lyapunov x q in
       test_func f
 
   end
@@ -117,7 +119,7 @@ module Make
   let inv () = alco_fun "inv" To_test.inv
 
   let qr () = alco_fun "qr" To_test.qr
-      
+
   let split () = alco_fun "split" To_test.split
 
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -15,7 +15,7 @@ module Make
   module AlgoM = Owl.Algodiff.D
   open AlgoM
 
-  module GT = FDGrad_test (struct let n = 3 let n_xs = 20 let threshold = 1E-6 let eps = 1E-4 end) 
+  module GT = FDGrad_test (struct let n = 3 let n_xs = 20 let threshold = 1E-5 let eps = 1E-5 end) 
 
   open GT
 
@@ -33,21 +33,25 @@ module Make
     let trace () = test_func Maths.trace
     let tril  () = test_func Maths.tril
     let triu  () = test_func Maths.triu
+
     let inv   () = 
       let e = Arr (Owl.Mat.eye n) in
       let f x = 
         Maths.(inv (x + e)) in
       test_func f
+
     let qr  () =
       let f x = 
         let q, r = Maths.qr x in
         Maths.(q + r)
       in test_func f
+
     let chol  () = 
       let f x = 
         let s = Maths.(transpose x *@ x) in
         Maths.( (chol ~upper:true s) + (chol ~upper:false s))
       in test_func f 
+
     let split () =
       let f x = 
         let a = Maths.split 0 [| 1; 1; 1|] x in

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -46,6 +46,13 @@ module Make
         Maths.(q + r)
       in test_func f
 
+    let svd () = 
+      let f x =                   
+        let x = Maths.((transpose x) *@ x) in
+        let u, s, vt = Maths.svd x in
+        Maths.(u + (sum' s) * (l2norm_sqr' vt))
+      in test_func f
+
     let chol  () = 
       let f x = 
         let s = Maths.(transpose x *@ x) in
@@ -100,6 +107,8 @@ module Make
 
   let qr () = alco_fun "qr" To_test.qr
 
+  let svd () = alco_fun "svd" To_test.svd
+
   let split () = alco_fun "split" To_test.split
 
 
@@ -119,6 +128,7 @@ module Make
     "chol",  `Slow,   chol;
     "qr",    `Slow,   qr;
     "split", `Slow,   split;
+    "svd",   `Slow,   svd;
   ]
 
 end

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -23,34 +23,34 @@ module Make
   let xs = Array.init n_xs (fun _ -> Mat.gaussian n n)
            |> Array.map (fun a -> Maths.(transpose a *@ a))
 
-  let ds = 
-    Array.init (n * n) (fun j -> 
+  let ds =
+    Array.init (n * n) (fun j ->
         Arr (M.init n n (fun i -> if i=j then 1. else 0.)))
 
   let g ~f x = (grad f) x
-  let fd_g ~f x d = 
+  let fd_g ~f x d =
     let dx = Maths.( (F eps) * d) in
     Maths.( ((f (x + dx)) - (f (x - dx))) / (F (2. *. eps)) )
 
-  let check_grads ?threshold:(th=1E-5) rs = 
+  let check_grads ?threshold:(th=1E-5) rs =
     let n_d = Array.length rs in
     let r_fds = Array.map snd rs in
     let rms = (Array.fold_left (fun acc r_fd -> acc +. (r_fd *. r_fd ) ) 0. r_fds) /. (float n_d) |> sqrt in
     let max_err = rs |> Array.map (fun (r_ad, r_fd) -> abs_float (r_ad -. r_fd) /. (rms +. 1E-9) ) |> (Array.fold_left max (-1.)) in
     max_err, max_err < th
 
-  let test_func f  = 
+  let test_func f  =
     let f x = Maths.(sum' (f x)) in
     Array.map (fun x ->
-        let max_err, check = 
-          Array.map (fun d -> 
-              let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
-              let r_fd = (fd_g ~f x d)  |> unpack_flt in
-              r_ad, r_fd
-            ) ds 
-          |> check_grads in
-        check
-      ) xs 
+      let max_err, check =
+        Array.map (fun d ->
+          let r_ad = Maths.(sum' ( (g ~f x) * d )) |> unpack_flt in
+            let r_fd = (fd_g ~f x d)  |> unpack_flt in
+            r_ad, r_fd
+          ) ds
+        |> check_grads in
+      check
+    ) xs 
     |> (Array.fold_left (fun (a, c) b -> a && b, (if b then (succ c) else c) ) (true, 0) )
 
 
@@ -68,35 +68,35 @@ module Make
     let tril  () = test_func Maths.tril
     let triu  () = test_func Maths.triu
     let inv   () = test_func Maths.inv
-    let qr  () = 
+    let qr  () =
       let f x =
         match (Maths.qr x) with
           | Pair (q, r) -> Maths.(q + r)
           | _ -> assert false  in
         test_func f
 
-    let lyapunov () = 
+    let lyapunov () =
       let q = Arr Owl.Mat.(neg (eye n)) in
       let f x = Maths.lyapunov x q in
-      test_func f 
+      test_func f
 
   end
 
-  let alco_fun s f = 
+  let alco_fun s f =
     let check, c = f () in
     Alcotest.(check bool) (sprintf "%s: %i/%i passed" s c n_xs) true check
 
-  let sin  () = alco_fun "sin" To_test.sin
+  let sin () = alco_fun "sin" To_test.sin
 
-  let cos  () = alco_fun "cos" To_test.cos
+  let cos () = alco_fun "cos" To_test.cos
 
-  let tan  () = alco_fun "tan" To_test.tan
+  let tan () = alco_fun "tan" To_test.tan
 
-  let sinh  () = alco_fun "sinh" To_test.sinh
+  let sinh () = alco_fun "sinh" To_test.sinh
 
-  let cosh  () = alco_fun "cosh" To_test.cosh
+  let cosh () = alco_fun "cosh" To_test.cosh
 
-  let tanh  () = alco_fun "tanh" To_test.tanh
+  let tanh () = alco_fun "tanh" To_test.tanh
 
   let exp () = alco_fun "exp" To_test.exp
 
@@ -113,7 +113,7 @@ module Make
   let qr () = alco_fun "qr" To_test.qr
 
 
-  let test_set = [ 
+  let test_set = [
     "sin",   `Slow,   sin;
     "cos",   `Slow,   cos;
     "tan",   `Slow,   tan;
@@ -126,7 +126,7 @@ module Make
     "tril",  `Slow,   tril;
     "triu",  `Slow,   triu;
     "inv",   `Slow,   inv;
-    "qr",  `Slow,   qr;
+    "qr",    `Slow,   qr;
   ]
 
 end

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -15,7 +15,7 @@ module Make
   module AlgoM = Owl.Algodiff.D
   open AlgoM
 
-  module GT = FDGrad_test (struct let n = 3 let n_xs = 20 let threshold = 1E-5 let eps = 1E-5 end) 
+  module GT = FDGrad_test (struct let n = 3 let n_xs = 20 let threshold = 1E-6 let eps = 1E-5 end) 
 
   open GT
 
@@ -47,10 +47,12 @@ module Make
       in test_func f
 
     let svd () = 
-      let f x =                   
-        let x = Maths.((transpose x) *@ x) in
-        let u, s, vt = Maths.svd x in
-        Maths.(u + (sum' s) * (l2norm_sqr' vt))
+      let f =                   
+        let y = Mat.gaussian 20 n in 
+        fun x -> 
+          let x = Maths.(y *@ x) in
+          let u, s, vt = Maths.svd x in
+          Maths.(u + (sum' s) * (l2norm_sqr' vt))
       in test_func f
 
     let chol  () = 
@@ -66,11 +68,12 @@ module Make
       test_func f
 
     let lyapunov () =
-      let f x = 
+      let f = 
         let q = Arr Owl.Mat.((gaussian n n)) in
-        let q = Maths.(q + x) in
-        let q = Maths.(neg (transpose q *@ q)) in
-        Maths.lyapunov x q in
+        fun x -> 
+          let q = Maths.(q + x) in
+          let q = Maths.(neg (transpose q *@ q)) in
+          Maths.lyapunov x q in
       test_func f
 
   end
@@ -102,7 +105,7 @@ module Make
   let triu () = alco_fun "triu" To_test.triu
 
   let inv () = alco_fun "inv" To_test.inv
-      
+
   let chol () = alco_fun "chol" To_test.chol
 
   let qr () = alco_fun "qr" To_test.qr


### PR DESCRIPTION
1. implemented reverse-mode gradient for thin `svd` and `chol`
2. minor changes in algodiff unit test to improve numerical stability of tests for `inv` and `tan`