### PR TITLE
Do not create .owl folder when loading owl library

### DIFF
--- a/bin/owl_bin_zoo.ml
+++ b/bin/owl_bin_zoo.ml
@@ -17,6 +17,15 @@ let main args =
   (* initialise logger *)
   Owl_log.set_color true;
   Owl_log.(set_level DEBUG);
+
+  (* initialise owl zoo working environment *)
+  (* set up owl's folder *)
+  let home = Sys.getenv "HOME" ^ "/.owl" in
+  let dir_zoo = home ^ "/zoo" in
+  (* Note: use of Sys.file_exist is racy *)
+  (try Unix.mkdir home 0o755 with Unix.Unix_error(Unix.EEXIST, _, _) -> ());
+  (try Unix.mkdir dir_zoo 0o755 with Unix.Unix_error(Unix.EEXIST, _, _) -> ());
+
   (* add zoo directive *)
   Owl_zoo_dir.add_dir_zoo ();
 

--- a/src/owl/misc/owl_dataset.ml
+++ b/src/owl/misc/owl_dataset.ml
@@ -9,12 +9,13 @@ open Owl_types
 
 let remote_data_path () = "https://github.com/ryanrhymes/owl_dataset/raw/master/"
 
-let local_data_path () =
-  let d = Sys.getenv "HOME" ^ "/.owl/dataset/" in
-  if Sys.file_exists d = false then (
-    Owl_log.info "create %s" d;
-    Unix.mkdir d 0o755;
-  );
+let local_data_path () : string =
+  let home = Sys.getenv "HOME" ^ "/.owl" in
+  let d = home ^ "/dataset" in
+  Owl_log.info "create %s if not present" d;
+  (* Note: use of Sys.file_exist is racy *)
+  (try Unix.mkdir home 0o755 with Unix. Unix_error(EEXIST, _, _) -> ());
+  (try Unix.mkdir d 0o755 with Unix. Unix_error(EEXIST, _, _) -> ());
   d
 
 let download_data fname =

--- a/src/owl/owl.ml
+++ b/src/owl/owl.ml
@@ -82,22 +82,3 @@ end
 module Mat = struct
   include Owl_dense.Matrix.D
 end
-
-
-(* initialise owl's working environment *)
-
-let _ =
-  (* set up owl's folder *)
-  let home = Sys.getenv "HOME" ^ "/.owl" in
-  let dir_dataset = home ^ "/dataset" in
-  let dir_zoo = home ^ "/zoo" in
-  if Sys.file_exists home = false then
-    Unix.mkdir home 0o755;
-  if Sys.file_exists dir_dataset = false then
-    Unix.mkdir dir_dataset 0o755;
-  if Sys.file_exists dir_zoo = false then
-    Unix.mkdir dir_zoo 0o755
-
-
-
-(* ends here *)


### PR DESCRIPTION
I believe that libraries should not come with unexpected surprises, in particular I think that the main owl library should not create files in the system and instead file creation should be triggered by the user action (like downloading something from the zoo or a dataset). The creation of .owl/dataset and .owl/zoo has been moved to the zoo cli and the Dataset.load_data_path functions instead.

This change will also allow to run tests (at least some of them) inside
the opam sandboxed envirionment. In fact this is how I found out about
this.

Note that checking the existence of a folder and then creating it is racy (imagine you are downloading something in the zoo in a terminal and getting two datasets from two different instances of utop or jupyter).

The parenthesis around the try are because ocaml was associating all the rest of the code to the with block.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>