### PR TITLE
function to build aiso operations + algodiff gradients for CARE

### DIFF
--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1515,9 +1515,9 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
               let dr_b a _b _cp ca = _linsolve_backward_b trans typ a !ca
             end : Piso))
 
-
     and linsolve ?(trans = false) ?(typ = `n) = Lazy.force _linsolve ~trans ~typ
-    and care _a _b _q _r = failwith "ignore"
+
+    and care _a _b _q _r = failwith "notimplemented"
   end
 
   (* neural network module: for specialised neural network operations *)

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1517,6 +1517,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
     and linsolve ?(trans = false) ?(typ = `n) = Lazy.force _linsolve ~trans ~typ
+    and care _a _b _q _r = failwith "ignore"
   end
 
   (* neural network module: for specialised neural network operations *)

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1521,74 +1521,93 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     and _care =
       lazy
         (let unpack a = a.(0), a.(1), a.(2), a.(3) in
-         let care_forward p a b r at bt qt rt =
+         let care_forward ~diag_r p a b r at bt qt rt =
            let tr_b = transpose b in
-           let inv_r = inv r in
-           let atilde = a - (b *@ inv_r *@ tr_b *@ p) in
+           let r = if diag_r then diag r else r in
+           let inv_r = if diag_r then pack_flt 1. / r else inv r in
+           let atilde =
+             if diag_r
+             then a - (b * inv_r *@ tr_b *@ p)
+             else a - (b *@ inv_r *@ tr_b *@ p)
+           in
            let tr_atilde = transpose atilde in
-           let da () =
+           let dp_da () =
              let pat = p *@ at in
              lyapunov tr_atilde (neg (transpose pat) - pat)
            in
-           let dq () = lyapunov tr_atilde (neg qt) in
-           let dr () =
-             let pbinv_r = p *@ b *@ inv_r in
+           let dp_dq () = lyapunov tr_atilde (neg qt) in
+           let dp_dr () =
+             let pbinv_r = if diag_r then p *@ (b * inv_r) else p *@ b *@ inv_r in
              lyapunov tr_atilde (neg (pbinv_r *@ rt *@ transpose pbinv_r))
            in
-           let db () =
-             let x = p *@ bt *@ inv_r *@ tr_b *@ p in
+           let dp_db () =
+             let x =
+               if diag_r
+               then p *@ (bt * inv_r) *@ tr_b *@ p
+               else p *@ bt *@ inv_r *@ tr_b *@ p
+             in
              lyapunov tr_atilde (x + transpose x)
            in
-           [| da; db; dq; dr |]
+           [| dp_da; dp_db; dp_dq; dp_dr |]
          in
-         let care_backward a b q r p pbar =
+         let care_backward ~diag_r a b q r p pbar =
            let tr_b = transpose b in
-           let inv_r = inv r in
-           let atilde = a - (b *@ inv_r *@ tr_b *@ p) in
+           let inv_r = if diag_r then pack_flt 1. / diag r else inv r in
+           let atilde =
+             if diag_r
+             then a - (b * inv_r *@ tr_b *@ p)
+             else a - (b *@ inv_r *@ tr_b *@ p)
+           in
            let s = lyapunov atilde (neg pbar) in
            (* the following calculations are not calculated unless needed *)
            let qbar () = s in
            let rbar () =
-             let pbinv_r = p *@ b *@ inv_r in
+             let pbinv_r = if diag_r then p *@ (b * inv_r) else p *@ b *@ inv_r in
              transpose pbinv_r *@ s *@ pbinv_r
            in
            let abar () = pack_flt 2. * p *@ s in
-           let bbar () = neg (pack_flt 2.) * p *@ s *@ p *@ b *@ inv_r in
+           let bbar () =
+             if diag_r
+             then neg (pack_flt 2.) * p *@ s *@ p *@ (b * inv_r)
+             else neg (pack_flt 2.) * p *@ s *@ p *@ b *@ inv_r
+           in
            [| abar, a; bbar, b; qbar, q; rbar, r |]
          in
-         build_aiso
-           (module struct
-             let label = "care"
+         fun ~diag_r ->
+           build_aiso
+             (module struct
+               let label = "care"
 
-             let ff a =
-               match unpack a with
-               | Arr a, Arr b, Arr q, Arr r -> A.care a b q r |> pack_arr
-               | _                                  -> error_uniop "care" a.(0)
-
-
-             let df idxs p inp tangents =
-               let a, b, _, r = unpack inp in
-               let at, bt, qt, rt = unpack tangents in
-               let dp = care_forward p a b r at bt qt rt in
-               Array.map (fun k -> dp.(k) ()) idxs |> Array.fold_left ( + ) (pack_flt 0.)
+               let ff a =
+                 match unpack a with
+                 | Arr a, Arr b, Arr q, Arr r -> A.care ~diag_r a b q r |> pack_arr
+                 | _                                  -> error_uniop "care" a.(0)
 
 
-             let dr idxs inp p pbar_ref =
-               let pbar = !pbar_ref in
-               let bars =
-                 let a, b, q, r = unpack inp in
-                 care_backward a b q r p pbar
-               in
-               Array.map
-                 (fun k ->
-                   let bar, x = bars.(k) in
-                   bar (), x)
-                 idxs
-               |> Array.to_list
-           end : Aiso))
+               let df idxs p inp tangents =
+                 let a, b, _, r = unpack inp in
+                 let at, bt, qt, rt = unpack tangents in
+                 let dp = care_forward ~diag_r p a b r at bt qt rt in
+                 Array.map (fun k -> dp.(k) ()) idxs
+                 |> Array.fold_left ( + ) (pack_flt 0.)
 
 
-    and care a b q r = Lazy.force _care [| a; b; q; r |]
+               let dr idxs inp p pbar_ref =
+                 let pbar = !pbar_ref in
+                 let bars =
+                   let a, b, q, r = unpack inp in
+                   care_backward ~diag_r a b q r p pbar
+                 in
+                 Array.map
+                   (fun k ->
+                     let bar, x = bars.(k) in
+                     bar (), x)
+                   idxs
+                 |> Array.to_list
+             end : Aiso))
+
+
+    and care ?(diag_r = false) a b q r = Lazy.force _care ~diag_r [| a; b; q; r |]
   end
 
   (* neural network module: for specialised neural network operations *)

--- a/src/base/algodiff/owl_algodiff_ops_builder.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder.ml
@@ -16,7 +16,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
   (* single input pair outputs operation *)
-  and op_sipo ~ff ~fd ~df ~r a =
+  let op_sipo ~ff ~fd ~df ~r a =
     match a with
     | DF (ap, at, ai)         ->
       let cp1, cp2 = fd ap in
@@ -49,7 +49,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
   (* single input three outputs operation *)
-  and op_sito ~ff ~fd ~df ~r a =
+  let op_sito ~ff ~fd ~df ~r a =
     match a with
     | DF (ap, at, ai)         ->
       let cp1, cp2, cp3 = fd ap in
@@ -88,7 +88,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
   (* single input array outputs operation *)
-  and op_siao ~ff ~fd ~df ~r a =
+  let op_siao ~ff ~fd ~df ~r a =
     match a with
     | DF (ap, at, ai)         ->
       let cp_arr = fd ap in
@@ -107,7 +107,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
   (* pair input single output operation *)
-  and op_piso ~ff ~fd ~df_da ~df_db ~df_dab ~r_d_d ~r_d_c ~r_c_d a b =
+  let op_piso ~ff ~fd ~df_da ~df_db ~df_dab ~r_d_d ~r_d_c ~r_c_d a b =
     match a, b with
     | F _ap, DF (bp, bt, bi)                           ->
       let cp = fd a bp in
@@ -347,4 +347,85 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
         b
     in
     f
+
+
+  module type Aiso = sig
+    val label : string
+    val ff : t array -> t
+    val df : int array -> t -> t array -> t array -> t
+    val dr : int array -> t array -> t -> t ref -> (t * t) list
+  end
+
+  let build_aiso =
+    let build_info =
+      Array.fold_left
+        (fun (i, t, m, idxs) x ->
+          match m, x with
+          | _, F _ | _, Arr _ -> succ i, t, m, idxs
+          | `n, DR (_, _, _, _, t', _) -> succ i, t', `r, [ i ]
+          | `f, DR (_, _, _, _, t', _) ->
+            if t' > t
+            then succ i, t', `r, []
+            else if t' = t
+            then failwith "clash"
+            else succ i, t, `f, idxs
+          | `r, DR (_, _, _, _, t', _) ->
+            if t' > t
+            then succ i, t', `r, []
+            else if t' = t
+            then succ i, t', `r, i :: idxs
+            else succ i, t, m, idxs
+          | `n, DF (_, _, t') -> succ i, t', `f, [ i ]
+          | `f, DF (_, _, t') ->
+            if t' > t
+            then succ i, t', `f, []
+            else if t' = t
+            then succ i, t', `f, i :: idxs
+            else succ i, t, `f, idxs
+          | `r, DF (_, _, t') ->
+            if t' > t
+            then succ i, t', `f, []
+            else if t' = t
+            then failwith "clash"
+            else succ i, t, `r, idxs
+          | _ -> assert false)
+        (0, -10000, `n, [])
+    in
+    fun (module S : Aiso) ->
+      let rec f a =
+        let _, t, mode, idxs = build_info a in
+        match mode with
+        | `n -> S.ff a
+        | `f ->
+          let cp =
+            Array.map
+              (fun x ->
+                match x with
+                | DF (p, _, t') -> if t = t' then p else x
+                | x             -> x)
+              a
+            |> f
+          in
+          let at =
+            let at = a |> Array.map (fun x -> x |> tangent) in
+            S.df (Array.of_list idxs) cp a at
+          in
+          DF (cp, at, t)
+        | `r ->
+          let cp =
+            Array.map
+              (fun x ->
+                match x with
+                | DR (p, _, _, _, t', _) -> if t = t' then p else x
+                | x                      -> x)
+              a
+            |> f
+          in
+          let idxs = List.rev idxs in
+          let adjoint cp ca t = List.append (S.dr (Array.of_list idxs) a cp ca) t in
+          let register t = List.append List.(map (fun i -> a.(i)) idxs) t in
+          let label = S.label, List.(map (fun i -> a.(i)) idxs) in
+          DR (cp, ref (zero cp), (adjoint, register, label), ref 0, t, ref 0)
+      in
+      f
 end

--- a/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
@@ -109,4 +109,13 @@ module type Sig = sig
   end
 
   val build_piso : (module Piso) -> t -> t -> t
+
+  module type Aiso = sig
+    val label : string
+    val ff : t array -> t
+    val df : int array -> t -> t array -> t array -> t
+    val dr : int array -> t array -> t -> t ref -> (t * t) list
+  end
+
+  val build_aiso : (module Aiso) -> t array -> t
 end

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -260,6 +260,9 @@ module type Sig = sig
 
     val linsolve : ?trans:bool -> ?typ:[ `n | `u | `l ] -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val care : t -> t -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
   end
 
   (** {6 Supported Neural Network functions} *)

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -261,7 +261,7 @@ module type Sig = sig
     val linsolve : ?trans:bool -> ?typ:[ `n | `u | `l ] -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val care : t -> t -> t -> t -> t
+    val care : ?diag_r:bool -> t -> t -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
   end
 

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -502,6 +502,9 @@ module Make
     trans |> ignore; typ |> ignore;
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.linsolve")
 
+  let care _a _b _q _r =
+    raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.linsolve")
+
   let diag ?k _x =
     k |> ignore;
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.diag")

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -504,7 +504,7 @@ module Make
 
   let care ?(diag_r = false) _a _b _q _r =
     diag_r |> ignore;
-    raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.linsolve")
+    raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.care")
 
   let diag ?k _x =
     k |> ignore;

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -502,7 +502,8 @@ module Make
     trans |> ignore; typ |> ignore;
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.linsolve")
 
-  let care _a _b _q _r =
+  let care ?(diag_r = false) _a _b _q _r =
+    diag_r |> ignore;
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.linsolve")
 
   let diag ?k _x =

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -533,7 +533,7 @@ module type Sig = sig
   val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
   (** TODO *)
 
-  val care : arr -> arr -> arr -> arr -> arr
+  val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
   (** TODO *)
 
   val diag: ?k:int -> arr -> arr

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -533,6 +533,9 @@ module type Sig = sig
   val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
   (** TODO *)
 
+  val care : arr -> arr -> arr -> arr -> arr
+  (** TODO *)
+
   val diag: ?k:int -> arr -> arr
   (** TODO *)
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -432,6 +432,8 @@ val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -
 
 val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
+val care : arr -> arr -> arr -> arr -> arr
+
 val diag: ?k:int -> arr -> arr 
 
 val diagm: ?k:int -> arr -> arr 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -423,8 +423,8 @@ val svd : ?thin:bool -> arr -> arr * arr * arr
 val qr : arr -> arr * arr
 
 val lq : arr -> arr * arr
-                
-val chol : ?upper:bool -> arr -> arr 
+
+val chol : ?upper:bool -> arr -> arr
 
 val lyapunov : arr -> arr -> arr
 
@@ -432,15 +432,15 @@ val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -
 
 val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
-val care : arr -> arr -> arr -> arr -> arr
+val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
 
-val diag: ?k:int -> arr -> arr 
+val diag: ?k:int -> arr -> arr
 
-val diagm: ?k:int -> arr -> arr 
+val diagm: ?k:int -> arr -> arr
 
-val triu: ?k:int -> arr -> arr 
+val triu: ?k:int -> arr -> arr
 
-val tril: ?k:int -> arr -> arr 
+val tril: ?k:int -> arr -> arr
 
 val trace : arr -> elt
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -5007,6 +5007,9 @@ let linsolve ?(trans=false) ?(typ=`n) _a _b =
   trans |> ignore; typ |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.linsolve")
 
+let care _a _b _q _r = 
+  raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.care")
+
 let diag ?(k=0) _x =
   k |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.diag")

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -5007,7 +5007,8 @@ let linsolve ?(trans=false) ?(typ=`n) _a _b =
   trans |> ignore; typ |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.linsolve")
 
-let care _a _b _q _r = 
+let care ?(diag_r = false)_a _b _q _r =
+  diag_r |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.care")
 
 let diag ?(k=0) _x =

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -750,7 +750,7 @@ val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> (float, 'b) 
 val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
-val care : (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+val care : ?diag_r:bool -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
 val diag: ?k:int -> (float, 'b) t -> (float, 'b) t 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -747,7 +747,10 @@ val lyapunov : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 val discrete_lyapunov : ?solver:[`default | `bilinear | `direct] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
-val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
+val care : (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
 val diag: ?k:int -> (float, 'b) t -> (float, 'b) t 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -432,7 +432,7 @@ val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -
 
 val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
-val care : arr -> arr -> arr -> arr -> arr
+val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
 
 val diag : ?k:int -> arr -> arr
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -430,7 +430,9 @@ val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr
 
-val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
+val linsolve : ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
+
+val care : arr -> arr -> arr -> arr -> arr
 
 val diag : ?k:int -> arr -> arr
 

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -327,6 +327,8 @@ module type Sig = sig
 
   val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
+  val care : arr -> arr -> arr -> arr -> arr
+
   val diag : ?k:int -> arr -> arr
 
   val diagm : ?k:int -> arr -> arr

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -327,7 +327,7 @@ module type Sig = sig
 
   val linsolve: ?trans:bool -> ?typ:[`n | `u | `l] -> arr -> arr -> arr
 
-  val care : arr -> arr -> arr -> arr -> arr
+  val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
 
   val diag : ?k:int -> arr -> arr
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -39,6 +39,7 @@ module Generic = struct
 
   let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_generic.linsolve ~trans ~typ a b
 
+  let care = Owl_linalg_generic.care
 end
 
 
@@ -79,6 +80,7 @@ module S = struct
 
   let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_s.linsolve ~trans ~typ a b
 
+  let care = Owl_linalg_s.care
 end
 
 
@@ -118,6 +120,8 @@ module D = struct
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_d.discrete_lyapunov ~solver a q
 
   let linsolve ?(trans=false) ?(typ=`n) a b = Owl_linalg_d.linsolve ~trans ~typ a b
+
+  let care = Owl_linalg_d.care
 end
 
 

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -20,7 +20,7 @@ module Generic = struct
   (* inject function aliases *)
 
   let inv = Owl_linalg_generic.inv
-              
+
   let mpow = Owl_linalg_generic.mpow
 
   let tril ?(k=0) x = Owl_dense_matrix_generic.tril ~k x
@@ -30,8 +30,8 @@ module Generic = struct
   let qr x =
     let q, r, _ = Owl_linalg_generic.qr ~thin:true ~pivot:false x in
     (q,r)
-  
-  let lq x = Owl_linalg_generic.lq ~thin:true x 
+
+  let lq x = Owl_linalg_generic.lq ~thin:true x
 
   let lyapunov a q = Owl_linalg_generic.lyapunov a q
 
@@ -56,11 +56,11 @@ module S = struct
 
   let svd ?(thin=true) = Owl_linalg_s.svd ~thin
 
-  let chol = Owl_linalg_s.chol 
+  let chol = Owl_linalg_s.chol
 
   let mpow = Owl_linalg_s.mpow
 
-  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
+  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x
 
   let eye n = Owl_dense_matrix_s.eye n
 
@@ -72,7 +72,7 @@ module S = struct
     let q, r, _ = Owl_linalg_s.qr ~thin:true ~pivot:false x in
     (q,r)
 
-  let lq x = Owl_linalg_s.lq ~thin:true x 
+  let lq x = Owl_linalg_s.lq ~thin:true x
 
   let lyapunov = Owl_linalg_s.lyapunov
 
@@ -96,12 +96,12 @@ module D = struct
   let logdet = Owl_linalg_d.logdet
 
   let svd ?(thin=true) = Owl_linalg_d.svd ~thin
-              
-  let chol = Owl_linalg_d.chol 
+
+  let chol = Owl_linalg_d.chol
 
   let mpow = Owl_linalg_d.mpow
 
-  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x 
+  let diagm ?(k=0) x = Owl_dense_matrix_generic.diagm ~k x
 
   let eye n = Owl_dense_matrix_d.eye n
 
@@ -113,7 +113,7 @@ module D = struct
     let q, r, _ = Owl_linalg_d.qr ~thin:true ~pivot:false x in
     (q,r)
 
-  let lq x = Owl_linalg_d.lq ~thin:true x 
+  let lq x = Owl_linalg_d.lq ~thin:true x
 
   let lyapunov = Owl_linalg_d.lyapunov
 
@@ -145,7 +145,7 @@ module C = struct
     let q, r, _ = Owl_linalg_c.qr ~thin:true ~pivot:false x in
     (q,r)
 
-  let lq x = Owl_linalg_c.lq ~thin:true x 
+  let lq x = Owl_linalg_c.lq ~thin:true x
 
   let lyapunov = Owl_linalg_c.lyapunov
 
@@ -175,9 +175,9 @@ module Z = struct
     let q, r, _ = Owl_linalg_z.qr ~thin:true ~pivot:false x in
     (q,r)
 
-  let lq x = Owl_linalg_z.lq ~thin:true x 
+  let lq x = Owl_linalg_z.lq ~thin:true x
 
-  let lyapunov = Owl_linalg_z.lyapunov 
+  let lyapunov = Owl_linalg_z.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_z.discrete_lyapunov ~solver a q
 

--- a/src/owl/linalg/owl_linalg_d.mli
+++ b/src/owl/linalg/owl_linalg_d.mli
@@ -105,7 +105,6 @@ val care : mat -> mat -> mat -> mat -> mat
 
 val dare : mat -> mat -> mat -> mat -> mat
 
-
 (** {6 Low-level factorisation functions} *)
 
 val lufact : mat -> mat * int32_mat

--- a/src/owl/linalg/owl_linalg_d.mli
+++ b/src/owl/linalg/owl_linalg_d.mli
@@ -101,7 +101,7 @@ val lyapunov : mat -> mat -> mat
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> mat -> mat -> mat
 
-val care : mat -> mat -> mat -> mat -> mat
+val care : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
 
 val dare : mat -> mat -> mat -> mat -> mat
 

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -822,8 +822,14 @@ let discrete_lyapunov ?(solver=`default) a q =
   solve a q
 
 
-let care a b q r =
-  let g = M.(b *@ (inv r) *@ (transpose b)) in
+let care ?(diag_r=false) a b q r =
+  let g =
+    if diag_r then
+      let r = M.diag r in
+      let inv_r = M.reci r in
+      M.(b * (inv_r) *@ (transpose b))
+    else
+      M.(b *@ (inv r) *@ (transpose b)) in
   let z = M.(concat_vh [| [| a    ; neg g             |];
                           [| neg q; neg (transpose a) |] |]) in
 

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -452,9 +452,9 @@ Returns:
 
 
 
-val care : (float, 'a) t -> (float, 'a) t -> (float, 'a) t -> (float, 'a) t -> (float, 'a) t
+val care : ?diag_r:bool -> (float, 'a) t -> (float, 'a) t -> (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (**
-``care a b q r`` solves the continuous-time algebraic Riccati equation system
+``care ?diag_r a b q r`` solves the continuous-time algebraic Riccati equation system
 in the following form. The algorithm is based on :cite:`laub1979schur`.
 
 .. math::
@@ -465,6 +465,7 @@ Parameters:
   * ``b`` : real cofficient matrix B.
   * ``q`` : real cofficient matrix Q.
   * ``r`` : real cofficient matrix R. R must be non-singular.
+  * ``diag_r`` : true if R is a diagonal matrix. false by default
 
 Returns:
   * ``x`` : a solution matrix X.

--- a/src/owl/linalg/owl_linalg_s.mli
+++ b/src/owl/linalg/owl_linalg_s.mli
@@ -105,7 +105,6 @@ val care : mat -> mat -> mat -> mat -> mat
 
 val dare : mat -> mat -> mat -> mat -> mat
 
-
 (** {6 Low-level factorisation functions} *)
 
 val lufact : mat -> mat * int32_mat

--- a/src/owl/linalg/owl_linalg_s.mli
+++ b/src/owl/linalg/owl_linalg_s.mli
@@ -101,7 +101,7 @@ val lyapunov : mat -> mat -> mat
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> mat -> mat -> mat
 
-val care : mat -> mat -> mat -> mat -> mat
+val care : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
 
 val dare : mat -> mat -> mat -> mat -> mat
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -236,6 +236,23 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       in
       test_func f
 
+    let care () =
+      let b = Mat.gaussian n n in
+      let q = Mat.gaussian n n in
+      let f x =
+        let a = x in
+        let b = Maths.((tril x) + b) in
+        let r =
+          let e = Mat.eye n in
+          let r = Maths.(e + (a *@ transpose a)) in
+          Maths.(r *@ (transpose r)) in
+        let q =
+          let q = Maths.(q + a) in
+          Maths.(q *@ transpose q + Mat.(eye n)) in
+        Linalg.care a b q r
+      in
+      test_func f
+
 
     let alco_fun s f =
       let check, c =
@@ -247,9 +264,8 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
 
 
     let test_set =
-      [ 
-         
-      "neg", `Slow, neg   
+      [
+      "neg", `Slow, neg
       ; "abs", `Slow, abs
       ; "signum", `Slow, signum
       ; "floor", `Slow, floor
@@ -293,6 +309,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       ; "discrete_lyapunov", `Slow, discrete_lyapunov
       ; "linsolve", `Slow, linsolve
       ; "linsolve_triangular", `Slow, linsolve_triangular
+      ; "care", `Slow, care
       ]
       |> List.map (fun (s, m, f) ->
              let f () = alco_fun s f in

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -249,7 +249,9 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
         let q =
           let q = Maths.(q + a) in
           Maths.(q *@ transpose q + Mat.(eye n)) in
-        Linalg.care a b q r
+        let c1 = (Linalg.care a b q r) in
+        let c2 = (Linalg.care ~diag_r:true a b q Maths.(diagm (diag r))) in
+        Maths.(c1 + c2)
       in
       test_func f
 


### PR DESCRIPTION
1. Added a function `build_aiso` that can be used to build  algodiff operation that takes an array input and produces a single output. This is useful for building operations that take many arguments.

2. One such example is the  continous-time algebraic Ricatti equation, which takes four inputs and produces a single output. I've added `Owl.Algodiff.D.Linalg.care` using  `build_aiso`. 

FUTURE: 
1. use `build_aiso` to build operations such as `concatenate` 
2. `Owl.Algodiff.D.Linalg.dare`