### PR TITLE
Fedora works!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,5 @@ matrix:
 
   fast_finish: true
   allow_failures:
-    - env: OCAML_VERSION=4.06 DISTRO=fedora
     - env: OCAML_VERSION=4.07 DISTRO=ubuntu
 

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -129,8 +129,12 @@ let openblas_default : C.Pkg_config.package_conf =
     else if Sys.file_exists p2 then ["-L" ^ p2]
     else []
   in
+  let p0 = "/usr/include/openblas" in
+  let cflags = if Sys.file_exists p0 then ["-I" ^ p0]
+    else []
+  in
   let libs = libs @ ["-lopenblas"] in
-  C.Pkg_config.{cflags=[]; libs}
+  C.Pkg_config.{cflags; libs}
 
 
 let get_accelerate_libs c =


### PR DESCRIPTION
With the updated conf-openblas recently merged to the opam-repository, Fedora can now be used with owl seamlessly. This PR properly re-enables Fedora tests.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>