### PR TITLE
base: remove Unix time dependency temporarily

### DIFF
--- a/src/base/misc/owl_io.ml
+++ b/src/base/misc/owl_io.ml
@@ -46,20 +46,13 @@ let iteri_lines_of_file ?(verbose=true) f fname =
   let i = ref 0 in
   let h = open_in fname in
   (
-    let t0 = Unix.gettimeofday () in
-    let t1 = ref (Unix.gettimeofday ()) in
     try while true do
       f !i (input_line h);
       i := !i + 1;
       (* output summary if in verbose mode *)
       if verbose = true then (
-        let t2 = Unix.gettimeofday () in
-        if t2 -. !t1 > 5. then (
-          t1 := t2;
-          let speed = float_of_int !i /. (t2 -. t0) |> int_of_float in
-          Owl_log.info "processed %i, avg. %i docs/s" !i speed
+          Owl_log.info "processed %i" !i
         )
-      )
     done with End_of_file -> ()
   );
   close_in h
@@ -79,22 +72,13 @@ let iteri_lines_of_marshal ?(verbose=true) f fname =
   let i = ref 0 in
   let h = open_in fname in
   (
-    let t1 = ref (Unix.gettimeofday ()) in
-    let i1 = ref 0 in
-
     try while true do
       f !i (Marshal.from_channel h);
       i := !i + 1;
       (* output summary if in verbose mode *)
       if verbose = true then (
-        let t2 = Unix.gettimeofday () in
-        if t2 -. !t1 > 5. then (
-          let speed = float_of_int (!i - !i1) /. (t2 -. !t1) |> int_of_float in
-          i1 := !i;
-          t1 := t2;
-          Owl_log.info "processed %i, avg. %i docs/s" !i speed
+          Owl_log.info "processed %i" !i
         )
-      )
     done with End_of_file -> ()
   );
   close_in h

--- a/src/base/misc/owl_log.ml
+++ b/src/base/misc/owl_log.ml
@@ -52,16 +52,6 @@ let _level_to_str = function
   | FATAL -> _shall_paint Magenta "FATAL"
 
 let make_prefix lvl =
-  let ts = Unix.gettimeofday() in
-  let tm = Unix.localtime ts in
-  Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d.%03d %s : "
-    (tm.Unix.tm_year + 1900)
-    (tm.Unix.tm_mon + 1)
-    tm.Unix.tm_mday
-    tm.Unix.tm_hour
-    tm.Unix.tm_min
-    tm.Unix.tm_sec
-    (modf ts |> fst |> ( *. ) 1000. |> int_of_float)
     (_level_to_str lvl)
 
 let _log lvl fmt =

--- a/src/base/misc/owl_utils.ml
+++ b/src/base/misc/owl_utils.ml
@@ -210,10 +210,7 @@ let format_time t =
 
 (** measure the time spent in a function in millisecond *)
 let time f =
-  let t = Unix.gettimeofday () in
-  f ();
-  (Unix.gettimeofday () -. t) *. 1000.
-
+  0.
 
 (** TODO: return the the distance between [1.0] and the next larger representable
   floating-point value. *)


### PR DESCRIPTION
Remove Unix time code from Owl_base.

This is needed because MirageOS failed to be built as:

 Error: No implementations provided for the following modules:
          Unix referenced from /home/ehirdoy/.opam/4.06.1+lto/lib/owl-base/owl_base.cmxa(Owl_utils),
            /home/ehirdoy/.opam/4.06.1+lto/lib/owl-base/owl_base.cmxa(Owl_log),
            /home/ehirdoy/.opam/4.06.1+lto/lib/owl-base/owl_base.cmxa(Owl_io)

This can be temporary workaround.
Other non-unix time function could revert this commit later.

Signed-off-by: Hiroshi Doyu <hiroshi.doyu@ericsson.com>