### PR TITLE
Avoid input duplication with Graph.model and multi-input nn

### DIFF
--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -274,6 +274,8 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
 
 
   let model nn =
+    if Array.length nn.roots > 1
+    then failwith "Owl_neural_graph:model Did you mean to use model_inputs?";
     let nn = copy nn in
     _remove_training_nodes nn;
     let inference x =


### PR DESCRIPTION
If one mistakenly uses `Graph.model` with a multi-input nn with inputs of the same shape, the input data is duplicated. If they don't have the same shape, it hits an assert error. 

This adds a check for multi-input and suggests to use `Graph.model_inputs` if appropriate. It resolves https://github.com/owlbarn/owl/issues/484 as the other issues were due to my misunderstanding.