### PR TITLE
Fix Travis, part2: disable owl-base tests (all tests require owl)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ env:
     - PINS="owl-base:. owl-aeos:. owl-top:. owl-zoo:. owl:."
     - DISTRO=debian-stable
   matrix:
-    - PACKAGE="owl-base"
     - PACKAGE="owl"

--- a/owl-base.opam
+++ b/owl-base.opam
@@ -11,12 +11,10 @@ description: "Owl is an OCaml scientific library."
 build: [
   [ "dune" "subst" ] {pinned}
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "alcotest" {test}
   "base-bigarray"
   "dune" {build}
 ]


### PR DESCRIPTION
All tests require owl, this was coming from a leftover commit in the previous PR. Apologies