### PR TITLE
Stats_dist: don't use balance_last for multinomial distribution (#347)

### DIFF
--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -492,11 +492,10 @@ from ``n`` trials. The probabilty mass function is as follows.
 .. math::
   P(x) = \frac{n!}{{x_1}! \cdot\cdot\cdot {x_k}!} p_{1}^{x_1} \cdot\cdot\cdot p_{k}^{x_k}
 
-``p`` is the probabilty mass of ``k`` categories. If the elements in ``p`` do
-not sum to 1, the last element of the ``p`` array is not used and is replaced
-with the remaining probability left over from the earlier elements.
+``p`` is the probabilty mass of ``k`` categories. The elements in ``p`` should
+all be positive (result is undefined in that case), but they don't need to sum
+to 1. For implementation details, refer to :cite:`davis1993computer`.
 
-For implemantation, refer to :cite:`davis1993computer`.
  *)
 
 val multinomial_pdf : int array -> p:float array -> float

--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -493,9 +493,9 @@ from ``n`` trials. The probabilty mass function is as follows.
   P(x) = \frac{n!}{{x_1}! \cdot\cdot\cdot {x_k}!} p_{1}^{x_1} \cdot\cdot\cdot p_{k}^{x_k}
 
 ``p`` is the probabilty mass of ``k`` categories. The elements in ``p`` should
-all be positive (result is undefined in that case), but they don't need to sum
-to 1. For implementation details, refer to :cite:`davis1993computer`.
-
+all be positive (result is undefined if there are negative values), but they 
+don't need to sum to 1: the result is the same whether or not ``p`` is normalized. 
+For implementation details, refer to :cite:`davis1993computer`.
  *)
 
 val multinomial_pdf : int array -> p:float array -> float

--- a/src/owl/stats/owl_stats_dist.ml
+++ b/src/owl/stats/owl_stats_dist.ml
@@ -378,8 +378,7 @@ let multinomial_rvs n ~p =
   let k = Array.length p in
   let _p = Genarray.create float64 c_layout [|k|] in
   let _s = Genarray.create int32 c_layout [|k|] in
-  Owl_utils.Array.balance_last 1. p |>
-  Array.iteri (fun i a -> Genarray.set _p [|i|] a);
+  Array.iteri (fun i a -> Genarray.set _p [|i|] a) p;
   _multinomial_rvs ~k ~n ~p:_p _s;
   Array.init k (fun i -> Genarray.get _s [|i|] |> Int32.to_int)
 
@@ -390,8 +389,7 @@ let multinomial_pdf x ~p =
   assert (k = Array.length p);
   let _p = Genarray.create float64 c_layout [|k|] in
   let _s = Genarray.create int32 c_layout [|k|] in
-  Owl_utils.Array.balance_last 1. p |>
-  Array.iteri (fun i a -> Genarray.set _p [|i|] a);
+  Array.iteri (fun i a -> Genarray.set _p [|i|] a) p;
   Array.iteri (fun i a -> Genarray.set _s [|i|] (Int32.of_int a)) x;
   _multinomial_pdf ~k ~p:_p _s
 
@@ -402,8 +400,7 @@ let multinomial_logpdf x ~p =
   assert (k = Array.length p);
   let _p = Genarray.create float64 c_layout [|k|] in
   let _s = Genarray.create int32 c_layout [|k|] in
-  Owl_utils.Array.balance_last 1. p |>
-  Array.iteri (fun i a -> Genarray.set _p [|i|] a);
+  Array.iteri (fun i a -> Genarray.set _p [|i|] a) p;
   Array.iteri (fun i a -> Genarray.set _s [|i|] (Int32.of_int a)) x;
   _multinomial_logpdf ~k ~p:_p _s
 


### PR DESCRIPTION
As described in #347, balance_last raises exceptions in case where
numerical inaccuracy prevent summation to 1 of input
probabilities. The comments there argue that not only the
transformation performed by balance_last, but is also not really
necessary. See notably this comment:

As I see it, owl's current implementation is very close to the one in
the GSL. It computes the sum of input probabilities (norm variable),
and it seems to me that it doesn't matter that these sum to 1. Playing
with gsl confirms it:

```ocaml
# Gsl.Randist.multinomial rng ~n:100000 ~p:[|1. ; 2.|];;
- : int array = [|33251; 66749|]
```

This seems very natural to me, and much less confusing and error prone
than ignoring the last element of the probability vector.

So in summary, it would be enough to remove the call to balance_last
in multinomial_rvs:

```ocaml
let multinomial_rvs n ~p =
  let k = Array.length p in
  let _p = Genarray.create float64 c_layout [|k|] in
  let _s = Genarray.create int32 c_layout [|k|] in
  Owl_utils.Array.balance_last 1. p |>
  Array.iteri (fun i a -> Genarray.set _p [|i|] a);
  _multinomial_rvs ~k ~n ~p:_p _s;
  Array.init k (fun i -> Genarray.get _s [|i|] |> Int32.to_int)
```
The same is true IMO for the pdf:
```ocaml
# Gsl.Randist.multinomial_pdf ~n:[|3;6|] ~p:[|1. ; 2.|];;
- : float = 0.273129096174363206
# Gsl.Randist.multinomial_pdf ~n:[|3;6|] ~p:[|0.333333333333333 ; 0.6666666666666|];;
- : float = 0.273129096174363706
```
