### PR TITLE
owl: update bounds on eigen

### DIFF
--- a/owl.opam
+++ b/owl.opam
@@ -24,7 +24,7 @@ depends: [
   "conf-openblas" {>= "0.2.0"}
   "ctypes"
   "dune" {build}
-  "eigen" {>= "0.0.3"}
+  "eigen" {>= "0.1.0"}
   "owl-base"
   "plplot"
   "stdio" {build}

--- a/src/owl/sparse/owl_sparse_common.ml
+++ b/src/owl/sparse/owl_sparse_common.ml
@@ -4,7 +4,7 @@
  *)
 
 open Bigarray
-open Eigen_types
+open Eigen.Types
 
 type ('a, 'b) kind = ('a, 'b) Bigarray.kind
 


### PR DESCRIPTION
This is a compilation fix for the release of `eigen` 0.1.0. You need to use this it if you are pinning the eigen dev-repo.

Please wait until https://github.com/ocaml/opam-repository/pull/13407 is merged.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>