### PR TITLE
Further fixups

### DIFF
--- a/owl-aeos.opam
+++ b/owl-aeos.opam
@@ -20,3 +20,7 @@ depends: [
   "ocaml-compiler-libs"
   "stdio" {build}
 ]
+
+depexts: [
+  ["libopenmp"] {os = "macos" & os-distribution = "homebrew"}
+]

--- a/src/owl/dune
+++ b/src/owl/dune
@@ -165,7 +165,7 @@
   )
  (c_flags (:include c_flags.sexp))
  (c_library_flags (:include c_library_flags.sexp))
- (flags (:include ocaml_flags.sexp))
+ (flags :standard (:include ocaml_flags.sexp))
  (libraries
   ctypes
   ctypes.stubs


### PR DESCRIPTION
The depext is to make the build work again on freshly installed macs, the dune file change is just to make the update from the previous PR behave exactly as before (almost: I kept `safe-string` out as it is the default now and can create runtime and compiler error when libraries are compiled with mixed safe/unsafe strings in old compilers).