### PR TITLE
Save and load Npy files

### DIFF
--- a/owl-top.opam
+++ b/owl-top.opam
@@ -20,5 +20,4 @@ depends: [
   "ocaml-compiler-libs"
   "owl" {>= version}
   "owl-zoo"
-  "npy"
 ]

--- a/owl-top.opam
+++ b/owl-top.opam
@@ -20,4 +20,5 @@ depends: [
   "ocaml-compiler-libs"
   "owl" {>= version}
   "owl-zoo"
+  "npy"
 ]

--- a/owl-zoo.opam
+++ b/owl-zoo.opam
@@ -26,4 +26,5 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml-compiler-libs"
   "owl" {>= version}
+  "npy"
 ]

--- a/owl-zoo.opam
+++ b/owl-zoo.opam
@@ -26,5 +26,4 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml-compiler-libs"
   "owl" {>= version}
-  "npy"
 ]

--- a/owl.opam
+++ b/owl.opam
@@ -34,4 +34,5 @@ depends: [
   "owl-base" {= version}
   "stdio" {build}
   "stdlib-shims"
+  "npy"
 ]

--- a/src/owl/dense/owl_dense_matrix_c.ml
+++ b/src/owl/dense/owl_dense_matrix_c.ml
@@ -61,6 +61,8 @@ let load f = M.load Complex32 f
 
 let load_txt ?sep f = M.load_txt Complex32 ?sep f
 
+let load_npy f = M.load_npy Complex32 f
+
 (* specific functions for complex64 matrix *)
 
 let vector n = empty 1 n

--- a/src/owl/dense/owl_dense_matrix_c.mli
+++ b/src/owl/dense/owl_dense_matrix_c.mli
@@ -411,15 +411,15 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> out:string -> unit
+val save : out:string -> mat -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
+val save_txt : ?sep:string -> ?append:bool -> out:string -> mat -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
-val save_npy : mat -> out:string -> unit
+val save_npy : out:string -> mat -> unit
 
 val load_npy : string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_c.mli
+++ b/src/owl/dense/owl_dense_matrix_c.mli
@@ -411,11 +411,11 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> string -> unit
+val save : mat -> out:string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_c.mli
+++ b/src/owl/dense/owl_dense_matrix_c.mli
@@ -419,6 +419,9 @@ val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
+val save_npy : mat -> out:string -> unit
+
+val load_npy : string -> mat
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_matrix_d.ml
+++ b/src/owl/dense/owl_dense_matrix_d.ml
@@ -63,6 +63,8 @@ let load f = M.load Float64 f
 
 let load_txt ?sep f = M.load_txt Float64 ?sep f
 
+let load_npy f = M.load_npy Float64 f
+
 (* specific functions for float64 matrix *)
 
 let vector n = empty 1 n

--- a/src/owl/dense/owl_dense_matrix_d.mli
+++ b/src/owl/dense/owl_dense_matrix_d.mli
@@ -404,6 +404,9 @@ val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
+val save_npy : mat -> out:string -> unit
+
+val load_npy : string -> mat
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_matrix_d.mli
+++ b/src/owl/dense/owl_dense_matrix_d.mli
@@ -396,15 +396,15 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> out:string -> unit
+val save : out:string -> mat -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
+val save_txt : ?sep:string -> ?append:bool -> out:string -> mat -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
-val save_npy : mat -> out:string -> unit
+val save_npy : out:string -> mat -> unit
 
 val load_npy : string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_d.mli
+++ b/src/owl/dense/owl_dense_matrix_d.mli
@@ -396,11 +396,11 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> string -> unit
+val save : mat -> out:string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -600,15 +600,6 @@ let load_txt ?(sep="\t") k f =
   close_in h; x
 
 
-let save_npy x ~out = Npy.write x out
-
-
-let load_npy kind file =
-  match Npy.read_copy file |> Npy.to_bigarray Bigarray.c_layout kind with
-  | Some x -> x
-  | None -> failwith Printf.(sprintf "%s: incorrect format" file)
-
-
 let semidef k n =
   let x = uniform k n n in
   dot (transpose x) x

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -600,6 +600,15 @@ let load_txt ?(sep="\t") k f =
   close_in h; x
 
 
+let save_npy x ~out = Npy.write x out
+
+
+let load_npy kind file =
+  match Npy.read_copy file |> Npy.to_bigarray Bigarray.c_layout kind with
+  | Some x -> x
+  | None -> failwith Printf.(sprintf "%s: incorrect format" file)
+
+
 let semidef k n =
   let x = uniform k n n in
   dot (transpose x) x
@@ -630,6 +639,7 @@ let meshgrid k xa xb ya yb xn yn =
   let x = map_by_row xn (fun _ -> u) (empty k yn xn) in
   let y = map_by_row yn (fun _ -> v) (empty k xn yn) in
   x, transpose y
+
 
 let meshup x y =
   let k = kind x in

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -565,7 +565,7 @@ let of_array k x m n =
   Owl_dense_ndarray_generic.reshape y [|m; n|]
 
 
-let save_txt ?(sep="\t") ?(append=false) x ~out =
+let save_txt ?(sep="\t") ?(append=false) ~out x =
   let perm = 0o666 in (* will be AND'ed with user's umask *)
   let open_flags = if append
                    then [Open_wronly; Open_creat; Open_append; Open_text]

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -565,14 +565,14 @@ let of_array k x m n =
   Owl_dense_ndarray_generic.reshape y [|m; n|]
 
 
-let save_txt ?(sep="\t") ?(append=false) x f =
+let save_txt ?(sep="\t") ?(append=false) x ~out =
   let perm = 0o666 in (* will be AND'ed with user's umask *)
   let open_flags = if append
                    then [Open_wronly; Open_creat; Open_append; Open_text]
 		   else [Open_wronly; Open_creat; Open_trunc;  Open_text]
   in
   let _op = Owl_utils.elt_to_str (kind x) in
-  let h = open_out_gen open_flags perm f in
+  let h = open_out_gen open_flags perm out in
   iter_rows (fun y ->
     iter (fun z -> Printf.fprintf h "%s%s" (_op z) sep) y;
     Printf.fprintf h "\n"

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1217,6 +1217,18 @@ val load_txt : ?sep:string -> ('a, 'b) kind -> string -> ('a, 'b) t
 delimitor is specified by ``sep`` which can be a regular expression.
  *)
 
+val save_npy : ('a, 'b) t -> out:string -> unit
+(**
+``save_npy x ~out`` saves the matrix ``x`` into a npy file ``out``. This function
+is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
+ *)
+
+val load_npy : ('a, 'b) kind -> string -> ('a, 'b) t
+(**
+``load_npy file`` load a npy ``file`` into a matrix of type ``k``. If the matrix is
+in the file is not of type ``k``, fails with ``[file]: incorrect format``. This
+function is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
+ *)
 
 (** {6 Unary math operators}  *)
 

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1189,9 +1189,9 @@ val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:('a -> string) 
 ``print x`` pretty prints matrix ``x`` without headings.
  *)
 
-val save : ('a, 'b) t -> string -> unit
+val save : ('a, 'b) t -> out:string -> unit
 (**
-``save x f`` saves the matrix ``x`` to a file with the name ``f``. The format
+``save x ~out`` saves the matrix ``x`` to a file with the name ``out``. The format
 is binary by using ``Marshal`` module to serialise the matrix.
  *)
 
@@ -1201,9 +1201,9 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 by using ``save`` function.
  *)
 
-val save_txt : ?sep:string -> ?append:bool -> ('a, 'b) t -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> ('a, 'b) t -> out:string -> unit
 (**
-``save_txt ~sep ~append x f`` saves the matrix ``x`` into a text file ``f``
+``save_txt ~sep ~append x ~out`` saves the matrix ``x`` into a text file ``out``
 delimited by the specified string ``sep`` (default: tab).  If ``append`` is
 ``false`` (it is by default), an existing file will be truncated and overwritten.
 If ``append`` is ``true`` and the file exists, new rows will be appended to it.

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1189,7 +1189,7 @@ val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:('a -> string) 
 ``print x`` pretty prints matrix ``x`` without headings.
  *)
 
-val save : ('a, 'b) t -> out:string -> unit
+val save : out:string -> ('a, 'b) t -> unit
 (**
 ``save x ~out`` saves the matrix ``x`` to a file with the name ``out``. The format
 is binary by using ``Marshal`` module to serialise the matrix.
@@ -1201,9 +1201,9 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 by using ``save`` function.
  *)
 
-val save_txt : ?sep:string -> ?append:bool -> ('a, 'b) t -> out:string -> unit
+val save_txt : ?sep:string -> ?append:bool -> out:string -> ('a, 'b) t -> unit
 (**
-``save_txt ~sep ~append x ~out`` saves the matrix ``x`` into a text file ``out``
+``save_txt ~sep ~append ~out x`` saves the matrix ``x`` into a text file ``out``
 delimited by the specified string ``sep`` (default: tab).  If ``append`` is
 ``false`` (it is by default), an existing file will be truncated and overwritten.
 If ``append`` is ``true`` and the file exists, new rows will be appended to it.
@@ -1217,9 +1217,9 @@ val load_txt : ?sep:string -> ('a, 'b) kind -> string -> ('a, 'b) t
 delimitor is specified by ``sep`` which can be a regular expression.
  *)
 
-val save_npy : ('a, 'b) t -> out:string -> unit
+val save_npy : out:string -> ('a, 'b) t -> unit
 (**
-``save_npy x ~out`` saves the matrix ``x`` into a npy file ``out``. This function
+``save_npy ~out x`` saves the matrix ``x`` into a npy file ``out``. This function
 is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
  *)
 

--- a/src/owl/dense/owl_dense_matrix_s.ml
+++ b/src/owl/dense/owl_dense_matrix_s.ml
@@ -60,6 +60,8 @@ let load f = M.load Float32 f
 
 let load_txt ?sep f = M.load_txt Float32 ?sep f
 
+let load_npy f = M.load_npy Float32 f
+
 (* specific functions for float64 matrix *)
 
 let vector n = empty 1 n

--- a/src/owl/dense/owl_dense_matrix_s.mli
+++ b/src/owl/dense/owl_dense_matrix_s.mli
@@ -404,6 +404,9 @@ val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
+val save_npy : mat -> out:string -> unit
+
+val load_npy : string -> mat
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_matrix_s.mli
+++ b/src/owl/dense/owl_dense_matrix_s.mli
@@ -396,15 +396,15 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> out:string -> unit
+val save : out:string -> mat -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
+val save_txt : ?sep:string -> ?append:bool -> out:string -> mat -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
-val save_npy : mat -> out:string -> unit
+val save_npy : out:string -> mat -> unit
 
 val load_npy : string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_s.mli
+++ b/src/owl/dense/owl_dense_matrix_s.mli
@@ -396,11 +396,11 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> string -> unit
+val save : mat -> out:string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_z.ml
+++ b/src/owl/dense/owl_dense_matrix_z.ml
@@ -61,6 +61,8 @@ let load f = M.load Complex64 f
 
 let load_txt ?sep f = M.load_txt Complex64 ?sep f
 
+let load_npy f = M.load_npy Complex64 f
+
 (* specific functions for complex64 matrix *)
 
 let vector n = empty 1 n

--- a/src/owl/dense/owl_dense_matrix_z.mli
+++ b/src/owl/dense/owl_dense_matrix_z.mli
@@ -419,15 +419,15 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> out:string -> unit
+val save : out:string -> mat -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
+val save_txt : ?sep:string -> ?append:bool -> out:string -> mat -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
-val save_npy : mat -> out:string -> unit
+val save_npy : out:string -> mat -> unit
 
 val load_npy : string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_z.mli
+++ b/src/owl/dense/owl_dense_matrix_z.mli
@@ -419,11 +419,11 @@ val of_cols : mat array -> mat
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-val save : mat -> string -> unit
+val save : mat -> out:string -> unit
 
 val load : string -> mat
 
-val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
+val save_txt : ?sep:string -> ?append:bool -> mat -> out:string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 

--- a/src/owl/dense/owl_dense_matrix_z.mli
+++ b/src/owl/dense/owl_dense_matrix_z.mli
@@ -427,6 +427,9 @@ val save_txt : ?sep:string -> ?append:bool -> mat -> string -> unit
 
 val load_txt : ?sep:string -> string -> mat
 
+val save_npy : mat -> out:string -> unit
+
+val load_npy : string -> mat
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_ndarray_c.ml
+++ b/src/owl/dense/owl_dense_ndarray_c.ml
@@ -45,6 +45,8 @@ let unit_basis n i = M.unit_basis Complex32 n i
 
 let load f = M.load Complex32 f
 
+let load_npy f = M.load_npy Complex32 f
+
 let of_array x d = M.of_array Complex32 x d
 
 let mmap fd ?pos shared dims = Unix.map_file fd ?pos Complex32 c_layout shared dims

--- a/src/owl/dense/owl_dense_ndarray_c.mli
+++ b/src/owl/dense/owl_dense_ndarray_c.mli
@@ -316,11 +316,11 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> out:string -> unit
+val save : out:string -> arr -> unit
 
 val load : string -> arr
 
-val save_npy : arr -> out:string -> unit
+val save_npy : out:string -> arr -> unit
 
 val load_npy : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_c.mli
+++ b/src/owl/dense/owl_dense_ndarray_c.mli
@@ -320,6 +320,10 @@ val save : arr -> out:string -> unit
 
 val load : string -> arr
 
+val save_npy : arr -> out:string -> unit
+
+val load_npy : string -> arr
+
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_ndarray_c.mli
+++ b/src/owl/dense/owl_dense_ndarray_c.mli
@@ -316,7 +316,7 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> string -> unit
+val save : arr -> out:string -> unit
 
 val load : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_d.ml
+++ b/src/owl/dense/owl_dense_ndarray_d.ml
@@ -47,6 +47,8 @@ let unit_basis n i = M.unit_basis Float64 n i
 
 let load f = M.load Float64 f
 
+let load_npy f = M.load_npy Float64 f
+
 let of_array x d = M.of_array Float64 x d
 
 let mmap fd ?pos shared dims = Unix.map_file fd ?pos Float64 c_layout shared dims

--- a/src/owl/dense/owl_dense_ndarray_d.mli
+++ b/src/owl/dense/owl_dense_ndarray_d.mli
@@ -310,11 +310,11 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> out:string -> unit
+val save : out:string -> arr -> unit
 
 val load : string -> arr
 
-val save_npy : arr -> out:string -> unit
+val save_npy : out:string -> arr -> unit
 
 val load_npy : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_d.mli
+++ b/src/owl/dense/owl_dense_ndarray_d.mli
@@ -310,7 +310,7 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> string -> unit
+val save : arr -> out:string -> unit
 
 val load : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_d.mli
+++ b/src/owl/dense/owl_dense_ndarray_d.mli
@@ -314,6 +314,10 @@ val save : arr -> out:string -> unit
 
 val load : string -> arr
 
+val save_npy : arr -> out:string -> unit
+
+val load_npy : string -> arr
+
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1828,7 +1828,7 @@ let print ?max_row ?max_col ?header ?fmt x =
 
 let pp_dsnda formatter x = Owl_pretty.pp_dsnda formatter x
 
-let save x f = Owl_io.marshal_to_file x f
+let save x ~out = Owl_io.marshal_to_file x out
 
 let load _k f = Owl_io.marshal_from_file f
 

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1828,11 +1828,11 @@ let print ?max_row ?max_col ?header ?fmt x =
 
 let pp_dsnda formatter x = Owl_pretty.pp_dsnda formatter x
 
-let save x ~out = Owl_io.marshal_to_file x out
+let save ~out x = Owl_io.marshal_to_file x out
 
 let load _k f = Owl_io.marshal_from_file f
 
-let save_npy x ~out = Npy.write x out
+let save_npy ~out x = Npy.write x out
 
 let load_npy kind file =
   match Npy.read_copy file |> Npy.to_bigarray Bigarray.c_layout kind with

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1832,6 +1832,13 @@ let save x ~out = Owl_io.marshal_to_file x out
 
 let load _k f = Owl_io.marshal_from_file f
 
+let save_npy x ~out = Npy.write x out
+
+let load_npy kind file =
+  match Npy.read_copy file |> Npy.to_bigarray Bigarray.c_layout kind with
+  | Some x -> x
+  | None -> failwith Printf.(sprintf "%s: incorrect format" file)
+
 let of_array k x d =
   let n = Array.fold_left (fun a b -> a * b) 1 d in
   let s = Printf.sprintf "x size = %i, output size = %i" (Array.length x) n in

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1050,9 +1050,9 @@ val pp_dsnda : Format.formatter -> ('a, 'b) t -> unit [@@ocaml.toplevel_printer]
 ``pp_dsnda`` only prints out parts of the ndarray.
  *)
 
-val save : ('a, 'b) t -> string -> unit
+val save : ('a, 'b) t -> out:string -> unit
 (**
-``save x s`` serialises a ndarray ``x`` to a file of name ``s``.
+``save x ~out`` serialises a ndarray ``x`` to a file of name ``out``.
  *)
 
 val load : ('a, 'b) kind -> string -> ('a, 'b) t

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1050,9 +1050,9 @@ val pp_dsnda : Format.formatter -> ('a, 'b) t -> unit [@@ocaml.toplevel_printer]
 ``pp_dsnda`` only prints out parts of the ndarray.
  *)
 
-val save : ('a, 'b) t -> out:string -> unit
+val save : out:string -> ('a, 'b) t -> unit
 (**
-``save x ~out`` serialises a ndarray ``x`` to a file of name ``out``.
+``save ~out x`` serialises a ndarray ``x`` to a file of name ``out``.
  *)
 
 val load : ('a, 'b) kind -> string -> ('a, 'b) t
@@ -1061,9 +1061,9 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 It is necesssary to specify the type of the ndarray with paramater ``k``.
 *)
 
-val save_npy : ('a, 'b) t -> out:string -> unit
+val save_npy : out:string -> ('a, 'b) t -> unit
 (**
-``save_npy x ~out`` saves the matrix ``x`` into a npy file ``out``. This function
+``save_npy ~out x`` saves the matrix ``x`` into a npy file ``out``. This function
 is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
  *)
 

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1061,6 +1061,18 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 It is necesssary to specify the type of the ndarray with paramater ``k``.
 *)
 
+val save_npy : ('a, 'b) t -> out:string -> unit
+(**
+``save_npy x ~out`` saves the matrix ``x`` into a npy file ``out``. This function
+is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
+ *)
+
+val load_npy : ('a, 'b) kind -> string -> ('a, 'b) t
+(**
+``load_npy file`` load a npy ``file`` into a matrix of type ``k``. If the matrix is
+in the file is not of type ``k``, fails with ``[file]: incorrect format``. This
+function is implemented using npy-ocaml https://github.com/LaurentMazare/npy-ocaml.
+ *)
 
 (** {6 Unary math operators }  *)
 

--- a/src/owl/dense/owl_dense_ndarray_s.ml
+++ b/src/owl/dense/owl_dense_ndarray_s.ml
@@ -44,6 +44,8 @@ let unit_basis n i = M.unit_basis Float32 n i
 
 let load f = M.load Float32 f
 
+let load_npy f = M.load_npy Float32 f
+
 let of_array x d = M.of_array Float32 x d
 
 let mmap fd ?pos shared dims = Unix.map_file fd ?pos Float32 c_layout shared dims

--- a/src/owl/dense/owl_dense_ndarray_s.mli
+++ b/src/owl/dense/owl_dense_ndarray_s.mli
@@ -310,11 +310,11 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> out:string -> unit
+val save : out:string -> arr -> unit
 
 val load : string -> arr
 
-val save_npy : arr -> out:string -> unit
+val save_npy : out:string -> arr -> unit
 
 val load_npy : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_s.mli
+++ b/src/owl/dense/owl_dense_ndarray_s.mli
@@ -310,7 +310,7 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> string -> unit
+val save : arr -> out:string -> unit
 
 val load : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_s.mli
+++ b/src/owl/dense/owl_dense_ndarray_s.mli
@@ -314,6 +314,10 @@ val save : arr -> out:string -> unit
 
 val load : string -> arr
 
+val save_npy : arr -> out:string -> unit
+
+val load_npy : string -> arr
+
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_ndarray_z.ml
+++ b/src/owl/dense/owl_dense_ndarray_z.ml
@@ -45,6 +45,8 @@ let unit_basis n i = M.unit_basis Complex64 n i
 
 let load f = M.load Complex64 f
 
+let load_npy f = M.load_npy Complex64 f
+
 let of_array x d = M.of_array Complex64 x d
 
 let mmap fd ?pos shared dims = Unix.map_file fd ?pos Complex64 c_layout shared dims

--- a/src/owl/dense/owl_dense_ndarray_z.mli
+++ b/src/owl/dense/owl_dense_ndarray_z.mli
@@ -316,11 +316,11 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> out:string -> unit
+val save : out:string -> arr -> unit
 
 val load : string -> arr
 
-val save_npy : arr -> out:string -> unit
+val save_npy : out:string -> arr -> unit
 
 val load_npy : string -> arr
 

--- a/src/owl/dense/owl_dense_ndarray_z.mli
+++ b/src/owl/dense/owl_dense_ndarray_z.mli
@@ -320,6 +320,10 @@ val save : arr -> out:string -> unit
 
 val load : string -> arr
 
+val save_npy : arr -> out:string -> unit
+
+val load_npy : string -> arr
+
 
 (** {6 Unary mathematical operations } *)
 

--- a/src/owl/dense/owl_dense_ndarray_z.mli
+++ b/src/owl/dense/owl_dense_ndarray_z.mli
@@ -316,7 +316,7 @@ val to_array : arr -> elt array
 
 val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-val save : arr -> string -> unit
+val save : arr -> out:string -> unit
 
 val load : string -> arr
 

--- a/src/owl/dune
+++ b/src/owl/dune
@@ -185,7 +185,7 @@
  (flags
   :standard
   (:include ocaml_flags.sexp))
- (libraries ctypes ctypes.stubs eigen owl-base stdlib-shims))
+ (libraries ctypes ctypes.stubs eigen owl-base stdlib-shims npy))
 
 (rule
  (targets c_flags.sexp c_library_flags.sexp ocaml_flags.sexp

--- a/src/owl/ext/owl_ext_dense_matrix.ml
+++ b/src/owl/ext/owl_ext_dense_matrix.ml
@@ -347,7 +347,7 @@ module type BasicSig = sig
 
   val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-  val save : mat -> string -> unit
+  val save : mat -> out:string -> unit
 
   val load : string -> mat
 
@@ -645,7 +645,7 @@ module Make_Basic
 
   let print x = M.print (unpack_box x)
 
-  let save x f = M.save (unpack_box x) f
+  let save x ~out = M.save (unpack_box x) ~out
 
   let load f = M.load f |> pack_box
 

--- a/src/owl/ext/owl_ext_dense_matrix.ml
+++ b/src/owl/ext/owl_ext_dense_matrix.ml
@@ -347,7 +347,7 @@ module type BasicSig = sig
 
   val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> mat -> unit
 
-  val save : mat -> out:string -> unit
+  val save : out:string -> mat -> unit
 
   val load : string -> mat
 
@@ -645,7 +645,7 @@ module Make_Basic
 
   let print x = M.print (unpack_box x)
 
-  let save x ~out = M.save (unpack_box x) ~out
+  let save ~out x = M.save (unpack_box x) ~out
 
   let load f = M.load f |> pack_box
 

--- a/src/owl/ext/owl_ext_dense_ndarray.ml
+++ b/src/owl/ext/owl_ext_dense_ndarray.ml
@@ -466,7 +466,6 @@ module Make_Basic
 
   let load f = M.load f |> pack_box
 
-
   let sum' x = M.sum' (unpack_box x) |> pack_elt
 
   let prod' x = M.prod' (unpack_box x) |> pack_elt

--- a/src/owl/ext/owl_ext_dense_ndarray.ml
+++ b/src/owl/ext/owl_ext_dense_ndarray.ml
@@ -257,7 +257,7 @@ module type BasicSig = sig
 
   val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-  val save : arr -> string -> unit
+  val save : arr -> out:string -> unit
 
   val load : string -> arr
 
@@ -462,7 +462,7 @@ module Make_Basic
 
   let print x = M.print (unpack_box x)
 
-  let save x f = M.save (unpack_box x) f
+  let save x ~out = M.save (unpack_box x) ~out
 
   let load f = M.load f |> pack_box
 

--- a/src/owl/ext/owl_ext_dense_ndarray.ml
+++ b/src/owl/ext/owl_ext_dense_ndarray.ml
@@ -257,7 +257,7 @@ module type BasicSig = sig
 
   val print : ?max_row:int -> ?max_col:int -> ?header:bool -> ?fmt:(elt -> string) -> arr -> unit
 
-  val save : arr -> out:string -> unit
+  val save : out:string -> arr -> unit
 
   val load : string -> arr
 
@@ -462,7 +462,7 @@ module Make_Basic
 
   let print x = M.print (unpack_box x)
 
-  let save x ~out = M.save (unpack_box x) ~out
+  let save ~out x = M.save (unpack_box x) ~out
 
   let load f = M.load f |> pack_box
 

--- a/test/unit_dense_matrix.ml
+++ b/test/unit_dense_matrix.ml
@@ -200,7 +200,7 @@ module To_test = struct
 
 
   let save_load () =
-    M.save x2 "ds_mat.tmp";
+    M.save x2 ~out:"ds_mat.tmp";
     let y = M.load Float64 "ds_mat.tmp" in
     M.equal x2 y
 

--- a/test/unit_dense_ndarray.ml
+++ b/test/unit_dense_ndarray.ml
@@ -158,7 +158,7 @@ module To_test = struct
   let l2norm' () = M.l2norm' vec = { Complex.re = 5.0; im = 0. }
 
   let save_load () =
-    M.save x0 "ds_nda.tmp";
+    M.save x0 ~out:"ds_nda.tmp";
     let y = M.load Float64 "ds_nda.tmp" in
     M.equal x0 y
 


### PR DESCRIPTION
- Added functions to load and save npy files. These functions are implemented using [npy-ocaml](https://github.com/LaurentMazare/npy-ocaml)
- For "save" functions such as `Mat.save` and `Mat.save_txt`, use labelled argument `~out` to specify file name. Currently, to save a matrix  `mat` as a text file `mat.txt` we would do something like this
```ocaml
let () = 
  let mat = ... in
  Mat.save_txt mat "out.txt"
```
However, `mat` often comes at the end of multiple steps of calculations, it would be convenient to  "pipe" it through `Mat.save_txt` like this
``` ocaml
let () = ... |> Mat.save_txt ~out:"mat.txt"
```
