### PR TITLE
Two new features in algodiff: eye and linsolve (triangular option)

### DIFF
--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -479,7 +479,7 @@ module Make
 
   let discrete_lyapunov ?(solver=`default) _a _q = solver |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
-  let linsolve ?trans _a _b = trans |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+  let linsolve ?trans ?(typ=`n) _a _b = trans |> ignore; typ |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
   let diag ?k _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -34,6 +34,8 @@ module Make
   let ones shape =
     make_node ~shape:[|Some shape|] (Ones shape) |> node_to_arr
 
+  let eye _n = raise Owl_exception.NOT_IMPLEMENTED 
+
   let create shape v =
     make_then_connect ~shape:[|Some shape|] (Create shape) [|elt_to_node v|] |> node_to_arr
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -29,6 +29,9 @@ module type Sig = sig
   val ones : int array -> arr
   (** TODO *)
 
+  val eye : int -> arr
+  (** TODO *)
+
   val create : int array -> elt -> arr
   (** TODO *)
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -521,7 +521,7 @@ module type Sig = sig
   val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr
   (** TODO *)
 
-  val linsolve : ?trans:bool -> arr -> arr -> arr
+  val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
   (** TODO *)
 
   val diag: ?k:int -> arr -> arr

--- a/src/base/dense/owl_base_dense_ndarray_d.ml
+++ b/src/base/dense/owl_base_dense_ndarray_d.ml
@@ -29,6 +29,9 @@ let init_nd dims f = M.init_nd Float64 dims f
 let zeros dims = M.zeros Float64 dims
 
 
+let eye n = M.eye Float64 n
+
+
 let ones dims = M.ones Float64 dims
 
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -25,6 +25,8 @@ val zeros : int array -> arr
 
 val ones : int array -> arr
 
+val eye : int -> arr
+
 val create : int array -> elt -> arr
 
 val init : int array -> (int -> elt) -> arr

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -426,7 +426,7 @@ val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr
 
-val linsolve: ?trans:bool  -> arr -> arr -> arr
+val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
 val diag: ?k:int -> arr -> arr 
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -4213,7 +4213,7 @@ let lyapunov _a _q = raise Owl_exception.NOT_IMPLEMENTED
 
 let discrete_lyapunov ?(solver=`default) _a _q = solver |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
-let linsolve ?(trans=false) _a _b = trans |> ignore; raise Owl_exception.NOT_IMPLEMENTED
+let linsolve ?(trans=false) ?(typ=`n) _a _b = trans |> ignore; typ |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 
 let diag ?(k=0) _x = k |> ignore; raise Owl_exception.NOT_IMPLEMENTED
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -164,6 +164,9 @@ let ones kind dims = create kind dims (Owl_const.one kind)
 let ones_ ~out = Genarray.(fill out (Owl_const.one (kind out)))
 
 
+let eye _kind _n = raise Owl_exception.NOT_IMPLEMENTED
+
+
 let shape x = Genarray.dims x
 
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -741,7 +741,7 @@ val lyapunov : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
-val linsolve: ?trans:bool -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
 val diag: ?k:int -> (float, 'b) t -> (float, 'b) t 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -52,6 +52,9 @@ val zeros : ('a, 'b) kind -> int array -> ('a, 'b) t
 val ones : ('a, 'b) kind -> int array -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+val eye : ('a, 'b) kind -> int -> ('a, 'b) t
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
 val uniform : ('a, 'b) kind -> ?a:'a -> ?b:'a -> int array -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_s.ml
+++ b/src/base/dense/owl_base_dense_ndarray_s.ml
@@ -29,6 +29,9 @@ let init_nd dims f = M.init_nd Float32 dims f
 let zeros dims = M.zeros Float32 dims
 
 
+let eye n = M.eye Float32 n
+
+
 let ones dims = M.ones Float32 dims
 
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -426,7 +426,7 @@ val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr
 
-val linsolve: ?trans:bool  -> arr -> arr -> arr
+val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
 val diag : ?k:int -> arr -> arr
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -25,6 +25,8 @@ val zeros : int array -> arr
 
 val ones : int array -> arr
 
+val eye : int -> arr
+
 val create : int array -> elt -> arr
 
 val init : int array -> (int -> elt) -> arr

--- a/src/base/optimise/owl_algodiff_generic.ml
+++ b/src/base/optimise/owl_algodiff_generic.ml
@@ -2313,6 +2313,8 @@ module Make
 
     let zeros m n = A.zeros [|m;n|] |> pack_arr
 
+    let eye n = A.eye n |> pack_arr
+
     let ones m n = A.ones [|m;n|] |> pack_arr
 
     let uniform ?a ?b m n = A.uniform ?a ?b [|m;n|] |> pack_arr

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -98,7 +98,7 @@ module type Sig = sig
     val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val linsolve : ?trans:bool -> t -> t -> t
+    val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val neg : t -> t

--- a/src/base/optimise/owl_algodiff_generic_sig.ml
+++ b/src/base/optimise/owl_algodiff_generic_sig.ml
@@ -309,6 +309,8 @@ module type Sig = sig
 
     val zeros : int -> int -> t
 
+    val eye : int -> t
+
     val ones : int -> int -> t
 
     val uniform : ?a:A.elt -> ?b:A.elt -> int -> int -> t

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -24,6 +24,8 @@ module type Sig = sig
 
   val zeros : int array -> arr
 
+  val eye : int -> arr
+
   val ones : int array -> arr
 
   val create : int array -> elt -> arr

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -321,7 +321,7 @@ module type Sig = sig
 
   val discrete_lyapunov: ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr
 
-  val linsolve: ?trans:bool -> arr -> arr -> arr
+  val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
   val diag : ?k:int -> arr -> arr
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -37,7 +37,7 @@ module Generic = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_generic.discrete_lyapunov ~solver a q
 
-  let linsolve ?(trans=false) a b = Owl_linalg_generic.linsolve ~trans a b
+  let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_generic.linsolve ~trans ~typ a b
 
 end
 
@@ -77,7 +77,7 @@ module S = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_s.discrete_lyapunov ~solver a q
 
-  let linsolve ?(trans=false) a b = Owl_linalg_s.linsolve ~trans a b
+  let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_s.linsolve ~trans ~typ a b
 
 end
 
@@ -117,7 +117,7 @@ module D = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_d.discrete_lyapunov ~solver a q
 
-  let linsolve ?(trans=false) a b = Owl_linalg_d.linsolve ~trans a b
+  let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_d.linsolve ~trans ~typ a b
 end
 
 
@@ -147,7 +147,7 @@ module C = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_c.discrete_lyapunov ~solver a q
 
-  let linsolve ?(trans=false) a b = Owl_linalg_c.linsolve ~trans a b
+  let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_c.linsolve ~trans ~typ a b
 end
 
 
@@ -177,7 +177,7 @@ module Z = struct
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_z.discrete_lyapunov ~solver a q
 
-  let linsolve ?(trans=false) a b = Owl_linalg_z.linsolve ~trans a b
+  let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_z.linsolve ~trans ~typ a b
 end
 
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -61,6 +61,8 @@ module S = struct
 
   let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
 
+  let eye n = Owl_dense_matrix_s.eye n
+
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 
   let triu ?(k=0) x = Owl_dense_matrix_generic.triu ~k x
@@ -99,6 +101,8 @@ module D = struct
 
   let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
 
+  let eye n = Owl_dense_matrix_d.eye n
+
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 
   let triu ?(k=0) x = Owl_dense_matrix_generic.triu ~k x
@@ -127,6 +131,8 @@ module C = struct
 
   let mpow = Owl_linalg_c.mpow
 
+  let eye n = Owl_dense_matrix_c.eye n
+
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 
   let triu ?(k=0) x = Owl_dense_matrix_generic.triu ~k x
@@ -154,6 +160,8 @@ module Z = struct
   let inv = Owl_linalg_z.inv
 
   let mpow = Owl_linalg_z.mpow
+
+  let eye n = Owl_dense_matrix_z.eye n
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
 


### PR DESCRIPTION
I added two new features to the algodiff modules
1. function to create the identity matrix with `Mat.eye`
2. use `triangular_linsolve` under the hood when solving equations of the form `Ax =b`, where `A` is a triangular matrix: e.g. if `A` is upper triangular (and the relevant adjoints), one can call ``Maths.linsolve ~typ:`u`` 