### PR TITLE
Draw poisson RVs in Ndarray and Mat modules

### DIFF
--- a/src/owl/core/owl_ndarray_maths.ml
+++ b/src/owl/core/owl_ndarray_maths.ml
@@ -7044,6 +7044,28 @@ let _owl_exponential : type a b. (a, b) kind -> (a, b) owl_arr_op13 = function
   | _       -> failwith "_owl_exponential: unsupported operation"
 
 
+external owl_float32_poisson
+  :  int
+  -> ('a, 'b) owl_arr
+  -> float
+  -> int
+  -> unit
+  = "float32_poisson"
+
+external owl_float64_poisson
+  :  int
+  -> ('a, 'b) owl_arr
+  -> float
+  -> int
+  -> unit
+  = "float64_poisson"
+
+let _owl_poisson : type a b. (a, b) kind -> (a, b) owl_arr_op12 = function
+  | Float32 -> owl_float32_poisson
+  | Float64 -> owl_float64_poisson
+  | _       -> failwith "_owl_poisson: unsupported operation"
+
+
 external owl_float32_diff
   :  int
   -> int

--- a/src/owl/core/owl_ndarray_maths_stub.c
+++ b/src/owl/core/owl_ndarray_maths_stub.c
@@ -5190,6 +5190,19 @@
 #define MAPFN(X) *X = a * f64_exponential
 #include OWL_NDARRAY_MATHS_MAP
 
+// poisson
+#define FUN18 float32_poisson
+#define INIT double a = Double_val(vA)
+#define NUMBER float 
+#define MAPFN(X) *X = poisson_rvs(a)
+#include OWL_NDARRAY_MATHS_MAP
+
+#define FUN18 float64_poisson
+#define INIT double a = Double_val(vA)
+#define NUMBER double
+#define MAPFN(X) *X = poisson_rvs(a)
+#include OWL_NDARRAY_MATHS_MAP
+
 // diff
 
 #define FUN20 float32_diff

--- a/src/owl/dense/owl_dense_matrix_d.ml
+++ b/src/owl/dense/owl_dense_matrix_d.ml
@@ -39,6 +39,8 @@ let uniform ?a ?b m n = M.uniform Float64 ?a ?b m n
 
 let gaussian ?mu ?sigma m n = M.gaussian Float64 ?mu ?sigma m n
 
+let poisson ~mu m n = M.poisson Float64 ~mu m n
+
 let semidef m = M.semidef Float64 m
 
 let linspace a b n = M.linspace Float64 a b n

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -172,6 +172,8 @@ let uniform k ?a ?b m n = Owl_dense_ndarray_generic.uniform k ?a ?b [| m; n |]
 
 let gaussian k ?mu ?sigma m n = Owl_dense_ndarray_generic.gaussian k ?mu ?sigma [| m; n |]
 
+let poisson k ~mu m n = Owl_dense_ndarray_generic.poisson k ~mu [| m; n |]
+
 let bernoulli k ?p m n = Owl_dense_ndarray_generic.bernoulli k ?p [| m; n |]
 
 let unit_basis k n i =

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -118,6 +118,12 @@ val gaussian : ('a, 'b) kind -> ?mu:'a -> ?sigma:'a -> int -> int -> ('a, 'b) t
 follow a Gaussian distribution with specified sigma. By default ``sigma = 1``.
  *)
 
+val poisson : ('a, 'b) kind -> mu:float -> int -> int -> ('a, 'b) t
+(**
+``poisson m n`` creates an ``m`` by ``n`` matrix where all the elements in ``x``
+follow a Poisson distribution with specified rate mu.
+ *)
+
 val semidef : (float, 'b) kind -> int -> (float, 'b) t
 (**
 `` semidef n `` returns an random ``n`` by ``n`` positive semi-definite matrix.

--- a/src/owl/dense/owl_dense_matrix_intf.ml
+++ b/src/owl/dense/owl_dense_matrix_intf.ml
@@ -871,6 +871,8 @@ module type Real = sig
   val cross_entropy' : mat -> mat -> elt
 
   val clip_by_l2norm : elt -> mat -> mat
+  
+  val poisson : mu:elt -> int -> int -> mat
 end
 
 module type Complex = sig

--- a/src/owl/dense/owl_dense_matrix_s.ml
+++ b/src/owl/dense/owl_dense_matrix_s.ml
@@ -35,6 +35,8 @@ let uniform ?a ?b m n = M.uniform Float32 ?a ?b m n
 
 let gaussian ?mu ?sigma m n = M.gaussian Float32 ?mu ?sigma m n
 
+let poisson ~mu m n = M.poisson Float32 ~mu m n
+
 let semidef m = M.semidef Float32 m
 
 let linspace a b n = M.linspace Float32 a b n

--- a/src/owl/dense/owl_dense_ndarray_d.ml
+++ b/src/owl/dense/owl_dense_ndarray_d.ml
@@ -33,6 +33,8 @@ let uniform ?a ?b dimension = M.uniform Float64 ?a ?b dimension
 
 let gaussian ?mu ?sigma dimension = M.gaussian ?mu ?sigma Float64 dimension
 
+let poisson ~mu dimension = M.poisson ~mu Float64 dimension
+
 let sequential ?a ?step dimension = M.sequential Float64 ?a ?step dimension
 
 let linspace a b n = M.linspace Float64 a b n

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1277,12 +1277,14 @@ let gaussian_ ?mu ?sigma ~out =
 
 
 let poisson k ~mu d =
+  if mu < 0. then failwith Printf.(sprintf "poisson rate must be nonnegative: mu = %f" mu);
   let x = empty k d in
   _owl_poisson k (numel x) x mu 0;
   x
 
 
 let poisson_ ~mu ~out =
+  if mu < 0. then failwith Printf.(sprintf "poisson rate must be nonnegative: mu = %f" mu);
   let k = kind out in
   _owl_poisson k (numel out) out mu 0
 

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -1276,6 +1276,17 @@ let gaussian_ ?mu ?sigma ~out =
   _owl_gaussian k (numel out) out mu sigma
 
 
+let poisson k ~mu d =
+  let x = empty k d in
+  _owl_poisson k (numel x) x mu 0;
+  x
+
+
+let poisson_ ~mu ~out =
+  let k = kind out in
+  _owl_poisson k (numel out) out mu 0
+
+
 let linspace k a b n =
   let x = empty k [| n |] in
   _owl_linspace k n a b x;

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -101,6 +101,11 @@ val gaussian : ('a, 'b) kind -> ?mu:'a -> ?sigma:'a -> int array -> ('a, 'b) t
 ``gaussian Float64 [|3;4;5|]`` ...
  *)
 
+val poisson : ('a, 'b) kind -> mu:float -> int array -> ('a, 'b) t
+(**
+``poisson Float64 [|3;4;5|]`` ...
+ *)
+
 val sequential : ('a, 'b) kind -> ?a:'a -> ?step:'a -> int array -> ('a, 'b) t
 (**
 ``sequential Bigarray.Float64 [|3;4;5|] 2.`` creates a three-diemensional
@@ -2263,6 +2268,9 @@ val uniform_ : ?a:'a -> ?b:'a -> out:('a, 'b) t -> unit
 (** TODO *)
 
 val gaussian_ : ?mu:'a -> ?sigma:'a -> out:('a, 'b) t -> unit
+(** TODO *)
+
+val poisson_ : mu:float -> out:('a, 'b) t -> unit
 (** TODO *)
 
 val sequential_ : ?a:'a -> ?step:'a -> out:('a, 'b) t -> unit

--- a/src/owl/dense/owl_dense_ndarray_intf.ml
+++ b/src/owl/dense/owl_dense_ndarray_intf.ml
@@ -556,6 +556,10 @@ module type Real = sig
   val cross_entropy' : arr -> arr -> float
 
   val fused_adagrad_ : ?out:arr -> rate:float -> eps:float -> arr -> unit
+
+  val poisson : mu:elt -> int array -> arr
+
+  val poisson_ : mu:elt -> out:arr -> unit
 end
 
 module type Complex = sig

--- a/src/owl/dense/owl_dense_ndarray_s.ml
+++ b/src/owl/dense/owl_dense_ndarray_s.ml
@@ -31,6 +31,8 @@ let uniform ?a ?b dimension = M.uniform Float32 ?a ?b dimension
 
 let gaussian ?mu ?sigma dimension = M.gaussian ?mu ?sigma Float32 dimension
 
+let poisson ~mu dimension = M.poisson ~mu Float32 dimension
+
 let sequential ?a ?step dimension = M.sequential Float32 ?a ?step dimension
 
 let linspace a b n = M.linspace Float32 a b n

--- a/src/owl/stats/owl_stats.h
+++ b/src/owl/stats/owl_stats.h
@@ -260,7 +260,7 @@ extern double multinomial_logpdf (const long K, const double p[], const int32_t 
 
 extern long poisson_rvs(double lambda);
 
-/** Poisson distribution **/
+/** Dirichlet distribution **/
 
 extern void dirichlet_rvs (const int K, const double alpha[], double theta[]);
 


### PR DESCRIPTION
I added a function to draw samples from a poisson distribution with rate `mu`
```ocaml
val poisson : mu:float -> int array -> Arr.arr
```
Here, I have not implemented the option to provide a `mu` of type `Arr.arr`, as suggested in #496.  

Perhaps, as future extensions,  for each the random variable functions `gaussian`, `uniform` and `poisson`, we could add the variants:

```ocaml
val gaussian_rvs : mu:Arr.arr -> sigma:Arr.arr -> int array -> Arr.arr
val uniform_rvs : a:Arr.arr -> b:Arr.arr -> int array -> Arr.arr
val poisson_rvs: mu:Arr.arr -> int array -> Arr.arr
```

where parameters `mu`, `sigma`, `a`, and `b` are broadcasted to the requested shape.

For `gaussian_rvs`, this could already easily implemented:

```ocaml
let gaussian_rvs ~mu ~sigma dims =
     mu + (sigma * (gaussian dims))
```