### PR TITLE
Fix exponential rvs

### DIFF
--- a/src/owl/stats/owl_stats_ziggurat.c
+++ b/src/owl/stats/owl_stats_ziggurat.c
@@ -54,7 +54,7 @@ inline double exponential_rvs (double lambda) {
 // init the internal state for exponential prng
 void std_exponential_rvs_init ( ) {
   double de = 7.697117470131487;
-  const double m2 = 2147483648.0;
+  const double m2 = 4294967296.0;
   double te = 7.697117470131487;
   const double ve = 3.949659822581572E-03;
 

--- a/src/owl/stats/owl_stats_ziggurat.c
+++ b/src/owl/stats/owl_stats_ziggurat.c
@@ -47,7 +47,7 @@ inline double std_exponential_rvs ( ) {
 
 
 inline double exponential_rvs (double lambda) {
-  return (lambda * std_exponential_rvs());
+  return (std_exponential_rvs() / lambda);
 }
 
 


### PR DESCRIPTION
Fixes #426  and fixes the inconsistency in the meaning of `lambda` for the exponential distribution between owl base and owl c; since it usually refers to the inverse mean, I modified zaggurat, not base.