### PR TITLE
minor changes in logdet

### DIFF
--- a/src/base/optimise/owl_algodiff_generic.ml
+++ b/src/base/optimise/owl_algodiff_generic.ml
@@ -1680,7 +1680,7 @@ module Make
               | L2NormS_D a                -> push (((!aa * (pack_flt 2.) * (primal a)), a) :: t)
               | Sigmoid_D a                -> push (((!aa * ap * ((pack_flt 1.) - ap)), a) :: t)
               | Relu_D a                   -> push (((!aa * ((signum (primal a) + (pack_flt 1.)) / (pack_flt 2.))), a) :: t)
-              | Inv_D a                    -> let dpt = transpose ap in push ((((neg dpt) * !aa * dpt), a) :: t)
+              | Inv_D a                    -> let dpt = transpose ap in push ((((neg dpt) *@ !aa *@ dpt), a) :: t)
               | Add_Row_D_D (a, b, i)      -> push ((!aa, a) :: (get_row !aa i, b) :: t)
               | Add_Row_D_C (a, _b, _i)    -> push ((!aa, a) :: t)
               | Add_Row_C_D (_a, b, i)     -> push ((get_row !aa i, b) :: t)

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -124,17 +124,18 @@ let logdet x =
 
   let _add_op = Owl_base_dense_common._add_elt _kind in
   let _log_op = Owl_base_dense_common._log_elt _kind in
-  let _neg_op = Owl_base_dense_common._neg_elt _kind in
+  let _abs_op = Owl_base_dense_common._abs_elt _kind in
 
   for i = 0 to m - 1 do
-    d := _add_op !d (_log_op (M.get a i i));
+    let e = M.get a i i in
+    d := _add_op !d (_log_op (_abs_op e));
     (* NOTE: +1 to adjust to Fortran index *)
-    if (M.get ipiv 0 i) <> Int32.of_int (i + 1) then
+    if (M.get ipiv 0 i) <> Int32.of_int (i + 1) && e > (Owl_const.zero _kind) then
       c := !c + 1
   done;
 
   match Owl_maths.is_odd !c with
-  | true  -> Owl_base_dense_common._neg_elt _kind !d
+  | true  -> failwith "logdet: det is negative"
   | false -> !d
 
 


### PR DESCRIPTION
The current implementation of `logdet` returns `nan` in cases where `getrf` returns `a`, `ipiv` and `a` has negative diagonal elements. I fixed this by taking the summing the log of the absolute values of the diagonal and keeping track of the sign of the determinant. If the sign of the determinant is negative, `logdet` fails with an error.

