### PR TITLE
Expose Eigen's Direct and Iterative Sparse System Solvers

### DIFF
--- a/src/owl/dune
+++ b/src/owl/dune
@@ -185,7 +185,7 @@
  (flags
   :standard
   (:include ocaml_flags.sexp))
- (libraries core ctypes ctypes.stubs eigen owl-base stdlib-shims))
+ (libraries ctypes ctypes.stubs eigen owl-base stdlib-shims))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp ocaml_flags.sexp

--- a/src/owl/dune
+++ b/src/owl/dune
@@ -185,7 +185,7 @@
  (flags
   :standard
   (:include ocaml_flags.sexp))
- (libraries ctypes ctypes.stubs eigen owl-base stdlib-shims))
+ (libraries core ctypes ctypes.stubs eigen owl-base stdlib-shims))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp ocaml_flags.sexp

--- a/src/owl/sparse/owl_sparse_common.ml
+++ b/src/owl/sparse/owl_sparse_common.ml
@@ -363,79 +363,79 @@ let _eigen_neg : type a b . (a, b) eigen_mat -> (a, b) eigen_mat =
 let _eigen_sparse_LU : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_LU a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_LU a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_LU a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_LU a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_LU a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_LU a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_LU a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_LU a b)
 
 let _eigen_sparse_QR : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_QR a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_QR a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_QR a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_QR a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_QR a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_QR a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_QR a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_QR a b)
 
 let _eigen_simplicial_LLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LLT a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LLT a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LLT a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LLT a b)
 
 let _eigen_simplicial_LDLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LDLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LDLT a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LDLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LDLT a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LDLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LDLT a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LDLT a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LDLT a b)
 
 let _eigen_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.conjugate_gradient a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.conjugate_gradient a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.conjugate_gradient a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.conjugate_gradient a b)
 
 let _eigen_least_squares_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.least_squares_conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.least_squares_conjugate_gradient a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.least_squares_conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.least_squares_conjugate_gradient a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.least_squares_conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.least_squares_conjugate_gradient a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.least_squares_conjugate_gradient a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.least_squares_conjugate_gradient a b)
 
 let _eigen_BiCGSTAB : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.biCGSTAB a b)
+      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.biCGSTAB a b)
     | SPMAT_D a, SPMAT_D b ->
-      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.biCGSTAB a b)
+      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.biCGSTAB a b)
     | SPMAT_C a, SPMAT_C b ->
-      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.biCGSTAB a b)
+      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.biCGSTAB a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.biCGSTAB a b)
+      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.biCGSTAB a b)
 
 
 (* ends here *)

--- a/src/owl/sparse/owl_sparse_common.ml
+++ b/src/owl/sparse/owl_sparse_common.ml
@@ -360,82 +360,86 @@ let _eigen_neg : type a b . (a, b) eigen_mat -> (a, b) eigen_mat =
   | SPMAT_C x -> SPMAT_C (Eigen.Sparse.C.neg x)
   | SPMAT_Z x -> SPMAT_Z (Eigen.Sparse.Z.neg x)
 
+let option_map ~f = function
+  | None   -> None
+  | Some v -> Some (f v)
+
 let _eigen_sparse_LU : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_LU a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_LU a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_LU a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_LU a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_LU a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_LU a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_LU a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_LU a b)
 
 let _eigen_sparse_QR : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_QR a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_QR a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_QR a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_QR a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_QR a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_QR a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_QR a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_QR a b)
 
 let _eigen_simplicial_LLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LLT a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LLT a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LLT a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LLT a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LLT a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LLT a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LLT a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LLT a b)
 
 let _eigen_simplicial_LDLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LDLT a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LDLT a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LDLT a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LDLT a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LDLT a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LDLT a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LDLT a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LDLT a b)
 
 let _eigen_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.conjugate_gradient a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.conjugate_gradient a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.conjugate_gradient a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.conjugate_gradient a b)
 
 let _eigen_least_squares_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.least_squares_conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.least_squares_conjugate_gradient a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.least_squares_conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.least_squares_conjugate_gradient a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.least_squares_conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.least_squares_conjugate_gradient a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.least_squares_conjugate_gradient a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.least_squares_conjugate_gradient a b)
 
 let _eigen_BiCGSTAB : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
   fun a b -> match a, b with
     | SPMAT_S a, SPMAT_S b ->
-      Core.Option.map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.biCGSTAB a b)
+      option_map ~f:(fun v -> SPMAT_S v) (Eigen.Sparse.S.biCGSTAB a b)
     | SPMAT_D a, SPMAT_D b ->
-      Core.Option.map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.biCGSTAB a b)
+      option_map ~f:(fun v -> SPMAT_D v) (Eigen.Sparse.D.biCGSTAB a b)
     | SPMAT_C a, SPMAT_C b ->
-      Core.Option.map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.biCGSTAB a b)
+      option_map ~f:(fun v -> SPMAT_C v) (Eigen.Sparse.C.biCGSTAB a b)
     | SPMAT_Z a, SPMAT_Z b ->
-      Core.Option.map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.biCGSTAB a b)
+      option_map ~f:(fun v -> SPMAT_Z v) (Eigen.Sparse.Z.biCGSTAB a b)
 
 
 (* ends here *)

--- a/src/owl/sparse/owl_sparse_common.ml
+++ b/src/owl/sparse/owl_sparse_common.ml
@@ -106,6 +106,20 @@ let _eigen_col : type a b . (a, b) eigen_mat -> int -> (a, b) eigen_mat =
   | SPMAT_C x -> SPMAT_C (Eigen.Sparse.C.col x j)
   | SPMAT_Z x -> SPMAT_Z (Eigen.Sparse.Z.col x j)
 
+let _eigen_rows : type a b . (a, b) eigen_mat -> int =
+  function
+  | SPMAT_S x -> Eigen.Sparse.S.rows x
+  | SPMAT_D x -> Eigen.Sparse.D.rows x
+  | SPMAT_C x -> Eigen.Sparse.C.rows x
+  | SPMAT_Z x -> Eigen.Sparse.Z.rows x
+
+let _eigen_cols : type a b . (a, b) eigen_mat -> int  =
+  function
+  | SPMAT_S x -> Eigen.Sparse.S.cols x
+  | SPMAT_D x -> Eigen.Sparse.D.cols x
+  | SPMAT_C x -> Eigen.Sparse.C.cols x
+  | SPMAT_Z x -> Eigen.Sparse.Z.cols x
+
 let _eigen_is_compressed : type a b . (a, b) eigen_mat -> bool =
   fun x -> match x with
   | SPMAT_S x -> Eigen.Sparse.S.is_compressed x
@@ -346,6 +360,82 @@ let _eigen_neg : type a b . (a, b) eigen_mat -> (a, b) eigen_mat =
   | SPMAT_C x -> SPMAT_C (Eigen.Sparse.C.neg x)
   | SPMAT_Z x -> SPMAT_Z (Eigen.Sparse.Z.neg x)
 
+let _eigen_sparse_LU : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_LU a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_LU a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_LU a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_LU a b)
+
+let _eigen_sparse_QR : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.sparse_QR a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.sparse_QR a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.sparse_QR a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.sparse_QR a b)
+
+let _eigen_simplicial_LLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LLT a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LLT a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LLT a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LLT a b)
+
+let _eigen_simplicial_LDLT : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.simplicial_LDLT a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.simplicial_LDLT a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.simplicial_LDLT a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.simplicial_LDLT a b)
+
+let _eigen_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.conjugate_gradient a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.conjugate_gradient a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.conjugate_gradient a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.conjugate_gradient a b)
+
+let _eigen_least_squares_conjugate_gradient : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.least_squares_conjugate_gradient a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.least_squares_conjugate_gradient a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.least_squares_conjugate_gradient a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.least_squares_conjugate_gradient a b)
+
+let _eigen_BiCGSTAB : type a b . (a, b) eigen_mat -> (a, b) eigen_mat -> (a, b) eigen_mat option =
+  fun a b -> match a, b with
+    | SPMAT_S a, SPMAT_S b ->
+      Option.map (fun v -> SPMAT_S v) (Eigen.Sparse.S.biCGSTAB a b)
+    | SPMAT_D a, SPMAT_D b ->
+      Option.map (fun v -> SPMAT_D v) (Eigen.Sparse.D.biCGSTAB a b)
+    | SPMAT_C a, SPMAT_C b ->
+      Option.map (fun v -> SPMAT_C v) (Eigen.Sparse.C.biCGSTAB a b)
+    | SPMAT_Z a, SPMAT_Z b ->
+      Option.map (fun v -> SPMAT_Z v) (Eigen.Sparse.Z.biCGSTAB a b)
 
 
 (* ends here *)

--- a/src/owl/sparse/owl_sparse_matrix_c.mli
+++ b/src/owl/sparse/owl_sparse_matrix_c.mli
@@ -272,3 +272,19 @@ val scalar_div : elt -> mat -> mat
 val power_scalar : mat -> elt -> mat
 
 val mpow : mat -> float -> mat
+
+
+(** {6 Direct and Iterative Sparse Linear System Solvers *)
+val sparse_LU : mat -> mat -> mat option
+
+val sparse_QR : mat -> mat -> mat option
+
+val simplicial_LLT : mat -> mat -> mat option
+
+val simplicial_LDLT : mat -> mat -> mat option
+
+val conjugate_gradient : mat -> mat -> mat option
+
+val least_squares_conjugate_gradient : mat -> mat -> mat option
+
+val biCGSTAB : mat -> mat -> mat option

--- a/src/owl/sparse/owl_sparse_matrix_d.mli
+++ b/src/owl/sparse/owl_sparse_matrix_d.mli
@@ -282,3 +282,19 @@ val scalar_div : elt -> mat -> mat
 val power_scalar : mat -> elt -> mat
 
 val mpow : mat -> float -> mat
+
+
+(** {6 Direct and Iterative Sparse Linear System Solvers *)
+val sparse_LU : mat -> mat -> mat option
+
+val sparse_QR : mat -> mat -> mat option
+
+val simplicial_LLT : mat -> mat -> mat option
+
+val simplicial_LDLT : mat -> mat -> mat option
+
+val conjugate_gradient : mat -> mat -> mat option
+
+val least_squares_conjugate_gradient : mat -> mat -> mat option
+
+val biCGSTAB : mat -> mat -> mat option

--- a/src/owl/sparse/owl_sparse_matrix_generic.ml
+++ b/src/owl/sparse/owl_sparse_matrix_generic.ml
@@ -67,8 +67,8 @@ let copy x = {
 }
 
 let transpose x = {
-  m = x.m;
-  n = x.n;
+  m = x.n;
+  n = x.m;
   k = x.k;
   d = _eigen_transpose x.d;
 }
@@ -608,3 +608,66 @@ let concat_horizontal _x _y =
   failwith "owl_sparse_matrix_generic:concat_horizontal:not implemented"
 
 let mpow _x _a = failwith "owl_sparse_matrix_generic:mpow:not implemented"
+
+let sparse_LU a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_sparse_LU a.d b.d)
+
+let sparse_QR a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_sparse_QR a.d b.d)
+
+let simplicial_LLT a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_simplicial_LLT a.d b.d)
+
+let simplicial_LDLT a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_simplicial_LDLT a.d b.d)
+
+let conjugate_gradient a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_conjugate_gradient a.d b.d)
+
+let least_squares_conjugate_gradient a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_least_squares_conjugate_gradient a.d b.d)
+
+let biCGSTAB a b =
+  Option.map (fun d ->
+    { m = _eigen_rows d
+    ; n = _eigen_cols d
+    ; k = a.k
+    ; d
+    })
+    (_eigen_BiCGSTAB a.d b.d)

--- a/src/owl/sparse/owl_sparse_matrix_generic.ml
+++ b/src/owl/sparse/owl_sparse_matrix_generic.ml
@@ -610,7 +610,7 @@ let concat_horizontal _x _y =
 let mpow _x _a = failwith "owl_sparse_matrix_generic:mpow:not implemented"
 
 let sparse_LU a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -619,7 +619,7 @@ let sparse_LU a b =
     (_eigen_sparse_LU a.d b.d)
 
 let sparse_QR a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -628,7 +628,7 @@ let sparse_QR a b =
     (_eigen_sparse_QR a.d b.d)
 
 let simplicial_LLT a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -637,7 +637,7 @@ let simplicial_LLT a b =
     (_eigen_simplicial_LLT a.d b.d)
 
 let simplicial_LDLT a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -646,7 +646,7 @@ let simplicial_LDLT a b =
     (_eigen_simplicial_LDLT a.d b.d)
 
 let conjugate_gradient a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -655,7 +655,7 @@ let conjugate_gradient a b =
     (_eigen_conjugate_gradient a.d b.d)
 
 let least_squares_conjugate_gradient a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -664,7 +664,7 @@ let least_squares_conjugate_gradient a b =
     (_eigen_least_squares_conjugate_gradient a.d b.d)
 
 let biCGSTAB a b =
-  Option.map (fun d ->
+  Core.Option.map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k

--- a/src/owl/sparse/owl_sparse_matrix_generic.ml
+++ b/src/owl/sparse/owl_sparse_matrix_generic.ml
@@ -610,7 +610,7 @@ let concat_horizontal _x _y =
 let mpow _x _a = failwith "owl_sparse_matrix_generic:mpow:not implemented"
 
 let sparse_LU a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -619,7 +619,7 @@ let sparse_LU a b =
     (_eigen_sparse_LU a.d b.d)
 
 let sparse_QR a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -628,7 +628,7 @@ let sparse_QR a b =
     (_eigen_sparse_QR a.d b.d)
 
 let simplicial_LLT a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -637,7 +637,7 @@ let simplicial_LLT a b =
     (_eigen_simplicial_LLT a.d b.d)
 
 let simplicial_LDLT a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -646,7 +646,7 @@ let simplicial_LDLT a b =
     (_eigen_simplicial_LDLT a.d b.d)
 
 let conjugate_gradient a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -655,7 +655,7 @@ let conjugate_gradient a b =
     (_eigen_conjugate_gradient a.d b.d)
 
 let least_squares_conjugate_gradient a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k
@@ -664,7 +664,7 @@ let least_squares_conjugate_gradient a b =
     (_eigen_least_squares_conjugate_gradient a.d b.d)
 
 let biCGSTAB a b =
-  Core.Option.map ~f:(fun d ->
+  option_map ~f:(fun d ->
     { m = _eigen_rows d
     ; n = _eigen_cols d
     ; k = a.k

--- a/src/owl/sparse/owl_sparse_matrix_generic.mli
+++ b/src/owl/sparse/owl_sparse_matrix_generic.mli
@@ -715,5 +715,39 @@ val power_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 val mpow : ('a, 'b) t -> float -> ('a, 'b) t
 (** TODO: not implemented, just a place holder. *)
 
+val sparse_LU : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``sparse_LU a b`` solves the linear system a * x = b using eigen's LU method
+*)
+
+val sparse_QR : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``sparse_QR a b`` solves the linear system a * x = b using eigen's QR method
+*)
+
+val simplicial_LLT : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``simplicial_LLT a b`` solves the linear system a * x = b using eigen's simplicial LLT method
+*)
+
+val simplicial_LDLT : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``simplicial_LDLT a b`` solves the linear system a * x = b using eigen's simplicial LDLT method
+*)
+
+val conjugate_gradient : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``conjugate_gradient a b`` solves the linear system a * x = b using eigen's conjugate gradient method
+*)
+
+val least_squares_conjugate_gradient : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``least_squares_conjugate_gradient a b`` solves the linear system a * x = b using eigen's least squares conjugate gradient method
+*)
+
+val biCGSTAB : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t option
+(**
+``biCGSTAB a b`` solves the linear system a * x = b using eigen's BiCGSTAB method
+*)
 
 (** ends here *)

--- a/src/owl/sparse/owl_sparse_matrix_s.mli
+++ b/src/owl/sparse/owl_sparse_matrix_s.mli
@@ -282,3 +282,19 @@ val scalar_div : elt -> mat -> mat
 val power_scalar : mat -> elt -> mat
 
 val mpow : mat -> float -> mat
+
+
+(** {6 Direct and Iterative Sparse Linear System Solvers *)
+val sparse_LU : mat -> mat -> mat option
+
+val sparse_QR : mat -> mat -> mat option
+
+val simplicial_LLT : mat -> mat -> mat option
+
+val simplicial_LDLT : mat -> mat -> mat option
+
+val conjugate_gradient : mat -> mat -> mat option
+
+val least_squares_conjugate_gradient : mat -> mat -> mat option
+
+val biCGSTAB : mat -> mat -> mat option

--- a/src/owl/sparse/owl_sparse_matrix_z.mli
+++ b/src/owl/sparse/owl_sparse_matrix_z.mli
@@ -272,3 +272,19 @@ val scalar_div : elt -> mat -> mat
 val power_scalar : mat -> elt -> mat
 
 val mpow : mat -> float -> mat
+
+
+(** {6 Direct and Iterative Sparse Linear System Solvers *)
+val sparse_LU : mat -> mat -> mat option
+
+val sparse_QR : mat -> mat -> mat option
+
+val simplicial_LLT : mat -> mat -> mat option
+
+val simplicial_LDLT : mat -> mat -> mat option
+
+val conjugate_gradient : mat -> mat -> mat option
+
+val least_squares_conjugate_gradient : mat -> mat -> mat option
+
+val biCGSTAB : mat -> mat -> mat option


### PR DESCRIPTION
See the [eigen] pull request for a comment about efficiency.

I added a dependency on Core for access to the Option module. If you would prefer to remove that and use pattern matching or a home-spun Option.map, that is also fine.

I also exposed eigen's rows() and cols() for convenience and as a defensive measure when setting the .m and .n properties of the solution matrices.

I did find one bug in the transpose() function, the dimensions were not being set correctly.