### PR TITLE
owl: add toplevel_printer annotation

### DIFF
--- a/src/base/core/owl_graph.mli
+++ b/src/base/core/owl_graph.mli
@@ -184,7 +184,7 @@ Topological sort of a given graph using a DFS order. Assumes that the graph is
 acyclic.
  *)
 
-val pp_node : Format.formatter -> 'a node -> unit
+val pp_node : Format.formatter -> 'a node -> unit [@@ocaml.toplevel_printer]
 (** Pretty print a given node. *)
 
 val to_string : bool -> 'a node array -> string

--- a/src/base/misc/owl_pretty.mli
+++ b/src/base/misc/owl_pretty.mli
@@ -8,7 +8,7 @@
 
 (** {6 Ndarray pretty printer} *)
 
-val pp_dsnda : Format.formatter -> ('a, 'b, 'c) Bigarray.Genarray.t -> unit
+val pp_dsnda : Format.formatter -> ('a, 'b, 'c) Bigarray.Genarray.t -> unit [@@ocaml.toplevel_printer]
 (** ``pp_dsnda`` is the pretty printer for n-dimensional arrays. *)
 
 val dsnda_to_string :  ?header:bool -> ?max_row:int -> ?max_col:int -> ?elt_to_str_fun:('a -> string) -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> string
@@ -25,7 +25,7 @@ the headers. [fmt] is the function to format every element into string.
 
 (** {6 Dataframe pretty printer} *)
 
-val pp_dataframe : Format.formatter -> Owl_dataframe.t -> unit
+val pp_dataframe : Format.formatter -> Owl_dataframe.t -> unit [@@ocaml.toplevel_printer]
 (** ``pp_dataframe`` is the pretty printer for dataframe. *)
 
 val dataframe_to_string : ?header:bool -> ?names:string array -> ?max_row:int -> ?max_col:int -> ?elt_to_str_fun:(Owl_dataframe.elt -> string) -> Owl_dataframe.t -> string

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -487,7 +487,7 @@ Arguments:
   val to_string : network -> string
   (** Convert a neural network to its string representation. *)
 
-  val pp_network : Format.formatter -> network -> unit
+  val pp_network : Format.formatter -> network -> unit [@@ocaml.toplevel_printer]
   (** Pretty printing function a neural network. *)
 
   val print : network -> unit

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -536,7 +536,7 @@ file format which you can use other tools further visualisation, such as
 Graphviz.
    *)
 
-  val pp_num : Format.formatter -> t -> unit
+  val pp_num : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
   (** ``pp_num t`` pretty prints the abstract number used in ``Algodiff``. *)
 
 

--- a/src/base/stats/owl_base_stats.mli
+++ b/src/base/stats/owl_base_stats.mli
@@ -130,7 +130,7 @@ val normalise : histogram -> histogram
 val normalise_density : histogram -> histogram
 (** Refer to :doc:`owl_stats`. *)
 
-val pp_hist: Format.formatter -> histogram -> unit
+val pp_hist: Format.formatter -> histogram -> unit [@@ocaml.toplevel_printer]
 (** Refer to :doc:`owl_stats`. *)
 
 val tukey_fences : ?k:float -> float array -> float * float

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1032,7 +1032,7 @@ and ``max_col`` specify the maximum number of rows and columns to display.
 function to format every element into string.
  *)
 
-val pp_dsnda : Format.formatter -> ('a, 'b) t -> unit
+val pp_dsnda : Format.formatter -> ('a, 'b) t -> unit [@@ocaml.toplevel_printer]
 (**
 ``pp_dsnda x`` prints ``x`` in OCaml toplevel. If the ndarray is too long,
 ``pp_dsnda`` only prints out parts of the ndarray.

--- a/src/owl/nlp/owl_nlp_vocabulary.mli
+++ b/src/owl/nlp/owl_nlp_vocabulary.mli
@@ -136,5 +136,5 @@ val save_txt : t -> string -> unit
 val to_string : t -> string
 (** ``to_string v`` returns the summary information of a vocabulary. *)
 
-val pp_vocab : Format.formatter -> t -> unit
+val pp_vocab : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]
 (** Pretty printer for vocabulary type. *)

--- a/src/owl/sparse/owl_sparse_matrix_generic.mli
+++ b/src/owl/sparse/owl_sparse_matrix_generic.mli
@@ -556,7 +556,7 @@ val print : ('a, 'b) t -> unit
 ``print x`` pretty prints matrix ``x`` without headings.
  *)
 
-val pp_spmat : ('a, 'b) t -> unit
+val pp_spmat : ('a, 'b) t -> unit [@@ocaml.toplevel_printer]
 (**
 ``pp_spmat x`` pretty prints matrix ``x`` with headings. Toplevel uses this
 function to print out the matrices.

--- a/src/owl/sparse/owl_sparse_ndarray_generic.mli
+++ b/src/owl/sparse/owl_sparse_ndarray_generic.mli
@@ -188,7 +188,7 @@ val of_array : ('a, 'b) kind -> int array -> (int array * 'a) array -> ('a, 'b) 
 val print : ('a, 'b) t -> unit
 (** TODO *)
 
-val pp_spnda : ('a, 'b) t -> unit
+val pp_spnda : ('a, 'b) t -> unit [@@ocaml.toplevel_printer]
 (** TODO *)
 
 val save : ('a, 'b) t -> string -> unit

--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -208,7 +208,7 @@ one. If bins are infinitely wide, their density is 0 and the sum over width
 times density of all finite bins is the total weight in the finite bins. The
 result is stored in the ``density`` field. *)
 
-val pp_hist: Format.formatter -> histogram -> unit
+val pp_hist: Format.formatter -> histogram -> unit [@@ocaml.toplevel_printer]
 (** Pretty-print summary information on a histogram record *)
 
 val ecdf : float array -> float array * float array


### PR DESCRIPTION
This will make the pretty printers automatically installed
in recent versions of utop (and hopefully further toplevels,
like jupyter, will follow). Practically it means that owl-top is
no longer necessary for utop to pretty print owl values.
See e.g. https://github.com/ocaml/opam-repository/pull/13348

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>