### PR TITLE
Do not call plsfnam if output filename is empty

### DIFF
--- a/src/plplot/owl_plot.ml
+++ b/src/plplot/owl_plot.ml
@@ -319,7 +319,8 @@ let _supported_device = [
 let _set_device h =
   try let x = Owl_utils.get_suffix h.output in
     Plplot.plsdev x;
-    Plplot.plsfnam h.output;
+    if String.length h.output = 0 then () else
+      Plplot.plsfnam h.output;
   with _exn -> ()
 
 


### PR DESCRIPTION
Hi.
This patch will fix the following problem.
(Please review carefully because I'm new to this library as well as to OCaml ;)

### problem
Functions of the plot module could cause crashes.
This can be reproduced e.g. by just using `plot_fun` as in the [tutorial](https://github.com/owlbarn/owl/wiki/Tutorial:-How-to-Plot-in-Owl%3F).
```OCaml
Plot.plot_fun Maths.sin 1. 3.14;;
```
With no output filename specified, PLplot asks the output device first, and then the filename.
In my environment without this patch, the program crashes just after entering the device number.
The output looks like below.
```
Plotting Options:
 < 1> ps         PostScript File (monochrome)
... 
 <22> svgcairo   Cairo SVG Driver
 <23> pngcairo   Cairo PNG Driver
...

Enter device number or keyword: 23
Can't open .
...
Can't open .

*** PLPLOT ERROR, IMMEDIATE EXIT ***
Too many tries.
Program aborted
```
### environment
FYI, I can repro the problem on
- Ubuntu 18.04
- libplplot 5.13.0 (from apt repository)
- OCaml 4.08.1
- opam 2.0.5
- owl 0.6.0 (from opam)