### PR TITLE
expose expand and squeeze in ndarray type

### DIFF
--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -135,6 +135,10 @@ module Make
     in
     make_then_connect (Pad (v, padding)) [|arr_to_node x|] |> node_to_arr
 
+  let expand ?(hi=false) _x _d = ignore hi; failwith "expand: not implemented" 
+
+  let squeeze ?(axis=[||]) _x = ignore axis; failwith "squeeze: not implemented"
+   
   let concatenate ?(axis=0) xs =
     make_then_connect (Concatenate axis) (Array.map arr_to_node xs) |> node_to_arr
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -95,6 +95,12 @@ module type Sig = sig
   val pad : ?v:elt -> int list list -> arr -> arr
   (** TODO *)
 
+  val expand : ?hi:bool -> arr -> int -> arr
+  (** TODO *)
+
+  val squeeze : ?axis:int array -> arr -> arr
+  (** TODO *)
+   
   val concatenate : ?axis:int -> arr array -> arr
   (** TODO *)
 

--- a/src/base/dense/owl_base_dense_ndarray_c.mli
+++ b/src/base/dense/owl_base_dense_ndarray_c.mli
@@ -75,6 +75,10 @@ val repeat : arr -> int array -> arr
 
 val concatenate : ?axis:int -> arr array -> arr
 
+val squeeze : ?axis:int array -> arr -> arr
+
+val expand : ?hi:bool -> arr -> int -> arr
+
 val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -77,6 +77,10 @@ val repeat : arr -> int array -> arr
 
 val concatenate : ?axis:int -> arr array -> arr
 
+val squeeze : ?axis:int array -> arr -> arr
+
+val expand : ?hi:bool -> arr -> int -> arr
+
 val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -597,6 +597,27 @@ let split ?(axis=0) parts varr =
   in
   (Array.map (fun def -> get_slice def varr) slices_defs)
 
+let squeeze ?(axis=[||]) x =
+  let a = match Array.length axis with
+    | 0 -> Array.init (num_dims x) (fun i -> i)
+    | _ -> axis
+  in
+  let s = Owl_utils.Array.filteri (fun i v ->
+    not (v == 1 && Array.mem i a)
+  ) (shape x)
+  in
+  reshape x s
+
+let expand ?(hi=false) x d =
+  let d0 = d - (num_dims x) in
+  match d0 > 0 with
+  | true  -> (
+      if hi = true then
+        Owl_utils.Array.pad `Right 1 d0 (shape x) |> reshape x
+      else
+        Owl_utils.Array.pad `Left 1 d0 (shape x) |> reshape x
+    )
+  | false -> x
 
 (* TODO : ensure this is desired behaviour *)
 (* Similar to draw rows for matrices *)

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -142,6 +142,12 @@ val pad : ?v:'a -> int list list -> ('a, 'b) t -> ('a, 'b) t
 val concatenate : ?axis:int -> ('a, 'b) t array -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+val squeeze : ?axis:int array -> ('a, 'b) t -> ('a, 'b) t
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+val expand : ?hi:bool -> ('a, 'b) t -> int -> ('a, 'b) t
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
 val split : ?axis:int -> int array -> ('a, 'b) t -> ('a, 'b) t array
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -77,6 +77,10 @@ val repeat : arr -> int array -> arr
 
 val concatenate : ?axis:int -> arr array -> arr
 
+val squeeze : ?axis:int array -> arr -> arr
+
+val expand : ?hi:bool -> arr -> int -> arr
+
 val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array

--- a/src/base/dense/owl_base_dense_ndarray_z.mli
+++ b/src/base/dense/owl_base_dense_ndarray_z.mli
@@ -75,6 +75,10 @@ val repeat : arr -> int array -> arr
 
 val concatenate : ?axis:int -> arr array -> arr
 
+val squeeze : ?axis:int array -> arr -> arr
+
+val expand : ?hi:bool -> arr -> int -> arr
+
 val split : ?axis:int -> int array -> arr -> arr array
 
 val draw : ?axis:int -> arr -> int -> arr * int array

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -72,6 +72,10 @@ module type Sig = sig
 
   val split : ?axis:int -> int array -> arr -> arr array
 
+  val expand : ?hi:bool -> arr -> int -> arr
+
+  val squeeze : ?axis:int array -> arr -> arr
+
   val draw : ?axis:int -> arr -> int -> arr * int array
 
   val map : (elt -> elt) -> arr -> arr


### PR DESCRIPTION
This will be useful for writing functors that take input module type `Owl_types_ndarray_algodiff.Sig`.