### PR TITLE
owl-base: drop seemingly unnecessary dependency on integers

### DIFF
--- a/src/base/dune
+++ b/src/base/dune
@@ -26,4 +26,4 @@
  (wrapped false)
  (flags
   (:standard -safe-string))
- (libraries bigarray integers stdlib-shims))
+ (libraries bigarray stdlib-shims))


### PR DESCRIPTION
Came up in the opam-repository submission

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>