### PR TITLE
Update lambda layer with optional output shape

### DIFF
--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -646,8 +646,8 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
     add_node nn [| input_node |] n
 
 
-  let lambda ?name ?act_typ lambda input_node =
-    let neuron = Lambda (Lambda.create lambda) in
+  let lambda ?name ?act_typ ?out_shape lambda input_node =
+    let neuron = Lambda (Lambda.create ?out_shape lambda) in
     let nn = get_network input_node in
     let n = make_node ?name [||] [||] neuron None nn in
     add_node ?act_typ nn [| input_node |] n

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -570,12 +570,19 @@ Arguments:
 ``flatten node`` flattens the input. Does not affect the batch size.
   *)
 
-  val lambda : ?name:string -> ?act_typ:Activation.typ -> (t -> t) -> node -> node
+  val lambda
+    :  ?name:string
+    -> ?act_typ:Activation.typ
+    -> ?out_shape:int array
+    -> (t -> t)
+    -> node
+    -> node
   (**
-``lambda func node`` wraps arbitrary expression as a Node object.
+``lambda ?target_shape func node`` wraps arbitrary expression as a Node object.
 
 Arguments:
   * ``func``: The function to be evaluated. Takes input tensor as first argument.
+  * ``target_shape``: the shape of the tensor returned by ``func``; set to the same as input shape if not specified.
   *)
 
   val lambda_array

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2424,11 +2424,18 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
       ; mutable out_shape : int array
       }
 
-    let create lambda = { lambda; in_shape = [||]; out_shape = [||] }
+    let create ?out_shape lambda =
+      let shp =
+        match out_shape with
+        | Some o -> o
+        | None   -> [||]
+      in
+      { lambda; in_shape = [||]; out_shape = shp }
+
 
     let connect out_shape l =
       l.in_shape <- Array.copy out_shape;
-      l.out_shape <- Array.copy out_shape
+      if l.out_shape = [||] then l.out_shape <- Array.copy out_shape
 
 
     let copy l = create l.lambda

--- a/src/base/neural/owl_neural_neuron_sig.ml
+++ b/src/base/neural/owl_neural_neuron_sig.ml
@@ -1329,7 +1329,7 @@ module type Sig = sig
       }
     (** Neuron type definition. *)
 
-    val create : (t -> t) -> neuron_typ
+    val create : ?out_shape:int array -> (t -> t) -> neuron_typ
     (** Create the neuron. *)
 
     val connect : int array -> neuron_typ -> unit


### PR DESCRIPTION
This PR adds an optional output shape argument to the lambda layer in neural network. Here is a simple example:

```ocaml
open Owl
open Neural.S
open Neural.S.Graph
open Neural.S.Algodiff
let dim = 2
let time_steps = 10
let batch_size = 3
let make_network () =
  input [| dim; time_steps |]
  |> lambda ~out_shape:[|dim; 1|] (fun x -> Maths.get_slice [[]; []; [0]] x)
  |> get_network
let nn = make_network ()

let data = Dense.Ndarray.S.ones [|batch_size; dim; time_steps |]
let result = Graph.model nn data
```