### PR TITLE
Broadcast bug for higher order derivatives

### DIFF
--- a/src/base/algodiff/owl_algodiff_core.ml
+++ b/src/base/algodiff/owl_algodiff_core.ml
@@ -68,6 +68,22 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
     | _      -> failwith "error: AD.shape"
 
 
+  let rec is_float x =
+    match x with
+    | Arr _ -> false
+    | F _   -> true
+    | DF _  -> is_float (primal' x)
+    | DR _  -> is_float (primal' x)
+
+
+  let rec is_arr x =
+    match x with
+    | Arr _ -> false
+    | F _   -> true
+    | DF _  -> is_arr (primal' x)
+    | DR _  -> is_arr (primal' x)
+
+
   let row_num x = (shape x).(0)
 
   let col_num x = (shape x).(1)

--- a/src/base/algodiff/owl_algodiff_core.ml
+++ b/src/base/algodiff/owl_algodiff_core.ml
@@ -64,6 +64,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
 
   let shape x =
     match primal' x with
+    | F _    -> [||]
     | Arr ap -> A.shape ap
     | _      -> failwith "error: AD.shape"
 

--- a/src/base/algodiff/owl_algodiff_core_sig.ml
+++ b/src/base/algodiff/owl_algodiff_core_sig.ml
@@ -39,6 +39,12 @@ module type Sig = sig
   val shape : t -> int array
   (** TODO *)
 
+  val is_float : t -> bool
+  (** TODO *)
+
+  val is_arr : t -> bool
+  (** TODO *)
+
   val row_num : t -> int
   (** number of rows *)
 

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -23,7 +23,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
       then x
       else if lx < ls
       then failwith Printf.(
-          sprintf "_squeeze_broadcase: x must have dimension greater than %i, instead has dimension %i" ls lx
+          sprintf "_squeeze_broadcast: x must have dimension greater than %i, instead has dimension %i" ls lx
           )
       else if ls = 0
       then sum' x

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -22,7 +22,9 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
       if sx = s
       then x
       else if lx < ls
-      then failwith "x should have higher dimensions than that specified by s"
+      then failwith Printf.(
+          sprintf "_squeeze_broadcase: x must have dimension greater than %i, instead has dimension %i" ls lx
+          )
       else if ls = 0
       then sum' x
       else (

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -38,7 +38,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
               else
                 failwith
                   Printf.(
-                    sprintf "there ought to be a broadcasting error %i, %i\n%!" s.(k) sx))
+                    sprintf "_squeeze_broadcast: unkonwn broadcasting error %i, %i\n%!" s.(k) sx))
             (0, [])
             sx
         in

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -15,7 +15,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
   module Maths = struct
     (* squeeze x so that it has shape s *)
-    let rec squeeze_broadcast x s =
+    let rec _squeeze_broadcast x s =
       let sx = shape x in
       let lx = Array.length sx in
       let ls = Array.length s in
@@ -885,12 +885,12 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
              let df_dab _cp _ap at _bp bt = at + bt
 
              let dr_ab a b _cp ca =
-               squeeze_broadcast !ca (shape a), squeeze_broadcast !ca (shape b)
+               _squeeze_broadcast !ca (shape a), _squeeze_broadcast !ca (shape b)
 
 
-             let dr_a a _b _cp ca = squeeze_broadcast !ca (shape a)
+             let dr_a a _b _cp ca = _squeeze_broadcast !ca (shape a)
 
-             let dr_b _a b _cp ca = squeeze_broadcast !ca (shape b)
+             let dr_b _a b _cp ca = _squeeze_broadcast !ca (shape b)
            end : Piso))
 
 
@@ -919,12 +919,12 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
              let df_dab _cp _ap at _bp bt = at - bt
 
              let dr_ab a b _cp ca =
-               squeeze_broadcast !ca (shape a), neg (squeeze_broadcast !ca (shape b))
+               _squeeze_broadcast !ca (shape a), neg (_squeeze_broadcast !ca (shape b))
 
 
-             let dr_a a _b _cp ca = squeeze_broadcast !ca (shape a)
+             let dr_a a _b _cp ca = _squeeze_broadcast !ca (shape a)
 
-             let dr_b _a b _cp ca = neg (squeeze_broadcast !ca (shape b))
+             let dr_b _a b _cp ca = neg (_squeeze_broadcast !ca (shape b))
            end : Piso))
 
 
@@ -953,13 +953,13 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
              let df_dab _cp ap at bp bt = (ap * bt) + (at * bp)
 
              let dr_ab a b _cp ca =
-               ( squeeze_broadcast (!ca * primal b) (shape a)
-               , squeeze_broadcast (!ca * primal a) (shape b) )
+               ( _squeeze_broadcast (!ca * primal b) (shape a)
+               , _squeeze_broadcast (!ca * primal a) (shape b) )
 
 
-             let dr_a a b _cp ca = squeeze_broadcast (!ca * b) (shape a)
+             let dr_a a b _cp ca = _squeeze_broadcast (!ca * b) (shape a)
 
-             let dr_b a b _cp ca = squeeze_broadcast (!ca * a) (shape b)
+             let dr_b a b _cp ca = _squeeze_broadcast (!ca * a) (shape b)
            end : Piso))
 
 
@@ -988,16 +988,16 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
              let df_dab cp _ap at bp bt = (at - (bt * cp)) / bp
 
              let dr_ab a b _cp ca =
-               ( squeeze_broadcast (!ca / primal b) (shape a)
-               , squeeze_broadcast
+               ( _squeeze_broadcast (!ca / primal b) (shape a)
+               , _squeeze_broadcast
                    (!ca * (neg (primal a) / (primal b * primal b)))
                    (shape b) )
 
 
-             let dr_a a b _cp ca = squeeze_broadcast (!ca / b) (shape a)
+             let dr_a a b _cp ca = _squeeze_broadcast (!ca / b) (shape a)
 
              let dr_b a b _cp ca =
-               squeeze_broadcast (!ca * (neg a / (primal b * primal b))) (shape b)
+               _squeeze_broadcast (!ca * (neg a / (primal b * primal b))) (shape b)
            end : Piso))
 
 
@@ -1028,15 +1028,15 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
              let dr_ab a b cp ca =
-               ( squeeze_broadcast (!ca * (a ** (b - pack_flt 1.)) * b) (shape a)
-               , squeeze_broadcast (!ca * cp * log a) (shape b) )
+               ( _squeeze_broadcast (!ca * (a ** (b - pack_flt 1.)) * b) (shape a)
+               , _squeeze_broadcast (!ca * cp * log a) (shape b) )
 
 
              let dr_a a b _cp ca =
-               squeeze_broadcast (!ca * (a ** (b - pack_flt 1.)) * b) (shape a)
+               _squeeze_broadcast (!ca * (a ** (b - pack_flt 1.)) * b) (shape a)
 
 
-             let dr_b a b cp ca = squeeze_broadcast (!ca * cp * log a) (shape b)
+             let dr_b a b cp ca = _squeeze_broadcast (!ca * cp * log a) (shape b)
            end : Piso))
 
 

--- a/src/base/algodiff/owl_algodiff_reverse.ml
+++ b/src/base/algodiff/owl_algodiff_reverse.ml
@@ -30,31 +30,12 @@ struct
 
 
   let reverse_push =
-    (* check adjoint a and its update v, ensure rank a >= rank v. This function fixes the
-       inconsistent shapes between a and v by performing the inverse operation of the
-       previous broadcasting function. Note that padding is on the left due to the expand
-       function called in broadcasting. *)
-    let _shrink a v =
-      match a, v with
-      | F _, Arr v   -> F (A.sum' v)
-      | Arr a, Arr v ->
-        let shp_a = A.shape a in
-        let shp_v = A.shape v in
-        if shp_a <> shp_v
-        then (
-          let shp_a, shp_v = Owl_utils_array.align `Left 1 shp_a shp_v in
-          let axis = Owl_utils_array.filter2_i ( <> ) shp_a shp_v in
-          Arr (A.sum_reduce ~axis v))
-        else Arr v
-      | _a, v        -> v
-    in
     let rec push xs =
       match xs with
       | []          -> ()
       | (v, x) :: t ->
         (match x with
         | DR (cp, aa, (adjoint, _, _), af, _ai, tracker) ->
-          let v = _shrink !aa v in
           aa := reverse_add !aa v;
           (af := Stdlib.(!af - 1));
           if !af = 0 && !tracker = 1


### PR DESCRIPTION
Currently,  when the forward pass involves broadcasting operations, we use `_shrink` in `owl_algodiff_reverse.ml` to make sure the adjoints have the right shape.
Because `_shrink` is not differentiable, we run into reshape/slicing errors when we try and differentiate through it to calculate higher order derivatives e.g.`hessian`.

This is not a problem when we are dealing with first-order gradients because we do not need to differentiate through `_shrink`.

In this PR, I fix this problem by removing the `_shrink` operation from `owl_algodiff_reverse.ml` and introduce a similar, but differentiable, function `_squeeze_broadcast` in `owl_algodiff_ops.ml`. This function is used to make sure that broadcast operations always return adjoints that have the right shape.

Here is a simple script that fails and is fixed in this PR

```ocaml
open Owl
module AD = Algodiff.D
let f x =
   let y = AD.Maths.get_slice [[]; [0]] x in
   let z = AD.Maths.get_slice [[]; [1;4]] x in
   AD.Maths.(sum' (exp (z+y)))
let () =
   let h = AD.(grad (grad f)) in
   let x = AD.Mat.gaussian 1 5 in
   h x |> ignore 
```

I have also changed the `shape` function in algodiff so that it returns an empty `int array` for a float.


