### PR TITLE
Sylvester Algodiff + bug fixes

### DIFF
--- a/src/base/algodiff/owl_algodiff_check.ml
+++ b/src/base/algodiff/owl_algodiff_check.ml
@@ -76,7 +76,7 @@ module Make (Algodiff : Owl_algodiff_generic_sig.Sig) = struct
       | F _, F _     -> ()
       | Arr a, Arr b ->
         if A.shape a <> A.shape b then failwith "tangent dimension mismatch" else ()
-      | _                -> failwith "tangent dimension mismatch"
+      | _            -> failwith "tangent dimension mismatch"
 
 
     let check ~threshold ~f ~directions samples =

--- a/src/base/algodiff/owl_algodiff_core.ml
+++ b/src/base/algodiff/owl_algodiff_core.ml
@@ -144,10 +144,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
   let type_info x =
     match x with
     | F _a                          -> Printf.sprintf "[%s]" (deep_info x)
-    | DF (ap, _at, ai)              -> Printf.sprintf
-                                         "[DF tag:%i ap:%s]"
-                                         ai
-                                         (deep_info ap)
+    | DF (ap, _at, ai)              -> Printf.sprintf "[DF tag:%i ap:%s]" ai (deep_info ap)
     | DR (ap, _at, _ao, _af, ai, _) ->
       Printf.sprintf "[DR tag:%i ap:%s]" ai (deep_info ap)
     | _                             -> Printf.sprintf "[%s]" (deep_info x)

--- a/src/base/algodiff/owl_algodiff_generic.ml
+++ b/src/base/algodiff/owl_algodiff_generic.ml
@@ -118,8 +118,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
         match dim_typ y, dim_typ x with
         | `row a, `row 1 -> a, 1
         | `row a, `row b -> a, b
-        | _                  -> failwith
-                                  "jacobian: input and output must both be row vectors"
+        | _              -> failwith "jacobian: input and output must both be row vectors"
       in
       let z = A.empty [| m; n |] in
       (match m > n with

--- a/src/base/algodiff/owl_algodiff_graph_convert.ml
+++ b/src/base/algodiff/owl_algodiff_graph_convert.ml
@@ -11,16 +11,16 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     (* local function to traverse the nodes *)
     let rec push tlist =
       match tlist with
-      | []          -> ()
+      | []       -> ()
       | hd :: tl ->
         if Hashtbl.mem nodes hd = false
         then (
           let op, prev =
             match hd with
             | DR (_ap, _aa, (_, _, label), _af, _ai, _) -> label
-            | F _a                                      -> Printf.sprintf "Const", []
-            | Arr _a                                    -> Printf.sprintf "Const", []
-            | DF (_, _, _)                              -> Printf.sprintf "DF", []
+            | F _a -> Printf.sprintf "Const", []
+            | Arr _a -> Printf.sprintf "Const", []
+            | DF (_, _, _) -> Printf.sprintf "DF", []
           in
           (* check if the node has been visited before *)
           Hashtbl.add nodes hd (!index, op, prev);

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1344,6 +1344,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
     and svd ?(thin = true) = Lazy.force _svd ~thin
+    and sylvester = raise (Owl_exception.NOT_IMPLEMENTED "owl_algodiff_ops.sylvester")
 
     (* pair outputs single input *)
     and _lyapunov =

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1154,7 +1154,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
               let dr idxs a _ ca =
                 let ca = split ~axis (Array.map (fun x -> (shape x).(axis)) a) !ca in
-                Array.map (fun k -> ca.(k), a.(k)) idxs |> Array.to_list
+                List.map (fun k -> ca.(k), a.(k)) idxs
             end : Aiso))
 
 
@@ -1555,8 +1555,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
                  let a, b, _, r = unpack inp in
                  let at, bt, qt, rt = unpack tangents in
                  let dp = care_forward ~diag_r p a b r at bt qt rt in
-                 Array.map (fun k -> dp.(k) ()) idxs
-                 |> Array.fold_left ( + ) (pack_flt 0.)
+                 List.map (fun k -> dp.(k) ()) idxs |> List.fold_left ( + ) (pack_flt 0.)
 
 
                let dr idxs inp p pbar_ref =
@@ -1565,12 +1564,11 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
                    let a, b, q, r = unpack inp in
                    care_backward ~diag_r a b q r p pbar
                  in
-                 Array.map
+                 List.map
                    (fun k ->
                      let bar, x = bars.(k) in
                      bar (), x)
                    idxs
-                 |> Array.to_list
              end : Aiso))
 
 

--- a/src/base/algodiff/owl_algodiff_ops_builder.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder.ml
@@ -343,8 +343,8 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
   module type Aiso = sig
     val label : string
     val ff : t array -> t
-    val df : int array -> t -> t array -> t array -> t
-    val dr : int array -> t array -> t -> t ref -> (t * t) list
+    val df : int list -> t -> t array -> t array -> t
+    val dr : int list -> t array -> t -> t ref -> (t * t) list
   end
 
   let build_aiso =
@@ -384,7 +384,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     fun (module S : Aiso) ->
       let rec f a =
         let _, t, mode, idxs = build_info a in
-        let idxs = idxs |> List.rev |> Array.of_list in
+        let idxs = idxs |> List.rev in
         match mode with
         | `normal  -> S.ff a
         | `forward ->
@@ -399,7 +399,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
           in
           let at =
             let at = a |> Array.map zero in
-            Array.iter (fun k -> at.(k) <- tangent a.(k)) idxs;
+            List.iter (fun k -> at.(k) <- tangent a.(k)) idxs;
             S.df idxs cp a at
           in
           DF (cp, at, t)
@@ -414,8 +414,8 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
             |> f
           in
           let adjoint cp ca t = List.append (S.dr idxs a cp ca) t in
-          let register t = Array.fold_left (fun t i -> a.(i) :: t) t idxs in
-          let label = S.label, Array.(map (fun i -> a.(i)) idxs) |> Array.to_list in
+          let register t = List.fold_left (fun t i -> a.(i) :: t) t idxs in
+          let label = S.label, List.(map (fun i -> a.(i)) idxs) in
           DR (cp, ref (zero cp), (adjoint, register, label), ref 0, t, ref 0)
       in
       f

--- a/src/base/algodiff/owl_algodiff_ops_builder.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder.ml
@@ -398,9 +398,10 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
             |> f
           in
           let at =
+            let ap = a |> Array.map primal in
             let at = a |> Array.map zero in
             List.iter (fun k -> at.(k) <- tangent a.(k)) idxs;
-            S.df idxs cp a at
+            S.df idxs cp ap at
           in
           DF (cp, at, t)
         | `reverse ->

--- a/src/base/algodiff/owl_algodiff_ops_builder.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder.ml
@@ -32,19 +32,10 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
          cp1 and cp2 has been called such that in reverse_push, we do not update the
          adjoint of ap before we've fully updated both ca1 and ca2 *)
       ( DR
-          ( cp1
-          , ca1_ref
-          , r (a, (cp1_ref, cp2_ref), (ca1_ref, ca2_ref))
-          , ref 0
-          , ai
-          , tracker )
+          (cp1, ca1_ref, r (a, (cp1_ref, cp2_ref), (ca1_ref, ca2_ref)), ref 0, ai, tracker)
       , DR
-          ( cp2
-          , ca2_ref
-          , r (a, (cp1_ref, cp2_ref), (ca1_ref, ca2_ref))
-          , ref 0
-          , ai
-          , tracker ) )
+          (cp2, ca2_ref, r (a, (cp1_ref, cp2_ref), (ca1_ref, ca2_ref)), ref 0, ai, tracker)
+      )
     | ap                      -> ff ap
 
 
@@ -109,31 +100,31 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
   (* pair input single output operation *)
   let op_piso ~ff ~fd ~df_da ~df_db ~df_dab ~r_d_d ~r_d_c ~r_c_d a b =
     match a, b with
-    | F _ap, DF (bp, bt, bi)                           ->
+    | F _ap, DF (bp, bt, bi) ->
       let cp = fd a bp in
       DF (cp, df_db cp a bp bt, bi)
-    | DF (ap, at, ai), F _bp                           ->
+    | DF (ap, at, ai), F _bp ->
       let cp = fd ap b in
       DF (cp, df_da cp ap at b, ai)
-    | Arr _ap, DF (bp, bt, bi)                         ->
+    | Arr _ap, DF (bp, bt, bi) ->
       let cp = fd a bp in
       DF (cp, df_db cp a bp bt, bi)
-    | DF (ap, at, ai), Arr _bp                         ->
+    | DF (ap, at, ai), Arr _bp ->
       let cp = fd ap b in
       DF (cp, df_da cp ap at b, ai)
-    | F _ap, DR (bp, _, _, _, bi, _)                   ->
+    | F _ap, DR (bp, _, _, _, bi, _) ->
       let cp = fd a bp in
       DR (cp, ref (zero cp), r_c_d a b, ref 0, bi, ref 0)
-    | DR (ap, _, _, _, ai, _), F _bp                   ->
+    | DR (ap, _, _, _, ai, _), F _bp ->
       let cp = fd ap b in
       DR (cp, ref (zero cp), r_d_c a b, ref 0, ai, ref 0)
-    | Arr _ap, DR (bp, _, _, _, bi, _)                 ->
+    | Arr _ap, DR (bp, _, _, _, bi, _) ->
       let cp = fd a bp in
       DR (cp, ref (zero cp), r_c_d a b, ref 0, bi, ref 0)
-    | DR (ap, _, _, _, ai, _), Arr _bp                 ->
+    | DR (ap, _, _, _, ai, _), Arr _bp ->
       let cp = fd ap b in
       DR (cp, ref (zero cp), r_d_c a b, ref 0, ai, ref 0)
-    | DF (ap, at, ai), DR (bp, _, _, _, bi, _)         ->
+    | DF (ap, at, ai), DR (bp, _, _, _, bi, _) ->
       (match cmp_tag ai bi with
       | 1  ->
         let cp = fd ap b in
@@ -142,7 +133,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
         let cp = fd a bp in
         DR (cp, ref (zero cp), r_c_d a b, ref 0, bi, ref 0)
       | _  -> failwith "error: forward and reverse clash at the same level")
-    | DR (ap, _, _, _, ai, _), DF (bp, bt, bi)         ->
+    | DR (ap, _, _, _, ai, _), DF (bp, bt, bi) ->
       (match cmp_tag ai bi with
       | -1 ->
         let cp = fd a bp in
@@ -151,7 +142,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
         let cp = fd ap b in
         DR (cp, ref (zero cp), r_d_c a b, ref 0, ai, ref 0)
       | _  -> failwith "error: forward and reverse clash at the same level")
-    | DF (ap, at, ai), DF (bp, bt, bi)                 ->
+    | DF (ap, at, ai), DF (bp, bt, bi) ->
       (match cmp_tag ai bi with
       | 0 ->
         let cp = fd ap bp in
@@ -173,7 +164,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
       | _ ->
         let cp = fd a bp in
         DR (cp, ref (zero cp), r_c_d a b, ref 0, bi, ref 0))
-    | a, b                                                 -> ff a b
+    | a, b -> ff a b
 
 
   module type Siso = sig
@@ -310,7 +301,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
         | F a, Arr b   -> S.ff_ab a b
         | Arr a, F b   -> S.ff_ba a b
         | Arr a, Arr b -> S.ff_bb a b
-        | _                -> error_binop S.label a b
+        | _            -> error_binop S.label a b
       in
       let fd = f in
       let r_d_d a b =
@@ -393,6 +384,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     fun (module S : Aiso) ->
       let rec f a =
         let _, t, mode, idxs = build_info a in
+        let idxs = idxs |> List.rev |> Array.of_list in
         match mode with
         | `normal  -> S.ff a
         | `forward ->
@@ -406,8 +398,9 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
             |> f
           in
           let at =
-            let at = a |> Array.map (fun x -> x |> tangent) in
-            S.df (Array.of_list idxs) cp a at
+            let at = a |> Array.map zero in
+            Array.iter (fun k -> at.(k) <- tangent a.(k)) idxs;
+            S.df idxs cp a at
           in
           DF (cp, at, t)
         | `reverse ->
@@ -420,10 +413,9 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
               a
             |> f
           in
-          let idxs = List.rev idxs in
-          let adjoint cp ca t = List.append (S.dr (Array.of_list idxs) a cp ca) t in
-          let register t = List.append List.(map (fun i -> a.(i)) idxs) t in
-          let label = S.label, List.(map (fun i -> a.(i)) idxs) in
+          let adjoint cp ca t = List.append (S.dr idxs a cp ca) t in
+          let register t = Array.fold_left (fun t i -> a.(i) :: t) t idxs in
+          let label = S.label, Array.(map (fun i -> a.(i)) idxs) |> Array.to_list in
           DR (cp, ref (zero cp), (adjoint, register, label), ref 0, t, ref 0)
       in
       f

--- a/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
@@ -113,8 +113,8 @@ module type Sig = sig
   module type Aiso = sig
     val label : string
     val ff : t array -> t
-    val df : int array -> t -> t array -> t array -> t
-    val dr : int array -> t array -> t -> t ref -> (t * t) list
+    val df : int list -> t -> t array -> t array -> t
+    val dr : int list -> t array -> t -> t ref -> (t * t) list
   end
 
   val build_aiso : (module Aiso) -> t array -> t

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -249,6 +249,9 @@ module type Sig = sig
     val svd : ?thin:bool -> t -> t * t * t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val sylvester : t -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
     val lyapunov : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/algodiff/owl_algodiff_reverse.ml
+++ b/src/base/algodiff/owl_algodiff_reverse.ml
@@ -11,7 +11,7 @@ struct
   let reverse_reset x =
     let rec reset xs =
       match xs with
-      | []        -> ()
+      | []     -> ()
       | x :: t ->
         (match x with
         | DR (_cp, aa, (_, register, _), af, _ai, tracker) ->
@@ -19,7 +19,7 @@ struct
           af := !af + 1;
           tracker := succ !tracker;
           if !af = 1 && !tracker = 1 then reset (register t) else reset t
-        | _                                                -> reset t)
+        | _ -> reset t)
     in
     reset [ x ]
 
@@ -41,11 +41,11 @@ struct
           let axis = Owl_utils_array.filter2_i ( <> ) shp_a shp_v in
           Arr (A.sum_reduce ~axis v))
         else Arr v
-      | _a, v            -> v
+      | _a, v        -> v
     in
     let rec push xs =
       match xs with
-      | []             -> ()
+      | []          -> ()
       | (v, x) :: t ->
         (match x with
         | DR (cp, aa, (adjoint, _, _), af, _ai, tracker) ->
@@ -57,7 +57,7 @@ struct
           else (
             tracker := pred !tracker;
             push t)
-        | _                                              -> push t)
+        | _ -> push t)
     in
     fun v x -> push [ v, x ]
 

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -491,6 +491,9 @@ module Make
   let lq _x =
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.lq")
 
+  let sylvester _a _b _c =
+    raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.sylvester")
+
   let lyapunov _a _q =
     raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.lyapunov")
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -524,6 +524,9 @@ module type Sig = sig
   val svd : ?thin:bool -> arr -> arr * arr * arr
   (** TODO *)
 
+  val sylvester: arr -> arr -> arr -> arr
+  (** TODO *)
+
   val lyapunov : arr -> arr -> arr
   (** TODO *)
 

--- a/src/base/dense/owl_base_dense_ndarray_d.mli
+++ b/src/base/dense/owl_base_dense_ndarray_d.mli
@@ -426,6 +426,8 @@ val lq : arr -> arr * arr
 
 val chol : ?upper:bool -> arr -> arr
 
+val sylvester : arr -> arr -> arr -> arr
+
 val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -5001,6 +5001,9 @@ let svd ?(thin=true) _x =
   thin |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.svd")
 
+let sylvester _a _b _c =
+  raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.sylvester")
+
 let lyapunov _a _q =
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.lyapunov")
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -741,6 +741,9 @@ val lq : (float, 'b) t -> (float, 'b) t * (float, 'b) t
 val svd : ?thin:bool -> (float, 'b) t -> (float, 'b) t * (float, 'b) t * (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+val sylvester : (float, 'b) t -> (float, 'b) t -> (float, 'b) t -> (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 val lyapunov : (float, 'b) t -> (float, 'b) t -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_s.mli
+++ b/src/base/dense/owl_base_dense_ndarray_s.mli
@@ -426,6 +426,8 @@ val qr : arr -> arr * arr
 
 val lq : arr -> arr * arr
 
+val sylvester : arr -> arr -> arr -> arr
+
 val lyapunov : arr -> arr -> arr
 
 val discrete_lyapunov : ?solver:[`default | `direct | `bilinear] -> arr -> arr -> arr

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -321,6 +321,8 @@ module type Sig = sig
 
   val lq : arr -> arr * arr
 
+  val sylvester: arr -> arr -> arr -> arr
+
   val lyapunov: arr -> arr -> arr
 
   val discrete_lyapunov: ?solver:[`default | `bilinear | `direct] -> arr -> arr -> arr

--- a/src/owl/dense/owl_dense_ndarray.ml
+++ b/src/owl/dense/owl_dense_ndarray.ml
@@ -33,7 +33,9 @@ module Generic = struct
 
   let lq x = Owl_linalg_generic.lq ~thin:true x
 
-  let lyapunov a q = Owl_linalg_generic.lyapunov a q
+  let sylvester = Owl_linalg_generic.lyapunov 
+
+  let lyapunov = Owl_linalg_generic.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_generic.discrete_lyapunov ~solver a q
 
@@ -73,6 +75,8 @@ module S = struct
     (q,r)
 
   let lq x = Owl_linalg_s.lq ~thin:true x
+
+  let sylvester = Owl_linalg_s.sylvester
 
   let lyapunov = Owl_linalg_s.lyapunov
 
@@ -115,6 +119,8 @@ module D = struct
 
   let lq x = Owl_linalg_d.lq ~thin:true x
 
+  let sylvester = Owl_linalg_d.sylvester
+
   let lyapunov = Owl_linalg_d.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_d.discrete_lyapunov ~solver a q
@@ -147,6 +153,8 @@ module C = struct
 
   let lq x = Owl_linalg_c.lq ~thin:true x
 
+  let sylvester = Owl_linalg_c.sylvester
+
   let lyapunov = Owl_linalg_c.lyapunov
 
   let discrete_lyapunov ?(solver=`default) a q = Owl_linalg_c.discrete_lyapunov ~solver a q
@@ -176,6 +184,8 @@ module Z = struct
     (q,r)
 
   let lq x = Owl_linalg_z.lq ~thin:true x
+
+  let sylvester = Owl_linalg_z.sylvester
 
   let lyapunov = Owl_linalg_z.lyapunov
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -11,7 +11,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
   open AlgoM
 
   let n = 3
-  let n_samples = 10 
+  let n_samples = 20 
   let threshold = 1E-6
   let eps = 1E-5
 
@@ -178,10 +178,11 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       test_func f
 
     let sylvester () =
-      let r = Mat.gaussian n n in
-      let b = Mat.gaussian n n in 
+      let r1 = Mat.gaussian n n in
+      let r2 = Mat.gaussian n n in
       let f x = 
-        let a = Maths.(x + r) in
+        let a = Maths.(x + r1) in
+        let b = Maths.(x + r2) in
         let c = Maths.(a *@ x + x *@ b) in
         Linalg.sylvester a x c in
     test_func f

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -177,6 +177,19 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       in
       test_func f
 
+    let sylvester () =
+      let r = Mat.gaussian n n in
+      let identity = Arr Owl.Mat.(eye n) in
+      let f x =
+        let q = Maths.(F 0.5 * (x + transpose x + identity)) in
+        let s = Maths.(r - transpose r) in
+        let p = Maths.(((r + x) *@ transpose (r + x)) + identity) in
+        let a = Maths.((s - (F 0.5 * q)) *@ inv p) in
+        let b = Maths.(a - (x *@ transpose x)) in
+        Linalg.sylvester a b x
+      in
+      test_func f
+
 
     let lyapunov () =
       let r = Mat.gaussian n n in

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -11,7 +11,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
   open AlgoM
 
   let n = 3
-  let n_samples = 20
+  let n_samples = 10 
   let threshold = 1E-6
   let eps = 1E-5
 
@@ -179,16 +179,12 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
 
     let sylvester () =
       let r = Mat.gaussian n n in
-      let identity = Arr Owl.Mat.(eye n) in
-      let f x =
-        let q = Maths.(F 0.5 * (x + transpose x + identity)) in
-        let s = Maths.(r - transpose r) in
-        let p = Maths.(((r + x) *@ transpose (r + x)) + identity) in
-        let a = Maths.((s - (F 0.5 * q)) *@ inv p) in
-        let b = Maths.(a - (x *@ transpose x)) in
-        Linalg.sylvester a b x
-      in
-      test_func f
+      let b = Mat.gaussian n n in 
+      let f x = 
+        let a = Maths.(x + r) in
+        let c = Maths.(a *@ x + x *@ b) in
+        Linalg.sylvester a x c in
+    test_func f
 
 
     let lyapunov () =
@@ -320,6 +316,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       ; "of_arrays", `Slow, of_arrays
       ; "to_arrays", `Slow, to_arrays
       ; "init_2d", `Slow, init_2d
+      ; "sylvester", `Slow, sylvester
       ; "lyapunov", `Slow, lyapunov
       ; "discrete_lyapunov", `Slow, discrete_lyapunov
       ; "linsolve", `Slow, linsolve

--- a/test/unit_linalg_solver.ml
+++ b/test/unit_linalg_solver.ml
@@ -1,4 +1,3 @@
-open Owl
 open Owl_exception
 
 module N = Owl_base_dense_ndarray.D
@@ -38,7 +37,7 @@ module To_test_gauss = struct
       N.set a [|i; i|] ((v +. 0.1) *. 20.)
     done;
     let flag = ref true in
-    for i = 0 to 9 do
+    for _ = 0 to 9 do
       let b = N.uniform [|n; 3|] in
       let a_inv, x = L.linsolve_gauss a b in
       let flag01 = approx_equal (N.dot a a_inv) (N.eye n) in


### PR DESCRIPTION
1. fixed bug in `build_aiso` calculation of tangents (should pass primal input array to `df` not original inputs)
2. added forward and reverse mode gradients for sylvester 
3. `of_arrays` now support higher order gradients
4. rewrote `concatenate` using `build_aiso`