### PR TITLE
added lgamma function

### DIFF
--- a/src/owl/core/owl_ndarray_maths.ml
+++ b/src/owl/core/owl_ndarray_maths.ml
@@ -2769,4 +2769,17 @@ let _owl_fused_adagrad : type a b. (a, b) kind -> (a, b) owl_arr_op33 = function
   | _         -> failwith "_owl_fused_adagrad: unsupported operation"
 
 
+(* special functions *)
+
+(* gamma functions *)
+external owl_float32_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float32_lgamma"
+external owl_float64_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float64_lgamma"
+
+let _owl_lgamma : type a b. (a, b) kind -> (a, b) owl_arr_op09 = fun k l x y ->
+  match k with
+  | Float32   -> owl_float32_lgamma l x y
+  | Float64   -> owl_float64_lgamma l x y
+  | _         -> failwith "_owl_lgamma: unsupported operation"
+ 
+
 (* ends here *)

--- a/src/owl/core/owl_ndarray_maths.ml
+++ b/src/owl/core/owl_ndarray_maths.ml
@@ -1250,6 +1250,16 @@ let _owl_atanh : type a b. (a, b) kind -> (a, b) owl_arr_op09 = fun k l x y ->
   | Complex64 -> owl_complex64_atanh l x y
   | _         -> failwith "_owl_atanh: unsupported operation"
 
+(* gamma functions *)
+external owl_float32_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float32_lgamma"
+external owl_float64_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float64_lgamma"
+
+let _owl_lgamma : type a b. (a, b) kind -> (a, b) owl_arr_op09 = fun k l x y ->
+  match k with
+  | Float32   -> owl_float32_lgamma l x y
+  | Float64   -> owl_float64_lgamma l x y
+  | _         -> failwith "_owl_lgamma: unsupported operation"
+ 
 external owl_float32_floor : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float32_floor"
 external owl_float64_floor : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float64_floor"
 external owl_complex32_floor : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "complex32_floor"
@@ -2769,17 +2779,6 @@ let _owl_fused_adagrad : type a b. (a, b) kind -> (a, b) owl_arr_op33 = function
   | _         -> failwith "_owl_fused_adagrad: unsupported operation"
 
 
-(* special functions *)
 
-(* gamma functions *)
-external owl_float32_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float32_lgamma"
-external owl_float64_lgamma : int -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> unit = "float64_lgamma"
-
-let _owl_lgamma : type a b. (a, b) kind -> (a, b) owl_arr_op09 = fun k l x y ->
-  match k with
-  | Float32   -> owl_float32_lgamma l x y
-  | Float64   -> owl_float64_lgamma l x y
-  | _         -> failwith "_owl_lgamma: unsupported operation"
- 
 
 (* ends here *)

--- a/src/owl/core/owl_ndarray_maths_stub.c
+++ b/src/owl/core/owl_ndarray_maths_stub.c
@@ -6,13 +6,14 @@
 #include "owl_core.h"
 #include "owl_stats.h"
 #include "owl_core_engine.h"
+#include "owl_cephes.h"
 
 
 // some helper functions
 
 #define LN10 2.302585092994045684017991454684364208  /* log_e 10 */
 #define exp10f(X) expf(LN10 * X)
-#define exp10(X) exp(LN10 * X)
+// #define exp10(X) exp(LN10 * X)
 
 
 #define OWL_ENABLE_TEMPLATE
@@ -3637,6 +3638,19 @@
 #define NUMBER1 double
 #include OWL_NDARRAY_MATHS_FOLD
 
+//  gamma functions
+#define FUN4 float32_lgamma
+#define NUMBER float
+#define NUMBER1 float
+#define MAPFN(X) (lgammaf(X))
+#include OWL_NDARRAY_MATHS_MAP
+ 
+#define FUN4 float64_lgamma
+#define NUMBER double
+#define NUMBER1 double
+#define MAPFN(X) (lgam(X))
+#include OWL_NDARRAY_MATHS_MAP
+ 
 
 ////// binary math operator //////
 
@@ -6954,6 +6968,9 @@
 #define NUMBER double
 #define MAPFN(X,Y) Y = a / sqrt (X + eps);
 #include OWL_NDARRAY_MATHS_MAP
+
+
+
 
 
 //////////////////// function templates ends ////////////////////

--- a/src/owl/dense/owl_dense_matrix_d.mli
+++ b/src/owl/dense/owl_dense_matrix_d.mli
@@ -591,6 +591,7 @@ val std : ?axis:int -> mat -> mat
 
 val mat2gray : ?amin:elt -> ?amax:elt -> mat -> mat
 
+val lgamma : mat -> mat 
 
 (** {6 Binary mathematical operations } *)
 
@@ -856,3 +857,5 @@ val elt_greater_scalar_ : ?out:mat -> mat -> elt -> unit
 val elt_less_equal_scalar_ : ?out:mat -> mat -> elt -> unit
 
 val elt_greater_equal_scalar_ : ?out:mat -> mat -> elt -> unit
+
+

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1789,6 +1789,11 @@ The elements in ``x`` are clipped by ``amin`` and ``amax``, and they will be bet
 ``0.`` and ``1.`` after conversion to represents the intensity.
  *)
 
+val lgamma : ('a, 'b) t-> ('a, 'b) t
+(**
+``lgamma x`` computes the loggamma of the elements in ``x`` and returns the result in
+a new matrix.
+ *)
 
 (** {6 Binary math operators}  *)
 
@@ -2545,3 +2550,7 @@ val elt_greater_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 ``elt_greater_equal_scalar_ x a`` is simiar to ``elt_greater_equal_scalar``
 function but the output is written to ``x``.
  *)
+
+
+
+

--- a/src/owl/dense/owl_dense_matrix_s.mli
+++ b/src/owl/dense/owl_dense_matrix_s.mli
@@ -591,6 +591,7 @@ val std : ?axis:int -> mat -> mat
 
 val mat2gray : ?amin:elt -> ?amax:elt -> mat -> mat
 
+val lgamma : mat -> mat 
 
 (** {6 Binary mathematical operations } *)
 
@@ -856,3 +857,5 @@ val elt_greater_scalar_ : ?out:mat -> mat -> elt -> unit
 val elt_less_equal_scalar_ : ?out:mat -> mat -> elt -> unit
 
 val elt_greater_equal_scalar_ : ?out:mat -> mat -> elt -> unit
+
+

--- a/src/owl/dense/owl_dense_ndarray_d.mli
+++ b/src/owl/dense/owl_dense_ndarray_d.mli
@@ -471,6 +471,7 @@ val cummax : ?axis:int -> arr -> arr
 
 val diff : ?axis:int -> ?n:int -> arr -> arr
 
+val lgamma : arr -> arr
 
 (** {6 Binary mathematical operations } *)
 
@@ -1278,9 +1279,12 @@ val rayleigh_logsf : sigma:arr -> arr -> arr
 
 val rayleigh_isf : sigma:arr -> arr -> arr
 
+ 
 
 (** {6 Helper functions}  *)
 
 val float_to_elt : float -> elt
 
 val elt_to_float : elt -> float
+
+

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -965,6 +965,12 @@ let l2norm' x =
 
 let log_sum_exp' x = _owl_log_sum_exp (kind x) (numel x) x
 
+(* gamma functions *)
+let lgamma x =
+  let y = copy x in
+  _owl_lgamma (kind x) (numel y) x y;
+  y
+
 let scalar_pow a x =
   let x = copy x in
   _owl_scalar_pow (kind x) (numel x) x x a;
@@ -6323,6 +6329,8 @@ let contract2 index_pairs x y =
   let ndims = Array.length loop0 |> Int64.of_int in
   Owl_ndarray._ndarray_contract_two (kind x) x y z incx1 incy1 incz1 loop1 ndims;
   z
+
+
 
 
 (* Helper functions *)

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1603,6 +1603,12 @@ val proj : (Complex.t, 'a) t -> (Complex.t, 'a) t
 ``proj x`` computes the projection on Riemann sphere of all elelments in ``x``.
  *)
 
+val lgamma : ('a, 'b) t -> ('a, 'b) t
+(**
+``lgamma x`` computes the loggamma of the elements in ``x`` and returns the result
+in a new ndarray.
+ *)
+ 
 
 (** {6 Binary math operators}  *)
 
@@ -2783,6 +2789,8 @@ val draw_rows2 : ?replacement:bool -> ('a, 'b) t -> ('a, 'b) t -> int -> ('a, 'b
 
 val draw_cols2 : ?replacement:bool -> ('a, 'b) t -> ('a, 'b) t -> int -> ('a, 'b) t * ('a, 'b) t * int array
 (** Refer to :doc:`owl_dense_matrix_generic` *)
+
+
 
 
 (** {6 Helper functions}  *)

--- a/src/owl/dense/owl_dense_ndarray_s.mli
+++ b/src/owl/dense/owl_dense_ndarray_s.mli
@@ -471,6 +471,7 @@ val cummax : ?axis:int -> arr -> arr
 
 val diff : ?axis:int -> ?n:int -> arr -> arr
 
+val lgamma : arr -> arr
 
 (** {6 Binary mathematical operations } *)
 
@@ -986,7 +987,6 @@ val draw_cols : ?replacement:bool -> arr -> int -> arr * int array
 val draw_rows2 : ?replacement:bool -> arr -> arr -> int -> arr * arr * int array
 
 val draw_cols2 : ?replacement:bool -> arr -> arr -> int -> arr * arr * int array
-
 
 (** {6 Helper functions}  *)
 


### PR DESCRIPTION
I'm reopening the PR for adding lgamma with a cleaner commit histroy.

Here I'm using `owl_cephes`'s `lgam` for the implementation of double-precision and the default c option `lgammaf` for single-precision. 
Note that the scalar `loggamma` function in the `Maths` module also uses `owl_cephes`'s `lgam` function.

Currently the single and double precision `lgamma` gives similar results up to around 8 decimal points.
We might consider including single-precision `cephes` functions in the future. 
