### PR TITLE
added linsolve and lq reverse-mode differentiation

### DIFF
--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -475,6 +475,8 @@ module Make
 
   let discrete_lyapunov ?(solver=`default) _a _q = solver |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
+  let linsolve ?trans _a _b = trans |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
   let diag ?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
   let diagm ?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -471,6 +471,8 @@ module Make
 
   let qr _x = raise Owl_exception.NOT_IMPLEMENTED
 
+  let lq _x = raise Owl_exception.NOT_IMPLEMENTED
+
   let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED
 
   let discrete_lyapunov ?(solver=`default) _a _q = solver |> ignore; raise Owl_exception.NOT_IMPLEMENTED

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -506,6 +506,9 @@ module type Sig = sig
   val qr : arr -> arr * arr
   (** TODO *)
 
+  val lq : arr -> arr * arr
+  (** TODO *)
+
   val svd : ?thin:bool -> arr -> arr * arr * arr
   (** TODO *)
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -515,6 +515,9 @@ module type Sig = sig
   val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr
   (** TODO *)
 
+  val linsolve : ?trans:bool -> arr -> arr -> arr
+  (** TODO *)
+
   val diag: ?k:int -> arr -> arr
   (** TODO *)
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -415,6 +415,8 @@ val logdet : arr -> elt
 val svd : ?thin:bool -> arr -> arr * arr * arr
 
 val qr : arr -> arr * arr
+
+val lq : arr -> arr * arr
                 
 val chol : ?upper:bool -> arr -> arr 
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -422,6 +422,8 @@ val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr
 
+val linsolve: ?trans:bool  -> arr -> arr -> arr
+
 val diag: ?k:int -> arr -> arr 
 
 val diagm: ?k:int -> arr -> arr 

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -4208,6 +4208,8 @@ let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED
 
 let discrete_lyapunov ?(solver=`default) _a _q = solver |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
+let linsolve ?(trans=false) _a _b = trans |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+
 let diag ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
 let diagm ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -4200,6 +4200,8 @@ let logdet _x = raise Owl_exception.NOT_IMPLEMENTED
 
 let qr _x = raise Owl_exception.NOT_IMPLEMENTED
 
+let lq _x = raise Owl_exception.NOT_IMPLEMENTED
+
 let chol ?(upper=true) _x = upper |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
 let svd ?(thin=true) _x = thin |> ignore; raise Owl_exception.NOT_IMPLEMENTED

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -726,6 +726,9 @@ val chol : ?upper:bool -> (float, 'b) t -> (float, 'b) t
 val qr : (float, 'b) t -> (float, 'b) t * (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+val lq : (float, 'b) t -> (float, 'b) t * (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 val svd : ?thin:bool -> (float, 'b) t -> (float, 'b) t * (float, 'b) t * (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -735,6 +735,9 @@ val lyapunov : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+val linsolve: ?trans:bool -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 val diag: ?k:int -> (float, 'b) t -> (float, 'b) t 
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -422,6 +422,8 @@ val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr
 
+val linsolve: ?trans:bool  -> arr -> arr -> arr
+
 val diag : ?k:int -> arr -> arr
 
 val diagm : ?k:int -> arr -> arr

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -418,6 +418,8 @@ val chol : ?upper:bool -> arr -> arr
 
 val qr : arr -> arr * arr
 
+val lq : arr -> arr * arr
+
 val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -92,6 +92,12 @@ module type Sig = sig
     val lyapunov : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val linsolve : ?trans:bool -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
     val neg : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -85,6 +85,9 @@ module type Sig = sig
 
     val qr : t -> t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val lq : t -> t * t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
                   
     val svd : ?thin:bool -> t -> t * t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -317,6 +317,8 @@ module type Sig = sig
 
   val discrete_lyapunov: ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr
 
+  val linsolve: ?trans:bool -> arr -> arr -> arr
+
   val diag : ?k:int -> arr -> arr
 
   val diagm : ?k:int -> arr -> arr

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -313,6 +313,8 @@ module type Sig = sig
 
   val qr : arr -> arr * arr
 
+  val lq : arr -> arr * arr
+
   val lyapunov: arr -> arr -> arr
 
   val discrete_lyapunov: ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -31,6 +31,8 @@ module Generic = struct
     let q, r, _ = Owl_linalg_generic.qr ~thin:true ~pivot:false x in
     (q,r)
   
+  let lq x = Owl_linalg_generic.lq ~thin:true x 
+
   let lyapunov a q = Owl_linalg_generic.lyapunov a q
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_generic.discrete_lyapunov ~solver a q
@@ -66,6 +68,8 @@ module S = struct
   let qr x =
     let q, r, _ = Owl_linalg_s.qr ~thin:true ~pivot:false x in
     (q,r)
+
+  let lq x = Owl_linalg_s.lq ~thin:true x 
 
   let lyapunov = Owl_linalg_s.lyapunov
 
@@ -103,6 +107,8 @@ module D = struct
     let q, r, _ = Owl_linalg_d.qr ~thin:true ~pivot:false x in
     (q,r)
 
+  let lq x = Owl_linalg_d.lq ~thin:true x 
+
   let lyapunov = Owl_linalg_d.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_d.discrete_lyapunov ~solver a q
@@ -129,6 +135,8 @@ module C = struct
     let q, r, _ = Owl_linalg_c.qr ~thin:true ~pivot:false x in
     (q,r)
 
+  let lq x = Owl_linalg_c.lq ~thin:true x 
+
   let lyapunov = Owl_linalg_c.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_c.discrete_lyapunov ~solver a q
@@ -154,6 +162,8 @@ module Z = struct
   let qr x =
     let q, r, _ = Owl_linalg_z.qr ~thin:true ~pivot:false x in
     (q,r)
+
+  let lq x = Owl_linalg_z.lq ~thin:true x 
 
   let lyapunov = Owl_linalg_z.lyapunov 
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -35,6 +35,8 @@ module Generic = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_generic.discrete_lyapunov ~solver a q
 
+  let linsolve ?(trans=false) a b = Owl_linalg_generic.linsolve ~trans a b
+
 end
 
 
@@ -69,6 +71,8 @@ module S = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_s.discrete_lyapunov ~solver a q
 
+  let linsolve ?(trans=false) a b = Owl_linalg_s.linsolve ~trans a b
+
 end
 
 
@@ -102,6 +106,8 @@ module D = struct
   let lyapunov = Owl_linalg_d.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_d.discrete_lyapunov ~solver a q
+
+  let linsolve ?(trans=false) a b = Owl_linalg_d.linsolve ~trans a b
 end
 
 
@@ -127,6 +133,7 @@ module C = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_c.discrete_lyapunov ~solver a q
 
+  let linsolve ?(trans=false) a b = Owl_linalg_c.linsolve ~trans a b
 end
 
 
@@ -152,6 +159,7 @@ module Z = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_z.discrete_lyapunov ~solver a q
 
+  let linsolve ?(trans=false) a b = Owl_linalg_z.linsolve ~trans a b
 end
 
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -65,6 +65,12 @@ module Make
         Maths.(q + r)
       in test_func f
 
+    let lq  () =
+      let f x = 
+        let l, q = Maths.lq x in
+        Maths.(l + q)
+      in test_func f
+
     let svd () = 
       let f =                   
         let y = Mat.gaussian 20 n in 
@@ -149,7 +155,7 @@ module Make
         let a1 = Maths.(r1 + b) in
         let a2 = Maths.(r2 + b) in
         let x1 = Maths.linsolve ~trans:true a1 b in
-        let x2 = Maths.linsolve ~trans:false b a2 in
+        let x2 = Maths.linsolve ~trans:false a2 b in
         Maths.(x1 + x2) in
       test_func f
   end
@@ -190,6 +196,8 @@ module Make
 
   let qr () = alco_fun "qr" To_test.qr
 
+  let lq () = alco_fun "lq" To_test.lq
+
   let svd () = alco_fun "svd" To_test.svd
 
   let split () = alco_fun "split" To_test.split
@@ -225,6 +233,7 @@ module Make
     "logdet",                   `Slow,     logdet;
     "chol",                     `Slow,     chol;
     "qr",                       `Slow,     qr;
+    "lq",                       `Slow,     lq;
     "split",                    `Slow,     split;
     "concatenate",              `Slow,     concatenate;
     "svd",                      `Slow,     svd;

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -142,7 +142,16 @@ module Make
           Maths.discrete_lyapunov a q in
       test_func f
 
-
+    let linsolve () = 
+      let r1 = Mat.gaussian n n in
+      let r2 = Mat.gaussian n n in
+      let f b = 
+        let a1 = Maths.(r1 + b) in
+        let a2 = Maths.(r2 + b) in
+        let x1 = Maths.linsolve ~trans:true a1 b in
+        let x2 = Maths.linsolve ~trans:false b a2 in
+        Maths.(x1 + x2) in
+      test_func f
   end
 
   let alco_fun s f =
@@ -197,6 +206,8 @@ module Make
 
   let discrete_lyapunov () = alco_fun "discrete_lyapunov" To_test.discrete_lyapunov
 
+  let linsolve () = alco_fun "linsolve" To_test.linsolve
+
   let test_set = [
     "sin",                      `Slow,     sin;
     "cos",                      `Slow,     cos;
@@ -222,6 +233,7 @@ module Make
     "init_2d",                  `Slow,     init_2d;
     "lyapunov",                 `Slow,     lyapunov;
     "discrete_lyapunov",        `Slow,     discrete_lyapunov;
+    "linsolve",                 `Slow,     linsolve;
   ]
 
 end


### PR DESCRIPTION
Implemented reverse-mode differentiation for `linsolve` and `lq` and relevant unit tests
`linsolve` is used to solve equations of the form `Ax = b`.