### PR TITLE
implemented solve triangular

### DIFF
--- a/src/base/types/owl_types_operator.ml
+++ b/src/base/types/owl_types_operator.ml
@@ -172,7 +172,7 @@ module type LinalgSig = sig
 
   val mpow : ('a, 'b) t -> float -> ('a, 'b) t
 
-  val linsolve : ?trans:bool -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+  val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 
 end
 

--- a/src/owl/linalg/owl_linalg_c.mli
+++ b/src/owl/linalg/owl_linalg_c.mli
@@ -89,6 +89,8 @@ val eigvals : ?permute:bool -> ?scale:bool -> mat -> mat
 
 val null : mat -> mat
 
+val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
+
 val linsolve : ?trans:bool -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt

--- a/src/owl/linalg/owl_linalg_c.mli
+++ b/src/owl/linalg/owl_linalg_c.mli
@@ -91,7 +91,7 @@ val null : mat -> mat
 
 val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
 
-val linsolve : ?trans:bool -> mat -> mat -> mat
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt
 

--- a/src/owl/linalg/owl_linalg_d.mli
+++ b/src/owl/linalg/owl_linalg_d.mli
@@ -89,6 +89,8 @@ val eigvals : ?permute:bool -> ?scale:bool -> mat -> complex_mat
 
 val null : mat -> mat
 
+val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
+
 val linsolve : ?trans:bool -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt

--- a/src/owl/linalg/owl_linalg_d.mli
+++ b/src/owl/linalg/owl_linalg_d.mli
@@ -91,7 +91,7 @@ val null : mat -> mat
 
 val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
 
-val linsolve : ?trans:bool -> mat -> mat -> mat
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt
 

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -668,7 +668,32 @@ let _get_trans_code
     | Complex64 -> 'C'
     | _         -> failwith "owl_linalg_generic:_get_trans_code"
 
-
+let triangular_solve  
+    : type c d. upper:bool -> ?trans:bool -> (c, d) t -> (c, d) t -> (c, d) t
+    = fun ~upper ?(trans=false) a b ->
+    let b = M.copy b in
+    let ma, _na = M.shape a in
+    let mb, nb = M.shape b in
+    assert (ma = mb && ma = _na);
+    let _a = M.flatten a |> Bigarray.array1_of_genarray in
+    let _b = M.flatten b |> Bigarray.array1_of_genarray in
+    let k = M.kind a in
+    let alpha = Owl_const.one k in
+    let transa = 
+      if trans then match k with
+        | Float32     -> Owl_cblas_basic.CblasTrans  
+        | Float64     -> Owl_cblas_basic.CblasTrans 
+        | Complex32   -> Owl_cblas_basic.CblasConjTrans 
+        | Complex64   -> Owl_cblas_basic.CblasConjTrans
+        | _           -> failwith "owl_linalg:triangular_solve"
+      else Owl_cblas_basic.CblasNoTrans in
+    let layout = Owl_cblas_basic.CblasRowMajor in
+    let side = Owl_cblas_basic.CblasLeft in
+    let uplo = if upper then Owl_cblas_basic.CblasUpper else Owl_cblas_basic.CblasLower in
+    let diag = Owl_cblas_basic.CblasNonUnit in
+    Owl_cblas_basic.trsm layout side uplo transa diag mb nb alpha _a ma _b nb;
+    b
+ 
 (* TODO: add opt parameter to specify the matrix properties so that we can
    choose the best solver for better performance.
 *)

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -353,6 +353,23 @@ negligible elements, ``M.col_num x`` is the nullity of ``a``, and
 
  *)
 
+val triangular_solve : upper:bool -> ?trans:bool -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+(**
+``triangular_linsolve a b -> x`` solves a linear system of equations ``a * x = b`` 
+   where ``a`` is either an upper or a lower triangular matrix. This function uses
+   cblas ``trsm`` under the hood.
+
+.. math::
+  AX = B
+
+By default, ``trans = false`` indicates no transpose. If ``trans = true``, then
+function will solve ``A^T * x = b`` for real matrices; ``A^H * x = b`` for
+complex matrices.
+
+.. math::
+  A^H X = B
+*)
+ 
 val linsolve : ?trans:bool -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``linsolve a b -> x`` solves a linear system of equations ``a * x = b`` in the

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -356,7 +356,7 @@ negligible elements, ``M.col_num x`` is the nullity of ``a``, and
 val triangular_solve : upper:bool -> ?trans:bool -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``triangular_linsolve a b -> x`` solves a linear system of equations ``a * x = b`` 
-   where ``a`` is either an upper or a lower triangular matrix. This function uses
+   where ``a`` is either a upper or a lower triangular matrix. This function uses
    cblas ``trsm`` under the hood.
 
 .. math::
@@ -370,12 +370,13 @@ complex matrices.
   A^H X = B
 *)
  
-val linsolve : ?trans:bool -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``linsolve a b -> x`` solves a linear system of equations ``a * x = b`` in the
-following form. The function uses LU factorisation with partial pivoting when
+following form. By default, ``typ=`n`` and the function use LU factorisation with partial pivoting when
 ``a`` is square and QR factorisation with column pivoting otherwise. The number
 of rows of ``a`` must equal the number of rows of ``b``.
+If ``a`` is a upper(lower) triangular matrix, the function calls the ``solve_triangular`` function when ``typ=`u``(``typ=`l``). 
 
 .. math::
   AX = B

--- a/src/owl/linalg/owl_linalg_s.mli
+++ b/src/owl/linalg/owl_linalg_s.mli
@@ -89,6 +89,8 @@ val eigvals : ?permute:bool -> ?scale:bool -> mat -> complex_mat
 
 val null : mat -> mat
 
+val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
+
 val linsolve : ?trans:bool -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt

--- a/src/owl/linalg/owl_linalg_s.mli
+++ b/src/owl/linalg/owl_linalg_s.mli
@@ -91,7 +91,7 @@ val null : mat -> mat
 
 val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
 
-val linsolve : ?trans:bool -> mat -> mat -> mat
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt
 

--- a/src/owl/linalg/owl_linalg_z.mli
+++ b/src/owl/linalg/owl_linalg_z.mli
@@ -89,6 +89,8 @@ val eigvals : ?permute:bool -> ?scale:bool -> mat -> mat
 
 val null : mat -> mat
 
+val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
+
 val linsolve : ?trans:bool -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt

--- a/src/owl/linalg/owl_linalg_z.mli
+++ b/src/owl/linalg/owl_linalg_z.mli
@@ -91,7 +91,7 @@ val null : mat -> mat
 
 val triangular_solve: upper:bool -> ?trans:bool -> mat -> mat -> mat
 
-val linsolve : ?trans:bool -> mat -> mat -> mat
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> mat -> mat -> mat
 
 val linreg : mat -> mat -> elt * elt
 


### PR DESCRIPTION
1. Added a `solve_triangular` function to the `Linalg` modules. This function efficiently solves linear equations of the form `Ax = b`, where `A` is is a triangular matrix. Under the hood, the function calls the cblas function `trsm`.  
2. Added an option to call the `solve_triangular` function to `linsolve`.  
e.g. ``linsolve ~trans ~typ:`u a b`` will call ``solve_triangular ~trans ~upper:true a b``. 