### PR TITLE
owl,owl-aeos: remove unnecessary sexplib dependency

### DIFF
--- a/owl-aeos.opam
+++ b/owl-aeos.opam
@@ -19,5 +19,4 @@ depends: [
   "dune" {build}
   "ocaml-compiler-libs"
   "stdio" {build}
-  "sexplib" {build}
 ]

--- a/owl.opam
+++ b/owl.opam
@@ -34,5 +34,4 @@ depends: [
   "owl-aeos"
   "plplot"
   "stdio" {build}
-  "sexplib" {build}
 ]

--- a/src/aeos/config/configure.ml
+++ b/src/aeos/config/configure.ml
@@ -5,11 +5,6 @@
 
 module C = Configurator.V1
 
-
-let write_sexp fn sexp =
-  Stdio.Out_channel.write_all fn ~data:(Sexplib.Sexp.to_string sexp)
-
-
 let get_os_type c =
   let sys = C.ocaml_config_var c "system" in
   match sys with Some s -> s | None -> ""
@@ -61,6 +56,6 @@ let () =
     (* assemble default config *)
     let conf : C.Pkg_config.package_conf = { cflags; libs } in
 
-    write_sexp "aeos_c_flags.sexp" Sexplib.Std.(sexp_of_list sexp_of_string conf.cflags);
-    write_sexp "aeos_c_library_flags.sexp" Sexplib.Std.(sexp_of_list sexp_of_string conf.libs);
+    C.Flags.write_sexp "aeos_c_flags.sexp" conf.cflags;
+    C.Flags.write_sexp "aeos_c_library_flags.sexp" conf.libs
   )

--- a/src/aeos/config/dune
+++ b/src/aeos/config/dune
@@ -2,6 +2,5 @@
  (name configure)
  (libraries
   dune.configurator
-  sexplib
   stdio
   ))

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -11,8 +11,6 @@ let get_os_type c =
 
 
 let get_ocaml_default_flags _c = [
-  ":standard";
-  "-safe-string";
 ]
 
 

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -5,11 +5,6 @@
 
 module C = Configurator.V1
 
-
-let write_sexp fn sexp =
-  Stdio.Out_channel.write_all fn ~data:(Sexplib.Sexp.to_string sexp)
-
-
 let get_os_type c =
   let sys = C.ocaml_config_var c "system" in
   match sys with Some s -> s | None -> ""
@@ -153,7 +148,7 @@ let () =
     (* assemble default config *)
     let conf : C.Pkg_config.package_conf = { cflags; libs } in
 
-    write_sexp "c_flags.sexp" Sexplib.Std.(sexp_of_list sexp_of_string conf.cflags);
-    write_sexp "c_library_flags.sexp" Sexplib.Std.(sexp_of_list sexp_of_string conf.libs);
-    write_sexp "ocaml_flags.sexp" Sexplib.Std.(sexp_of_list sexp_of_string ocaml_flags);
+    C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+    C.Flags.write_sexp "c_library_flags.sexp" conf.libs;
+    C.Flags.write_sexp "ocaml_flags.sexp" ocaml_flags;
   )

--- a/src/owl/config/dune
+++ b/src/owl/config/dune
@@ -2,6 +2,5 @@
  (name configure)
  (libraries
   dune.configurator
-  sexplib
   stdio
   ))


### PR DESCRIPTION
write_sexp is already bundled in `dune`.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>