### PR TITLE
Owl_io.marshal_to_file: use to_channel

### DIFF
--- a/src/base/misc/owl_io.ml
+++ b/src/base/misc/owl_io.ml
@@ -111,9 +111,8 @@ let mapi_lines_of_marshal f fname =
 
 (* save a marshalled object to a file *)
 let marshal_to_file x f =
-  let s = Marshal.to_string x [] in
   let h = open_out f in
-  output_string h s;
+  Marshal.to_channel h x [];
   close_out h
 
 


### PR DESCRIPTION
Should fix https://github.com/owlbarn/owl/issues/422

I have checked the uses of `Marshal`, it seems to be the only place where we use `to_string`.
Would be good to try and reproduce the issue independently of this and raise an issue for the ocaml compiler if `Marshal` is the one being wrong.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>