### PR TITLE
config-flags: allow to customise owl and owl_aeos cflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,17 @@ before compilation:
 - `OWL_ENABLE_OPENMP=1`: turn on OpenMP support in core module and
   the automatic parameter tuning (AEOS)
 
+- `OWL_CFLAGS` allows to change the default flags passed to the C targets,
+  it defaults to
+  ```
+  OWL_CFLAGS="-g -O3 -Ofast -march=native -mfpmath=sse -funroll-loops -ffast-math -DSFMT_MEXP=19937 -msse2 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare"`
+  ```
+
+- `OWL_AEOS_CFLAGS` allows to change the default flags passed to the C targets
+  when compiling AEOS. It defaults to
+  ```
+  OWL_AEOS_CFLAGS="-g -O3 -Ofast -march=native -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing"
+  ```
+
 If you are not using `opam`, you should run `make clean` before recompiling
 the library after having changed any of those environment variables.

--- a/src/aeos/config/configure.ml
+++ b/src/aeos/config/configure.ml
@@ -16,11 +16,17 @@ let get_os_type c =
   match sys with Some s -> s | None -> ""
 
 
-let get_default_cflags _c = [
-  "-g"; "-O3"; "-Ofast";
-  "-march=native"; "-funroll-loops"; "-ffast-math";
-  "-DSFMT_MEXP=19937"; "-fno-strict-aliasing";
-]
+let get_default_cflags = 
+  try
+    Sys.getenv "OWL_AEOS_CFLAGS" |> String.trim
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with Not_found ->
+    [
+      "-g"; "-O3"; "-Ofast";
+      "-march=native"; "-funroll-loops"; "-ffast-math";
+      "-DSFMT_MEXP=19937"; "-fno-strict-aliasing";
+    ]
 
 
 let get_openmp_cflags c =
@@ -63,7 +69,7 @@ let () =
       (* configure compile options *)
       let cflags = 
         []
-        @ get_default_cflags c
+        @ get_default_cflags
         @ get_openmp_cflags c
       in
 

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -71,17 +71,23 @@ let get_ocaml_devmode_flags _c =
   ]
 
 
-let default_cflags = [
-  (* Basic optimisation *)
-  "-g"; "-O3"; "-Ofast";
-  (* FIXME: experimental switches *)
-  (* "-mavx2"; "-mfma"; "-ffp-contract=fast"; *)
-  (* Experimental switches, -ffast-math may break IEEE754 semantics*)
-  "-march=native"; "-mfpmath=sse"; "-funroll-loops"; "-ffast-math";
-  (* Configure Mersenne Twister RNG *)
-  "-DSFMT_MEXP=19937"; "-msse2"; "-fno-strict-aliasing";
-  "-Wno-tautological-constant-out-of-range-compare";
-]
+let default_cflags = 
+  try
+    Sys.getenv "OWL_CFLAGS" |> String.trim
+    |> String.split_on_char ' '
+    |> List.filter (fun s -> String.trim s <> "")
+  with Not_found ->
+    [
+      (* Basic optimisation *)
+      "-g"; "-O3"; "-Ofast";
+      (* FIXME: experimental switches *)
+      (* "-mavx2"; "-mfma"; "-ffp-contract=fast"; *)
+      (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+      "-march=native"; "-mfpmath=sse"; "-funroll-loops"; "-ffast-math";
+      (* Configure Mersenne Twister RNG *)
+      "-DSFMT_MEXP=19937"; "-msse2"; "-fno-strict-aliasing";
+      "-Wno-tautological-constant-out-of-range-compare";
+    ]
 
 
 let default_libs =


### PR DESCRIPTION
This should help fixing https://github.com/owlbarn/owl/issues/354 and https://github.com/owlbarn/owl/issues/394

Would it make any sense to unify owl and aeos cflags or it is better to keep them separate?
Is there any modification you would like to have for the current default values?

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>