### PR TITLE
Re-add removed DiffSharp acknowledgment

### DIFF
--- a/ACKNOWLEDGEMENT.md
+++ b/ACKNOWLEDGEMENT.md
@@ -12,6 +12,8 @@ Because Owl is always under active development, there might be a lag between the
 
 - The early versions heavily relied on [Markus Mottl](http://www.ocaml.info/) and [Christophe Troestler](https://github.com/Chris00)'s projects: [Lacaml](https://github.com/mmottl/lacaml), [Gsl](https://github.com/mmottl/gsl-ocaml).
 
+- [DiffSharp](https://github.com/DiffSharp/DiffSharp) and [Hype](https://github.com/hypelib/Hype) code by [Atilim Gunes Baydin](http://www.robots.ox.ac.uk/~gunes/), [Barak Pearlmutter](http://www.bcl.hamilton.ie/~barak/), [Don Syme](https://www.microsoft.com/en-us/research/people/dsyme/) ported from F# to Algodiff and Optimise modules.
+
 - [Richard Mortier](https://github.com/mor1) has been providing great support and constructive feedback. We two together have been running interesting sub-projects on top of Owl.
 
 - [Ben Catterall](https://www.linkedin.com/in/ben-catterall-38643287/?ppe=1) did excellent theoretical work for Owl's underlying distributed computation engine. He also contributed to the NLP module.

--- a/ACKNOWLEDGEMENT.md
+++ b/ACKNOWLEDGEMENT.md
@@ -30,6 +30,8 @@ Because Owl is always under active development, there might be a lag between the
 
 - [Sergei Lebedev](https://github.com/superbobry) and [bagmanas](https://github.com/bagmanas) contributed various hypothesis test functions in Stats module.
 
+[Francois BERENGER](https://github.com/UnixJunkie) implemented a light and neat logging module which Owl borrows many ideas. The older version of Owl directly used Francois' library.
+
 - Interfacing to other C/C++ libraries (e.g., CBLAS, LAPACKE, Eigen, OpenCL, and etc.) relies on [Jeremy Yallop](https://www.cl.cam.ac.uk/~jdy22/)'s [ocaml-ctypes](https://github.com/ocamllabs/ocaml-ctypes).
 
 - The plot module is built on top of [Hezekiah M. Carty](https://github.com/hcarty)'s project: [ocaml-plplot](https://github.com/hcarty/ocaml-plplot).


### PR DESCRIPTION
This is for re-adding the reference to DiffSharp and Hype code that was ported to OWL Algodiff and Optimise modules. 

It was previously moved from ACKNOWLEDGEMENT.md to README.md with the following commit

https://github.com/owlbarn/owl/commit/da72252bf8e38aca515c1446de7405532d90f544#diff-0deeb0e08f77f3a24a4c8bff22e977a7

and subsequently removed from README.md with the following commit

https://github.com/owlbarn/owl/commit/493f4a5cbb1bbef75218b610badcb95717f7906d#diff-04c6e90faac2675aa89e2176d2eec7d8

Also note that Francois Berenger's acknowledgment seems to be lost in this process as well. @ryanrhymes 