### PR TITLE
Added poisson_rvs to Owl_distribution

### DIFF
--- a/src/base/types/owl_types_stats_dist.ml
+++ b/src/base/types/owl_types_stats_dist.ml
@@ -60,6 +60,8 @@ module type Sig = sig
 
   val exponential_isf : lambda:arr -> arr -> arr
 
+  val poisson_rvs : mu:arr -> n:int -> arr
+
   val gamma_rvs : shape:arr -> scale:arr -> n:int -> arr
 
   val gamma_pdf : shape:arr -> scale:arr -> arr -> arr

--- a/src/owl/ppl/owl_distribution.ml
+++ b/src/owl/ppl/owl_distribution.ml
@@ -118,6 +118,17 @@ module Make (A : Stats_Dist) = struct
     let isf t x = A.exponential_isf ~lambda:t.lambda x
   end
 
+  module Poisson = struct
+    type t = { mu : A.arr }
+
+    let make ~mu =
+      Utility._check_broadcast_shape [| mu |];
+      { mu }
+
+
+    let sample t n = A.poisson_rvs ~mu:t.mu ~n
+  end
+
   module Gamma = struct
     type t =
       { shape : A.arr

--- a/src/owl/ppl/owl_distribution.mli
+++ b/src/owl/ppl/owl_distribution.mli
@@ -123,6 +123,19 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
+  (** {6 Poisson distribtion} *)
+
+  module Poisson : sig
+    type t = { mu : A.arr }
+    (** Type definition of a specific distribution *)
+
+    val make : mu:A.arr -> t
+    (** Make a distribution of the given parameters. *)
+
+    val sample : t -> int -> A.arr
+    (** Sample a distribution of the given parameters. *)
+  end
+
   (** {6 Gamma distribtion} *)
 
   module Gamma : sig

--- a/src/owl/ppl/owl_distribution_common.ml
+++ b/src/owl/ppl/owl_distribution_common.ml
@@ -710,6 +710,32 @@ let _owl_exponential_isf : type a b. (a, b) kind -> (a, b) owl_arr_op17 = functi
   | _       -> failwith "_owl_exponential_isf: unsupported operation"
 
 
+external owl_float32_poisson_rvs
+  :  ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> unit
+  = "float32_poisson_rvs" "float32_poisson_rvs_impl"
+
+external owl_float64_poisson_rvs
+  :  ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> ('a, 'b) owl_arr
+  -> (int64, int64_elt) owl_arr
+  -> unit
+  = "float64_poisson_rvs" "float64_poisson_rvs_impl"
+
+let _owl_poisson_rvs : type a b. (a, b) kind -> (a, b) owl_arr_op17 = function
+  | Float32 -> owl_float32_poisson_rvs
+  | Float64 -> owl_float64_poisson_rvs
+  | _       -> failwith "_owl_poisson_rvs: unsupported operation"
+
+
 external owl_float32_gamma_rvs
   :  ('a, 'b) owl_arr
   -> (int64, int64_elt) owl_arr

--- a/src/owl/ppl/owl_distribution_common_c.c
+++ b/src/owl/ppl/owl_distribution_common_c.c
@@ -6,11 +6,9 @@
 #include "owl_core.h"
 #include "owl_stats.h"
 
-
 #define OWL_ENABLE_TEMPLATE
 
 //////////////////// function templates starts ////////////////////
-
 
 // uniform_rvs
 
@@ -18,14 +16,14 @@
 #define FUN25_IMPL float32_uniform_rvs_impl
 #define FUN25_CODE float32_uniform_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = *X + (*Y - *X) * sfmt_f32_2
+#define MAPFN(X, Y, Z) *Z = *X + (*Y - *X) * sfmt_f32_2
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_rvs
 #define FUN25_IMPL float64_uniform_rvs_impl
 #define FUN25_CODE float64_uniform_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = *X + (*Y - *X) * sfmt_f64_2
+#define MAPFN(X, Y, Z) *Z = *X + (*Y - *X) * sfmt_f64_2
 #include "owl_ndarray_maths_map.h"
 
 // uniform_pdf
@@ -34,14 +32,14 @@
 #define FUN25_IMPL float32_uniform_pdf_impl
 #define FUN25_CODE float32_uniform_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_pdf
 #define FUN25_IMPL float64_uniform_pdf_impl
 #define FUN25_CODE float64_uniform_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_logpdf
@@ -50,14 +48,14 @@
 #define FUN25_IMPL float32_uniform_logpdf_impl
 #define FUN25_CODE float32_uniform_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_logpdf
 #define FUN25_IMPL float64_uniform_logpdf_impl
 #define FUN25_CODE float64_uniform_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_cdf
@@ -66,14 +64,14 @@
 #define FUN25_IMPL float32_uniform_cdf_impl
 #define FUN25_CODE float32_uniform_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_cdf
 #define FUN25_IMPL float64_uniform_cdf_impl
 #define FUN25_CODE float64_uniform_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_logcdf
@@ -82,14 +80,14 @@
 #define FUN25_IMPL float32_uniform_logcdf_impl
 #define FUN25_CODE float32_uniform_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_logcdf
 #define FUN25_IMPL float64_uniform_logcdf_impl
 #define FUN25_CODE float64_uniform_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_ppf
@@ -98,14 +96,14 @@
 #define FUN25_IMPL float32_uniform_ppf_impl
 #define FUN25_CODE float32_uniform_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_ppf
 #define FUN25_IMPL float64_uniform_ppf_impl
 #define FUN25_CODE float64_uniform_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_sf
@@ -114,14 +112,14 @@
 #define FUN25_IMPL float32_uniform_sf_impl
 #define FUN25_CODE float32_uniform_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_sf
 #define FUN25_IMPL float64_uniform_sf_impl
 #define FUN25_CODE float64_uniform_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_logsf
@@ -130,14 +128,14 @@
 #define FUN25_IMPL float32_uniform_logsf_impl
 #define FUN25_CODE float32_uniform_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_logsf
 #define FUN25_IMPL float64_uniform_logsf_impl
 #define FUN25_CODE float64_uniform_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // uniform_isf
@@ -146,14 +144,14 @@
 #define FUN25_IMPL float32_uniform_isf_impl
 #define FUN25_CODE float32_uniform_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = uniform_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_uniform_isf
 #define FUN25_IMPL float64_uniform_isf_impl
 #define FUN25_CODE float64_uniform_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = uniform_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = uniform_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_rvs
@@ -162,14 +160,14 @@
 #define FUN25_IMPL float32_gaussian_rvs_impl
 #define FUN25_CODE float32_gaussian_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_rvs
 #define FUN25_IMPL float64_gaussian_rvs_impl
 #define FUN25_CODE float64_gaussian_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_pdf
@@ -178,14 +176,14 @@
 #define FUN25_IMPL float32_gaussian_pdf_impl
 #define FUN25_CODE float32_gaussian_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_pdf
 #define FUN25_IMPL float64_gaussian_pdf_impl
 #define FUN25_CODE float64_gaussian_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_logpdf
@@ -194,14 +192,14 @@
 #define FUN25_IMPL float32_gaussian_logpdf_impl
 #define FUN25_CODE float32_gaussian_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_logpdf
 #define FUN25_IMPL float64_gaussian_logpdf_impl
 #define FUN25_CODE float64_gaussian_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_cdf
@@ -210,14 +208,14 @@
 #define FUN25_IMPL float32_gaussian_cdf_impl
 #define FUN25_CODE float32_gaussian_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_cdf
 #define FUN25_IMPL float64_gaussian_cdf_impl
 #define FUN25_CODE float64_gaussian_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_logcdf
@@ -226,14 +224,14 @@
 #define FUN25_IMPL float32_gaussian_logcdf_impl
 #define FUN25_CODE float32_gaussian_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_logcdf
 #define FUN25_IMPL float64_gaussian_logcdf_impl
 #define FUN25_CODE float64_gaussian_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_ppf
@@ -242,14 +240,14 @@
 #define FUN25_IMPL float32_gaussian_ppf_impl
 #define FUN25_CODE float32_gaussian_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_ppf
 #define FUN25_IMPL float64_gaussian_ppf_impl
 #define FUN25_CODE float64_gaussian_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_sf
@@ -258,14 +256,14 @@
 #define FUN25_IMPL float32_gaussian_sf_impl
 #define FUN25_CODE float32_gaussian_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_sf
 #define FUN25_IMPL float64_gaussian_sf_impl
 #define FUN25_CODE float64_gaussian_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_logsf
@@ -274,14 +272,14 @@
 #define FUN25_IMPL float32_gaussian_logsf_impl
 #define FUN25_CODE float32_gaussian_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_logsf
 #define FUN25_IMPL float64_gaussian_logsf_impl
 #define FUN25_CODE float64_gaussian_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gaussian_isf
@@ -290,14 +288,14 @@
 #define FUN25_IMPL float32_gaussian_isf_impl
 #define FUN25_CODE float32_gaussian_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gaussian_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gaussian_isf
 #define FUN25_IMPL float64_gaussian_isf_impl
 #define FUN25_CODE float64_gaussian_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gaussian_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gaussian_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_rvs
@@ -306,14 +304,14 @@
 #define FUN24_IMPL float32_exponential_rvs_impl
 #define FUN24_CODE float32_exponential_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = exponential_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_rvs
 #define FUN24_IMPL float64_exponential_rvs_impl
 #define FUN24_CODE float64_exponential_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = exponential_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_pdf
@@ -322,14 +320,14 @@
 #define FUN24_IMPL float32_exponential_pdf_impl
 #define FUN24_CODE float32_exponential_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_pdf
 #define FUN24_IMPL float64_exponential_pdf_impl
 #define FUN24_CODE float64_exponential_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_logpdf
@@ -338,14 +336,14 @@
 #define FUN24_IMPL float32_exponential_logpdf_impl
 #define FUN24_CODE float32_exponential_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_logpdf
 #define FUN24_IMPL float64_exponential_logpdf_impl
 #define FUN24_CODE float64_exponential_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_cdf
@@ -354,14 +352,14 @@
 #define FUN24_IMPL float32_exponential_cdf_impl
 #define FUN24_CODE float32_exponential_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_cdf
 #define FUN24_IMPL float64_exponential_cdf_impl
 #define FUN24_CODE float64_exponential_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_logcdf
@@ -370,14 +368,14 @@
 #define FUN24_IMPL float32_exponential_logcdf_impl
 #define FUN24_CODE float32_exponential_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_logcdf
 #define FUN24_IMPL float64_exponential_logcdf_impl
 #define FUN24_CODE float64_exponential_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_ppf
@@ -386,14 +384,14 @@
 #define FUN24_IMPL float32_exponential_ppf_impl
 #define FUN24_CODE float32_exponential_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_ppf
 #define FUN24_IMPL float64_exponential_ppf_impl
 #define FUN24_CODE float64_exponential_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_sf
@@ -402,14 +400,14 @@
 #define FUN24_IMPL float32_exponential_sf_impl
 #define FUN24_CODE float32_exponential_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_sf
 #define FUN24_IMPL float64_exponential_sf_impl
 #define FUN24_CODE float64_exponential_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_logsf
@@ -418,14 +416,14 @@
 #define FUN24_IMPL float32_exponential_logsf_impl
 #define FUN24_CODE float32_exponential_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_logsf
 #define FUN24_IMPL float64_exponential_logsf_impl
 #define FUN24_CODE float64_exponential_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // exponential_isf
@@ -434,14 +432,30 @@
 #define FUN24_IMPL float32_exponential_isf_impl
 #define FUN24_CODE float32_exponential_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = exponential_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_isf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_exponential_isf
 #define FUN24_IMPL float64_exponential_isf_impl
 #define FUN24_CODE float64_exponential_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = exponential_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = exponential_isf(*X, *Y)
+#include "owl_ndarray_maths_map.h"
+
+// poisson_rvs
+
+#define FUN24 float32_poisson_rvs
+#define FUN24_IMPL float32_poisson_rvs_impl
+#define FUN24_CODE float32_poisson_rvs_code
+#define NUMBER float
+#define MAPFN(X, Y, Z) *Z = poisson_rvs(*X)
+#include "owl_ndarray_maths_map.h"
+
+#define FUN24 float64_poisson_rvs
+#define FUN24_IMPL float64_poisson_rvs_impl
+#define FUN24_CODE float64_poisson_rvs_code
+#define NUMBER double
+#define MAPFN(X, Y, Z) *Z = poisson_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_rvs
@@ -450,14 +464,14 @@
 #define FUN25_IMPL float32_gamma_rvs_impl
 #define FUN25_CODE float32_gamma_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_rvs
 #define FUN25_IMPL float64_gamma_rvs_impl
 #define FUN25_CODE float64_gamma_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_pdf
@@ -466,14 +480,14 @@
 #define FUN25_IMPL float32_gamma_pdf_impl
 #define FUN25_CODE float32_gamma_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_pdf
 #define FUN25_IMPL float64_gamma_pdf_impl
 #define FUN25_CODE float64_gamma_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_logpdf
@@ -482,14 +496,14 @@
 #define FUN25_IMPL float32_gamma_logpdf_impl
 #define FUN25_CODE float32_gamma_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_logpdf
 #define FUN25_IMPL float64_gamma_logpdf_impl
 #define FUN25_CODE float64_gamma_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_cdf
@@ -498,14 +512,14 @@
 #define FUN25_IMPL float32_gamma_cdf_impl
 #define FUN25_CODE float32_gamma_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_cdf
 #define FUN25_IMPL float64_gamma_cdf_impl
 #define FUN25_CODE float64_gamma_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_logcdf
@@ -514,14 +528,14 @@
 #define FUN25_IMPL float32_gamma_logcdf_impl
 #define FUN25_CODE float32_gamma_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_logcdf
 #define FUN25_IMPL float64_gamma_logcdf_impl
 #define FUN25_CODE float64_gamma_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_ppf
@@ -530,14 +544,14 @@
 #define FUN25_IMPL float32_gamma_ppf_impl
 #define FUN25_CODE float32_gamma_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_ppf
 #define FUN25_IMPL float64_gamma_ppf_impl
 #define FUN25_CODE float64_gamma_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_sf
@@ -546,14 +560,14 @@
 #define FUN25_IMPL float32_gamma_sf_impl
 #define FUN25_CODE float32_gamma_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_sf
 #define FUN25_IMPL float64_gamma_sf_impl
 #define FUN25_CODE float64_gamma_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_logsf
@@ -562,14 +576,14 @@
 #define FUN25_IMPL float32_gamma_logsf_impl
 #define FUN25_CODE float32_gamma_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_logsf
 #define FUN25_IMPL float64_gamma_logsf_impl
 #define FUN25_CODE float64_gamma_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gamma_isf
@@ -578,14 +592,14 @@
 #define FUN25_IMPL float32_gamma_isf_impl
 #define FUN25_CODE float32_gamma_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gamma_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gamma_isf
 #define FUN25_IMPL float64_gamma_isf_impl
 #define FUN25_CODE float64_gamma_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gamma_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gamma_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_rvs
@@ -594,14 +608,14 @@
 #define FUN25_IMPL float32_beta_rvs_impl
 #define FUN25_CODE float32_beta_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_rvs
 #define FUN25_IMPL float64_beta_rvs_impl
 #define FUN25_CODE float64_beta_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_pdf
@@ -610,14 +624,14 @@
 #define FUN25_IMPL float32_beta_pdf_impl
 #define FUN25_CODE float32_beta_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_pdf
 #define FUN25_IMPL float64_beta_pdf_impl
 #define FUN25_CODE float64_beta_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_logpdf
@@ -626,14 +640,14 @@
 #define FUN25_IMPL float32_beta_logpdf_impl
 #define FUN25_CODE float32_beta_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_logpdf
 #define FUN25_IMPL float64_beta_logpdf_impl
 #define FUN25_CODE float64_beta_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_cdf
@@ -642,14 +656,14 @@
 #define FUN25_IMPL float32_beta_cdf_impl
 #define FUN25_CODE float32_beta_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_cdf
 #define FUN25_IMPL float64_beta_cdf_impl
 #define FUN25_CODE float64_beta_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_logcdf
@@ -658,14 +672,14 @@
 #define FUN25_IMPL float32_beta_logcdf_impl
 #define FUN25_CODE float32_beta_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_logcdf
 #define FUN25_IMPL float64_beta_logcdf_impl
 #define FUN25_CODE float64_beta_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_ppf
@@ -674,14 +688,14 @@
 #define FUN25_IMPL float32_beta_ppf_impl
 #define FUN25_CODE float32_beta_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_ppf
 #define FUN25_IMPL float64_beta_ppf_impl
 #define FUN25_CODE float64_beta_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_sf
@@ -690,14 +704,14 @@
 #define FUN25_IMPL float32_beta_sf_impl
 #define FUN25_CODE float32_beta_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_sf
 #define FUN25_IMPL float64_beta_sf_impl
 #define FUN25_CODE float64_beta_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_logsf
@@ -706,14 +720,14 @@
 #define FUN25_IMPL float32_beta_logsf_impl
 #define FUN25_CODE float32_beta_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_logsf
 #define FUN25_IMPL float64_beta_logsf_impl
 #define FUN25_CODE float64_beta_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // beta_isf
@@ -722,14 +736,14 @@
 #define FUN25_IMPL float32_beta_isf_impl
 #define FUN25_CODE float32_beta_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = beta_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_beta_isf
 #define FUN25_IMPL float64_beta_isf_impl
 #define FUN25_CODE float64_beta_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = beta_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = beta_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_rvs
@@ -738,14 +752,14 @@
 #define FUN24_IMPL float32_chi2_rvs_impl
 #define FUN24_CODE float32_chi2_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = chi2_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_rvs
 #define FUN24_IMPL float64_chi2_rvs_impl
 #define FUN24_CODE float64_chi2_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = chi2_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_pdf
@@ -754,14 +768,14 @@
 #define FUN24_IMPL float32_chi2_pdf_impl
 #define FUN24_CODE float32_chi2_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_pdf
 #define FUN24_IMPL float64_chi2_pdf_impl
 #define FUN24_CODE float64_chi2_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_logpdf
@@ -770,14 +784,14 @@
 #define FUN24_IMPL float32_chi2_logpdf_impl
 #define FUN24_CODE float32_chi2_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_logpdf
 #define FUN24_IMPL float64_chi2_logpdf_impl
 #define FUN24_CODE float64_chi2_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_cdf
@@ -786,14 +800,14 @@
 #define FUN24_IMPL float32_chi2_cdf_impl
 #define FUN24_CODE float32_chi2_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_cdf
 #define FUN24_IMPL float64_chi2_cdf_impl
 #define FUN24_CODE float64_chi2_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_logcdf
@@ -802,14 +816,14 @@
 #define FUN24_IMPL float32_chi2_logcdf_impl
 #define FUN24_CODE float32_chi2_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_logcdf
 #define FUN24_IMPL float64_chi2_logcdf_impl
 #define FUN24_CODE float64_chi2_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_ppf
@@ -818,14 +832,14 @@
 #define FUN24_IMPL float32_chi2_ppf_impl
 #define FUN24_CODE float32_chi2_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_ppf
 #define FUN24_IMPL float64_chi2_ppf_impl
 #define FUN24_CODE float64_chi2_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_sf
@@ -834,14 +848,14 @@
 #define FUN24_IMPL float32_chi2_sf_impl
 #define FUN24_CODE float32_chi2_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_sf
 #define FUN24_IMPL float64_chi2_sf_impl
 #define FUN24_CODE float64_chi2_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_logsf
@@ -850,14 +864,14 @@
 #define FUN24_IMPL float32_chi2_logsf_impl
 #define FUN24_CODE float32_chi2_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_logsf
 #define FUN24_IMPL float64_chi2_logsf_impl
 #define FUN24_CODE float64_chi2_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // chi2_isf
@@ -866,14 +880,14 @@
 #define FUN24_IMPL float32_chi2_isf_impl
 #define FUN24_CODE float32_chi2_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = chi2_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_isf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_chi2_isf
 #define FUN24_IMPL float64_chi2_isf_impl
 #define FUN24_CODE float64_chi2_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = chi2_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = chi2_isf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_rvs
@@ -882,14 +896,14 @@
 #define FUN25_IMPL float32_f_rvs_impl
 #define FUN25_CODE float32_f_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_rvs
 #define FUN25_IMPL float64_f_rvs_impl
 #define FUN25_CODE float64_f_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_pdf
@@ -898,14 +912,14 @@
 #define FUN25_IMPL float32_f_pdf_impl
 #define FUN25_CODE float32_f_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_pdf
 #define FUN25_IMPL float64_f_pdf_impl
 #define FUN25_CODE float64_f_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_logpdf
@@ -914,14 +928,14 @@
 #define FUN25_IMPL float32_f_logpdf_impl
 #define FUN25_CODE float32_f_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_logpdf
 #define FUN25_IMPL float64_f_logpdf_impl
 #define FUN25_CODE float64_f_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_cdf
@@ -930,14 +944,14 @@
 #define FUN25_IMPL float32_f_cdf_impl
 #define FUN25_CODE float32_f_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_cdf
 #define FUN25_IMPL float64_f_cdf_impl
 #define FUN25_CODE float64_f_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_logcdf
@@ -946,14 +960,14 @@
 #define FUN25_IMPL float32_f_logcdf_impl
 #define FUN25_CODE float32_f_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_logcdf
 #define FUN25_IMPL float64_f_logcdf_impl
 #define FUN25_CODE float64_f_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_ppf
@@ -962,14 +976,14 @@
 #define FUN25_IMPL float32_f_ppf_impl
 #define FUN25_CODE float32_f_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_ppf
 #define FUN25_IMPL float64_f_ppf_impl
 #define FUN25_CODE float64_f_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_sf
@@ -978,14 +992,14 @@
 #define FUN25_IMPL float32_f_sf_impl
 #define FUN25_CODE float32_f_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_sf
 #define FUN25_IMPL float64_f_sf_impl
 #define FUN25_CODE float64_f_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_logsf
@@ -994,14 +1008,14 @@
 #define FUN25_IMPL float32_f_logsf_impl
 #define FUN25_CODE float32_f_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_logsf
 #define FUN25_IMPL float64_f_logsf_impl
 #define FUN25_CODE float64_f_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // f_isf
@@ -1010,14 +1024,14 @@
 #define FUN25_IMPL float32_f_isf_impl
 #define FUN25_CODE float32_f_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = f_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_f_isf
 #define FUN25_IMPL float64_f_isf_impl
 #define FUN25_CODE float64_f_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = f_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = f_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_rvs
@@ -1026,14 +1040,14 @@
 #define FUN25_IMPL float32_cauchy_rvs_impl
 #define FUN25_CODE float32_cauchy_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_rvs
 #define FUN25_IMPL float64_cauchy_rvs_impl
 #define FUN25_CODE float64_cauchy_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_pdf
@@ -1042,14 +1056,14 @@
 #define FUN25_IMPL float32_cauchy_pdf_impl
 #define FUN25_CODE float32_cauchy_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_pdf
 #define FUN25_IMPL float64_cauchy_pdf_impl
 #define FUN25_CODE float64_cauchy_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_logpdf
@@ -1058,14 +1072,14 @@
 #define FUN25_IMPL float32_cauchy_logpdf_impl
 #define FUN25_CODE float32_cauchy_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_logpdf
 #define FUN25_IMPL float64_cauchy_logpdf_impl
 #define FUN25_CODE float64_cauchy_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_cdf
@@ -1074,14 +1088,14 @@
 #define FUN25_IMPL float32_cauchy_cdf_impl
 #define FUN25_CODE float32_cauchy_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_cdf
 #define FUN25_IMPL float64_cauchy_cdf_impl
 #define FUN25_CODE float64_cauchy_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_logcdf
@@ -1090,14 +1104,14 @@
 #define FUN25_IMPL float32_cauchy_logcdf_impl
 #define FUN25_CODE float32_cauchy_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_logcdf
 #define FUN25_IMPL float64_cauchy_logcdf_impl
 #define FUN25_CODE float64_cauchy_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_ppf
@@ -1106,14 +1120,14 @@
 #define FUN25_IMPL float32_cauchy_ppf_impl
 #define FUN25_CODE float32_cauchy_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_ppf
 #define FUN25_IMPL float64_cauchy_ppf_impl
 #define FUN25_CODE float64_cauchy_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_sf
@@ -1122,14 +1136,14 @@
 #define FUN25_IMPL float32_cauchy_sf_impl
 #define FUN25_CODE float32_cauchy_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_sf
 #define FUN25_IMPL float64_cauchy_sf_impl
 #define FUN25_CODE float64_cauchy_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_logsf
@@ -1138,14 +1152,14 @@
 #define FUN25_IMPL float32_cauchy_logsf_impl
 #define FUN25_CODE float32_cauchy_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_logsf
 #define FUN25_IMPL float64_cauchy_logsf_impl
 #define FUN25_CODE float64_cauchy_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // cauchy_isf
@@ -1154,14 +1168,14 @@
 #define FUN25_IMPL float32_cauchy_isf_impl
 #define FUN25_CODE float32_cauchy_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = cauchy_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_cauchy_isf
 #define FUN25_IMPL float64_cauchy_isf_impl
 #define FUN25_CODE float64_cauchy_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = cauchy_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = cauchy_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_rvs
@@ -1170,14 +1184,14 @@
 #define FUN25_IMPL float32_lomax_rvs_impl
 #define FUN25_CODE float32_lomax_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_rvs
 #define FUN25_IMPL float64_lomax_rvs_impl
 #define FUN25_CODE float64_lomax_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_pdf
@@ -1186,14 +1200,14 @@
 #define FUN25_IMPL float32_lomax_pdf_impl
 #define FUN25_CODE float32_lomax_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_pdf
 #define FUN25_IMPL float64_lomax_pdf_impl
 #define FUN25_CODE float64_lomax_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_logpdf
@@ -1202,14 +1216,14 @@
 #define FUN25_IMPL float32_lomax_logpdf_impl
 #define FUN25_CODE float32_lomax_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_logpdf
 #define FUN25_IMPL float64_lomax_logpdf_impl
 #define FUN25_CODE float64_lomax_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_cdf
@@ -1218,14 +1232,14 @@
 #define FUN25_IMPL float32_lomax_cdf_impl
 #define FUN25_CODE float32_lomax_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_cdf
 #define FUN25_IMPL float64_lomax_cdf_impl
 #define FUN25_CODE float64_lomax_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_logcdf
@@ -1234,14 +1248,14 @@
 #define FUN25_IMPL float32_lomax_logcdf_impl
 #define FUN25_CODE float32_lomax_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_logcdf
 #define FUN25_IMPL float64_lomax_logcdf_impl
 #define FUN25_CODE float64_lomax_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_ppf
@@ -1250,14 +1264,14 @@
 #define FUN25_IMPL float32_lomax_ppf_impl
 #define FUN25_CODE float32_lomax_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_ppf
 #define FUN25_IMPL float64_lomax_ppf_impl
 #define FUN25_CODE float64_lomax_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_sf
@@ -1266,14 +1280,14 @@
 #define FUN25_IMPL float32_lomax_sf_impl
 #define FUN25_CODE float32_lomax_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_sf
 #define FUN25_IMPL float64_lomax_sf_impl
 #define FUN25_CODE float64_lomax_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_logsf
@@ -1282,14 +1296,14 @@
 #define FUN25_IMPL float32_lomax_logsf_impl
 #define FUN25_CODE float32_lomax_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_logsf
 #define FUN25_IMPL float64_lomax_logsf_impl
 #define FUN25_CODE float64_lomax_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lomax_isf
@@ -1298,14 +1312,14 @@
 #define FUN25_IMPL float32_lomax_isf_impl
 #define FUN25_CODE float32_lomax_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lomax_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lomax_isf
 #define FUN25_IMPL float64_lomax_isf_impl
 #define FUN25_CODE float64_lomax_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lomax_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lomax_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_rvs
@@ -1314,14 +1328,14 @@
 #define FUN25_IMPL float32_weibull_rvs_impl
 #define FUN25_CODE float32_weibull_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_rvs
 #define FUN25_IMPL float64_weibull_rvs_impl
 #define FUN25_CODE float64_weibull_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_pdf
@@ -1330,14 +1344,14 @@
 #define FUN25_IMPL float32_weibull_pdf_impl
 #define FUN25_CODE float32_weibull_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_pdf
 #define FUN25_IMPL float64_weibull_pdf_impl
 #define FUN25_CODE float64_weibull_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_logpdf
@@ -1346,14 +1360,14 @@
 #define FUN25_IMPL float32_weibull_logpdf_impl
 #define FUN25_CODE float32_weibull_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_logpdf
 #define FUN25_IMPL float64_weibull_logpdf_impl
 #define FUN25_CODE float64_weibull_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_cdf
@@ -1362,14 +1376,14 @@
 #define FUN25_IMPL float32_weibull_cdf_impl
 #define FUN25_CODE float32_weibull_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_cdf
 #define FUN25_IMPL float64_weibull_cdf_impl
 #define FUN25_CODE float64_weibull_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_logcdf
@@ -1378,14 +1392,14 @@
 #define FUN25_IMPL float32_weibull_logcdf_impl
 #define FUN25_CODE float32_weibull_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_logcdf
 #define FUN25_IMPL float64_weibull_logcdf_impl
 #define FUN25_CODE float64_weibull_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_ppf
@@ -1394,14 +1408,14 @@
 #define FUN25_IMPL float32_weibull_ppf_impl
 #define FUN25_CODE float32_weibull_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_ppf
 #define FUN25_IMPL float64_weibull_ppf_impl
 #define FUN25_CODE float64_weibull_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_sf
@@ -1410,14 +1424,14 @@
 #define FUN25_IMPL float32_weibull_sf_impl
 #define FUN25_CODE float32_weibull_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_sf
 #define FUN25_IMPL float64_weibull_sf_impl
 #define FUN25_CODE float64_weibull_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_logsf
@@ -1426,14 +1440,14 @@
 #define FUN25_IMPL float32_weibull_logsf_impl
 #define FUN25_CODE float32_weibull_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_logsf
 #define FUN25_IMPL float64_weibull_logsf_impl
 #define FUN25_CODE float64_weibull_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // weibull_isf
@@ -1442,14 +1456,14 @@
 #define FUN25_IMPL float32_weibull_isf_impl
 #define FUN25_CODE float32_weibull_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = weibull_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_weibull_isf
 #define FUN25_IMPL float64_weibull_isf_impl
 #define FUN25_CODE float64_weibull_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = weibull_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = weibull_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_rvs
@@ -1458,14 +1472,14 @@
 #define FUN25_IMPL float32_laplace_rvs_impl
 #define FUN25_CODE float32_laplace_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_rvs
 #define FUN25_IMPL float64_laplace_rvs_impl
 #define FUN25_CODE float64_laplace_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_pdf
@@ -1474,14 +1488,14 @@
 #define FUN25_IMPL float32_laplace_pdf_impl
 #define FUN25_CODE float32_laplace_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_pdf
 #define FUN25_IMPL float64_laplace_pdf_impl
 #define FUN25_CODE float64_laplace_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_logpdf
@@ -1490,14 +1504,14 @@
 #define FUN25_IMPL float32_laplace_logpdf_impl
 #define FUN25_CODE float32_laplace_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_logpdf
 #define FUN25_IMPL float64_laplace_logpdf_impl
 #define FUN25_CODE float64_laplace_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_cdf
@@ -1506,14 +1520,14 @@
 #define FUN25_IMPL float32_laplace_cdf_impl
 #define FUN25_CODE float32_laplace_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_cdf
 #define FUN25_IMPL float64_laplace_cdf_impl
 #define FUN25_CODE float64_laplace_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_logcdf
@@ -1522,14 +1536,14 @@
 #define FUN25_IMPL float32_laplace_logcdf_impl
 #define FUN25_CODE float32_laplace_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_logcdf
 #define FUN25_IMPL float64_laplace_logcdf_impl
 #define FUN25_CODE float64_laplace_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_ppf
@@ -1538,14 +1552,14 @@
 #define FUN25_IMPL float32_laplace_ppf_impl
 #define FUN25_CODE float32_laplace_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_ppf
 #define FUN25_IMPL float64_laplace_ppf_impl
 #define FUN25_CODE float64_laplace_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_sf
@@ -1554,14 +1568,14 @@
 #define FUN25_IMPL float32_laplace_sf_impl
 #define FUN25_CODE float32_laplace_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_sf
 #define FUN25_IMPL float64_laplace_sf_impl
 #define FUN25_CODE float64_laplace_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_logsf
@@ -1570,14 +1584,14 @@
 #define FUN25_IMPL float32_laplace_logsf_impl
 #define FUN25_CODE float32_laplace_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_logsf
 #define FUN25_IMPL float64_laplace_logsf_impl
 #define FUN25_CODE float64_laplace_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // laplace_isf
@@ -1586,14 +1600,14 @@
 #define FUN25_IMPL float32_laplace_isf_impl
 #define FUN25_CODE float32_laplace_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = laplace_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_laplace_isf
 #define FUN25_IMPL float64_laplace_isf_impl
 #define FUN25_CODE float64_laplace_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = laplace_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = laplace_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_rvs
@@ -1602,14 +1616,14 @@
 #define FUN25_IMPL float32_gumbel1_rvs_impl
 #define FUN25_CODE float32_gumbel1_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_rvs
 #define FUN25_IMPL float64_gumbel1_rvs_impl
 #define FUN25_CODE float64_gumbel1_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_pdf
@@ -1618,14 +1632,14 @@
 #define FUN25_IMPL float32_gumbel1_pdf_impl
 #define FUN25_CODE float32_gumbel1_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_pdf
 #define FUN25_IMPL float64_gumbel1_pdf_impl
 #define FUN25_CODE float64_gumbel1_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_logpdf
@@ -1634,14 +1648,14 @@
 #define FUN25_IMPL float32_gumbel1_logpdf_impl
 #define FUN25_CODE float32_gumbel1_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_logpdf
 #define FUN25_IMPL float64_gumbel1_logpdf_impl
 #define FUN25_CODE float64_gumbel1_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_cdf
@@ -1650,14 +1664,14 @@
 #define FUN25_IMPL float32_gumbel1_cdf_impl
 #define FUN25_CODE float32_gumbel1_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_cdf
 #define FUN25_IMPL float64_gumbel1_cdf_impl
 #define FUN25_CODE float64_gumbel1_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_logcdf
@@ -1666,14 +1680,14 @@
 #define FUN25_IMPL float32_gumbel1_logcdf_impl
 #define FUN25_CODE float32_gumbel1_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_logcdf
 #define FUN25_IMPL float64_gumbel1_logcdf_impl
 #define FUN25_CODE float64_gumbel1_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_ppf
@@ -1682,14 +1696,14 @@
 #define FUN25_IMPL float32_gumbel1_ppf_impl
 #define FUN25_CODE float32_gumbel1_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_ppf
 #define FUN25_IMPL float64_gumbel1_ppf_impl
 #define FUN25_CODE float64_gumbel1_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_sf
@@ -1698,14 +1712,14 @@
 #define FUN25_IMPL float32_gumbel1_sf_impl
 #define FUN25_CODE float32_gumbel1_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_sf
 #define FUN25_IMPL float64_gumbel1_sf_impl
 #define FUN25_CODE float64_gumbel1_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_logsf
@@ -1714,14 +1728,14 @@
 #define FUN25_IMPL float32_gumbel1_logsf_impl
 #define FUN25_CODE float32_gumbel1_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_logsf
 #define FUN25_IMPL float64_gumbel1_logsf_impl
 #define FUN25_CODE float64_gumbel1_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel1_isf
@@ -1730,14 +1744,14 @@
 #define FUN25_IMPL float32_gumbel1_isf_impl
 #define FUN25_CODE float32_gumbel1_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel1_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel1_isf
 #define FUN25_IMPL float64_gumbel1_isf_impl
 #define FUN25_CODE float64_gumbel1_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel1_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel1_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_rvs
@@ -1746,14 +1760,14 @@
 #define FUN25_IMPL float32_gumbel2_rvs_impl
 #define FUN25_CODE float32_gumbel2_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_rvs
 #define FUN25_IMPL float64_gumbel2_rvs_impl
 #define FUN25_CODE float64_gumbel2_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_pdf
@@ -1762,14 +1776,14 @@
 #define FUN25_IMPL float32_gumbel2_pdf_impl
 #define FUN25_CODE float32_gumbel2_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_pdf
 #define FUN25_IMPL float64_gumbel2_pdf_impl
 #define FUN25_CODE float64_gumbel2_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_logpdf
@@ -1778,14 +1792,14 @@
 #define FUN25_IMPL float32_gumbel2_logpdf_impl
 #define FUN25_CODE float32_gumbel2_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_logpdf
 #define FUN25_IMPL float64_gumbel2_logpdf_impl
 #define FUN25_CODE float64_gumbel2_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_cdf
@@ -1794,14 +1808,14 @@
 #define FUN25_IMPL float32_gumbel2_cdf_impl
 #define FUN25_CODE float32_gumbel2_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_cdf
 #define FUN25_IMPL float64_gumbel2_cdf_impl
 #define FUN25_CODE float64_gumbel2_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_logcdf
@@ -1810,14 +1824,14 @@
 #define FUN25_IMPL float32_gumbel2_logcdf_impl
 #define FUN25_CODE float32_gumbel2_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_logcdf
 #define FUN25_IMPL float64_gumbel2_logcdf_impl
 #define FUN25_CODE float64_gumbel2_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_ppf
@@ -1826,14 +1840,14 @@
 #define FUN25_IMPL float32_gumbel2_ppf_impl
 #define FUN25_CODE float32_gumbel2_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_ppf
 #define FUN25_IMPL float64_gumbel2_ppf_impl
 #define FUN25_CODE float64_gumbel2_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_sf
@@ -1842,14 +1856,14 @@
 #define FUN25_IMPL float32_gumbel2_sf_impl
 #define FUN25_CODE float32_gumbel2_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_sf
 #define FUN25_IMPL float64_gumbel2_sf_impl
 #define FUN25_CODE float64_gumbel2_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_logsf
@@ -1858,14 +1872,14 @@
 #define FUN25_IMPL float32_gumbel2_logsf_impl
 #define FUN25_CODE float32_gumbel2_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_logsf
 #define FUN25_IMPL float64_gumbel2_logsf_impl
 #define FUN25_CODE float64_gumbel2_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // gumbel2_isf
@@ -1874,14 +1888,14 @@
 #define FUN25_IMPL float32_gumbel2_isf_impl
 #define FUN25_CODE float32_gumbel2_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = gumbel2_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_gumbel2_isf
 #define FUN25_IMPL float64_gumbel2_isf_impl
 #define FUN25_CODE float64_gumbel2_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = gumbel2_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = gumbel2_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_rvs
@@ -1890,14 +1904,14 @@
 #define FUN25_IMPL float32_logistic_rvs_impl
 #define FUN25_CODE float32_logistic_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_rvs
 #define FUN25_IMPL float64_logistic_rvs_impl
 #define FUN25_CODE float64_logistic_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_pdf
@@ -1906,14 +1920,14 @@
 #define FUN25_IMPL float32_logistic_pdf_impl
 #define FUN25_CODE float32_logistic_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_pdf
 #define FUN25_IMPL float64_logistic_pdf_impl
 #define FUN25_CODE float64_logistic_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_logpdf
@@ -1922,14 +1936,14 @@
 #define FUN25_IMPL float32_logistic_logpdf_impl
 #define FUN25_CODE float32_logistic_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_logpdf
 #define FUN25_IMPL float64_logistic_logpdf_impl
 #define FUN25_CODE float64_logistic_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_cdf
@@ -1938,14 +1952,14 @@
 #define FUN25_IMPL float32_logistic_cdf_impl
 #define FUN25_CODE float32_logistic_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_cdf
 #define FUN25_IMPL float64_logistic_cdf_impl
 #define FUN25_CODE float64_logistic_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_logcdf
@@ -1954,14 +1968,14 @@
 #define FUN25_IMPL float32_logistic_logcdf_impl
 #define FUN25_CODE float32_logistic_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_logcdf
 #define FUN25_IMPL float64_logistic_logcdf_impl
 #define FUN25_CODE float64_logistic_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_ppf
@@ -1970,14 +1984,14 @@
 #define FUN25_IMPL float32_logistic_ppf_impl
 #define FUN25_CODE float32_logistic_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_ppf
 #define FUN25_IMPL float64_logistic_ppf_impl
 #define FUN25_CODE float64_logistic_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_sf
@@ -1986,14 +2000,14 @@
 #define FUN25_IMPL float32_logistic_sf_impl
 #define FUN25_CODE float32_logistic_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_sf
 #define FUN25_IMPL float64_logistic_sf_impl
 #define FUN25_CODE float64_logistic_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_logsf
@@ -2002,14 +2016,14 @@
 #define FUN25_IMPL float32_logistic_logsf_impl
 #define FUN25_CODE float32_logistic_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_logsf
 #define FUN25_IMPL float64_logistic_logsf_impl
 #define FUN25_CODE float64_logistic_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // logistic_isf
@@ -2018,14 +2032,14 @@
 #define FUN25_IMPL float32_logistic_isf_impl
 #define FUN25_CODE float32_logistic_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = logistic_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_logistic_isf
 #define FUN25_IMPL float64_logistic_isf_impl
 #define FUN25_CODE float64_logistic_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = logistic_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = logistic_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_rvs
@@ -2034,14 +2048,14 @@
 #define FUN25_IMPL float32_lognormal_rvs_impl
 #define FUN25_CODE float32_lognormal_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_rvs
 #define FUN25_IMPL float64_lognormal_rvs_impl
 #define FUN25_CODE float64_lognormal_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_rvs(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_rvs(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_pdf
@@ -2050,14 +2064,14 @@
 #define FUN25_IMPL float32_lognormal_pdf_impl
 #define FUN25_CODE float32_lognormal_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_pdf
 #define FUN25_IMPL float64_lognormal_pdf_impl
 #define FUN25_CODE float64_lognormal_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_pdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_pdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_logpdf
@@ -2066,14 +2080,14 @@
 #define FUN25_IMPL float32_lognormal_logpdf_impl
 #define FUN25_CODE float32_lognormal_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_logpdf
 #define FUN25_IMPL float64_lognormal_logpdf_impl
 #define FUN25_CODE float64_lognormal_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_logpdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logpdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_cdf
@@ -2082,14 +2096,14 @@
 #define FUN25_IMPL float32_lognormal_cdf_impl
 #define FUN25_CODE float32_lognormal_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_cdf
 #define FUN25_IMPL float64_lognormal_cdf_impl
 #define FUN25_CODE float64_lognormal_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_cdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_cdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_logcdf
@@ -2098,14 +2112,14 @@
 #define FUN25_IMPL float32_lognormal_logcdf_impl
 #define FUN25_CODE float32_lognormal_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_logcdf
 #define FUN25_IMPL float64_lognormal_logcdf_impl
 #define FUN25_CODE float64_lognormal_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_logcdf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logcdf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_ppf
@@ -2114,14 +2128,14 @@
 #define FUN25_IMPL float32_lognormal_ppf_impl
 #define FUN25_CODE float32_lognormal_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_ppf
 #define FUN25_IMPL float64_lognormal_ppf_impl
 #define FUN25_CODE float64_lognormal_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_ppf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_ppf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_sf
@@ -2130,14 +2144,14 @@
 #define FUN25_IMPL float32_lognormal_sf_impl
 #define FUN25_CODE float32_lognormal_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_sf
 #define FUN25_IMPL float64_lognormal_sf_impl
 #define FUN25_CODE float64_lognormal_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_sf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_sf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_logsf
@@ -2146,14 +2160,14 @@
 #define FUN25_IMPL float32_lognormal_logsf_impl
 #define FUN25_CODE float32_lognormal_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_logsf
 #define FUN25_IMPL float64_lognormal_logsf_impl
 #define FUN25_CODE float64_lognormal_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_logsf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_logsf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // lognormal_isf
@@ -2162,14 +2176,14 @@
 #define FUN25_IMPL float32_lognormal_isf_impl
 #define FUN25_CODE float32_lognormal_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = lognormal_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN25 float64_lognormal_isf
 #define FUN25_IMPL float64_lognormal_isf_impl
 #define FUN25_CODE float64_lognormal_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = lognormal_isf(*Z, *X, *Y)
+#define MAPFN(X, Y, Z) *Z = lognormal_isf(*Z, *X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_rvs
@@ -2178,14 +2192,14 @@
 #define FUN24_IMPL float32_rayleigh_rvs_impl
 #define FUN24_CODE float32_rayleigh_rvs_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = rayleigh_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_rvs
 #define FUN24_IMPL float64_rayleigh_rvs_impl
 #define FUN24_CODE float64_rayleigh_rvs_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_rvs(*X)
+#define MAPFN(X, Y, Z) *Z = rayleigh_rvs(*X)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_pdf
@@ -2194,14 +2208,14 @@
 #define FUN24_IMPL float32_rayleigh_pdf_impl
 #define FUN24_CODE float32_rayleigh_pdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_pdf
 #define FUN24_IMPL float64_rayleigh_pdf_impl
 #define FUN24_CODE float64_rayleigh_pdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_pdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_pdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_logpdf
@@ -2210,14 +2224,14 @@
 #define FUN24_IMPL float32_rayleigh_logpdf_impl
 #define FUN24_CODE float32_rayleigh_logpdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_logpdf
 #define FUN24_IMPL float64_rayleigh_logpdf_impl
 #define FUN24_CODE float64_rayleigh_logpdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_logpdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logpdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_cdf
@@ -2226,14 +2240,14 @@
 #define FUN24_IMPL float32_rayleigh_cdf_impl
 #define FUN24_CODE float32_rayleigh_cdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_cdf
 #define FUN24_IMPL float64_rayleigh_cdf_impl
 #define FUN24_CODE float64_rayleigh_cdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_cdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_cdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_logcdf
@@ -2242,14 +2256,14 @@
 #define FUN24_IMPL float32_rayleigh_logcdf_impl
 #define FUN24_CODE float32_rayleigh_logcdf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_logcdf
 #define FUN24_IMPL float64_rayleigh_logcdf_impl
 #define FUN24_CODE float64_rayleigh_logcdf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_logcdf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logcdf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_ppf
@@ -2258,14 +2272,14 @@
 #define FUN24_IMPL float32_rayleigh_ppf_impl
 #define FUN24_CODE float32_rayleigh_ppf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_ppf
 #define FUN24_IMPL float64_rayleigh_ppf_impl
 #define FUN24_CODE float64_rayleigh_ppf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_ppf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_ppf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_sf
@@ -2274,14 +2288,14 @@
 #define FUN24_IMPL float32_rayleigh_sf_impl
 #define FUN24_CODE float32_rayleigh_sf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_sf
 #define FUN24_IMPL float64_rayleigh_sf_impl
 #define FUN24_CODE float64_rayleigh_sf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_sf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_sf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_logsf
@@ -2290,14 +2304,14 @@
 #define FUN24_IMPL float32_rayleigh_logsf_impl
 #define FUN24_CODE float32_rayleigh_logsf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_logsf
 #define FUN24_IMPL float64_rayleigh_logsf_impl
 #define FUN24_CODE float64_rayleigh_logsf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_logsf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_logsf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 // rayleigh_isf
@@ -2306,14 +2320,14 @@
 #define FUN24_IMPL float32_rayleigh_isf_impl
 #define FUN24_CODE float32_rayleigh_isf_code
 #define NUMBER float
-#define MAPFN(X,Y,Z) *Z = rayleigh_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_isf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 #define FUN24 float64_rayleigh_isf
 #define FUN24_IMPL float64_rayleigh_isf_impl
 #define FUN24_CODE float64_rayleigh_isf_code
 #define NUMBER double
-#define MAPFN(X,Y,Z) *Z = rayleigh_isf(*X, *Y)
+#define MAPFN(X, Y, Z) *Z = rayleigh_isf(*X, *Y)
 #include "owl_ndarray_maths_map.h"
 
 //////////////////// function templates ends ////////////////////

--- a/src/owl/ppl/owl_distribution_generic.ml
+++ b/src/owl/ppl/owl_distribution_generic.ml
@@ -164,6 +164,8 @@ let exponential_isf ~lambda x =
   broadcast_op2 (_owl_exponential_isf (kind x)) lambda lambda x
 
 
+let poisson_rvs ~mu ~n = broadcast_op1 (_owl_poisson_rvs (kind mu)) mu n
+
 let gamma_rvs ~shape ~scale ~n = broadcast_op0 (_owl_gamma_rvs (kind shape)) shape scale n
 
 let gamma_pdf ~shape ~scale x = broadcast_op2 (_owl_gamma_pdf (kind x)) shape scale x

--- a/src/owl/stats/owl_stats_dist_hypergeometric.c
+++ b/src/owl/stats/owl_stats_dist_hypergeometric.c
@@ -45,8 +45,8 @@ long hypergeometric_hrua_rvs(long good, long bad, long sample) {
   d7 = sqrt((double) (popsize - m) * sample * d4 * d5 / (popsize - 1) + 0.5);
   d8 = D1 * d7 + D2;
   d9 = (long) floor((double) (m + 1) * (mingoodbad + 1) / (popsize + 2));
-  d10 = (loggam(d9 + 1) + loggam(mingoodbad - d9 + 1) + loggam(m - d9 + 1) +
-         loggam(maxgoodbad - m + d9 + 1));
+  d10 = (lgam(d9 + 1) + lgam(mingoodbad - d9 + 1) + lgam(m - d9 + 1) +
+         lgam(maxgoodbad - m + d9 + 1));
   d11 = fmin(fmin(m, mingoodbad) + 1., floor(d6 + 16 * d7));
 
   while (1) {
@@ -57,8 +57,8 @@ long hypergeometric_hrua_rvs(long good, long bad, long sample) {
     if ((W < 0.) || (W >= d11)) continue;
 
     Z = (long) floor(W);
-    T = d10 - (loggam(Z + 1) + loggam(mingoodbad - Z + 1) + loggam(m - Z + 1) +
-               loggam(maxgoodbad - m + Z + 1));
+    T = d10 - (lgam(Z + 1) + lgam(mingoodbad - Z + 1) + lgam(m - Z + 1) +
+               lgam(maxgoodbad - m + Z + 1));
 
     if ((X * (4. - X) - 3.) <= T) break;
     if (X * (X - T) >= 1) continue;

--- a/src/owl/stats/owl_stats_dist_poisson.c
+++ b/src/owl/stats/owl_stats_dist_poisson.c
@@ -8,44 +8,13 @@
 
 /** Poisson distribution **/
 
-// FIXME: replace with lgam in cephes?
-double loggam(double x) {
-  static double a[10] = {
-    8.333333333333333e-02,-2.777777777777778e-03,
-    7.936507936507937e-04,-5.952380952380952e-04,
-    8.417508417508418e-04,-1.917526917526918e-03,
-    6.410256410256410e-03,-2.955065359477124e-02,
-    1.796443723688307e-01,-1.39243221690590e+00 };
-  double x0 = x;
-  long n = 0;
-  if ((x == 1.) || (x == 2.))
-    return 0.;
-  else if (x <= 7.) {
-    n = (long) (7 - x);
-    x0 = x + n;
-  }
-  double x2 = 1. / (x0 * x0);
-  double xp = 2 * M_PI;
-  double gl0 = a[9];
-  for (long k = 8; k >= 0; k--) {
-    gl0 *= x2;
-    gl0 += a[k];
-  }
-  double gl = gl0 / x0 + 0.5 * log(xp) + (x0 - 0.5) * log(x0) - x0;
-  if (x <= 7.0) {
-    for (long k = 1; k <= n; k++) {
-      gl -= log(x0 - 1.0);
-      x0 -= 1.0;
-    }
-  }
-  return gl;
-}
-
-long poisson_mult_rvs(double lam) {
+long poisson_mult_rvs(double lam)
+{
   long X = 0;
   double enlam = exp(-lam);
   double prod = 1.;
-  while (1) {
+  while (1)
+  {
     prod *= sfmt_f64_3;
     if (prod > enlam)
       X += 1;
@@ -54,7 +23,8 @@ long poisson_mult_rvs(double lam) {
   }
 }
 
-long poisson_ptrs_rvs(double lam) {
+long poisson_ptrs_rvs(double lam)
+{
   long k;
   double U, V, slam, loglam, a, b, invalpha, vr, us;
 
@@ -65,21 +35,21 @@ long poisson_ptrs_rvs(double lam) {
   invalpha = 1.1239 + 1.1328 / (b - 3.4);
   vr = 0.9277 - 3.6224 / (b - 2);
 
-  while (1) {
+  while (1)
+  {
     U = sfmt_f64_3 - 0.5;
     V = sfmt_f64_3;
     us = 0.5 - fabs(U);
-    k = (long) floor((2 * a / us + b) * U + lam + 0.43);
+    k = (long)floor((2 * a / us + b) * U + lam + 0.43);
     if ((us >= 0.07) && (V <= vr))
       return k;
     if ((k < 0) || ((us < 0.013) && (V > us)))
       continue;
     if ((log(V) + log(invalpha) - log(a / (us * us) + b)) <=
-        (-lam + k * loglam - loggam(k + 1)))
+        (-lam + k * loglam - lgam(k + 1)))
       return k;
   }
 }
-
 
 long poisson_rvs(double lambda)
 {


### PR DESCRIPTION
Following the last PR #498, I've added `poisson_rvs` to `Owl_distribution_generic` and `Owl_distribution` as a module.

I've also replaced the `loggamma` function with the cephes implementation `lgam` (this was on the TODO).

On a side note, I find some of the documentation in `owl_ndarray_maths_map.h` slightly confusing. I'm still not entirely sure why `exponential_rvs` uses `FUN24` and `gaussian_rvs` uses `FUN25`. I'm using `FUN24` to define `poisson_rvs`, as like `exponential_rvs` it only has one parameter. It would be nice to have a more detailed description of these functions and maybe more informative names at some point? Just a thought.