### PR TITLE
Fixing typos in 'src' directory

### DIFF
--- a/src/base/algodiff/owl_algodiff_core.ml
+++ b/src/base/algodiff/owl_algodiff_core.ml
@@ -15,7 +15,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
     !_global_tag
 
 
-  (* hepler functions of the core AD component *)
+  (* helper functions of the core AD component *)
 
   let reset_zero = function
     | F _    -> F A.(float_to_elt 0.)

--- a/src/base/algodiff/owl_algodiff_generic_sig.ml
+++ b/src/base/algodiff/owl_algodiff_generic_sig.ml
@@ -70,7 +70,7 @@ module type Sig = sig
   (** laplacian of ``f : (scalar -> scalar)`` at ``x``. *)
 
   val laplacian' : (t -> t) -> t -> t * t
-  (** simiar to ``laplacian``, but return ``(f x, laplacian f x)``. *)
+  (** similar to ``laplacian``, but return ``(f x, laplacian f x)``. *)
 
   val gradhessian : (t -> t) -> t -> t * t
   (** return ``(grad f x, hessian f x)``, ``f : (scalar -> scalar)`` *)

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -2018,7 +2018,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
   module NN = struct
     open Maths
 
-    (* NOTE: these fucntions are for neural network. There are many restrictions at the
+    (* NOTE: these functions are for neural network. There are many restrictions at the
        moment. E.g. they do not support higher-order derivatives, and some do not support
        forward mode, so use them when you know what you are doing. *)
 

--- a/src/base/core/owl_exception.mli
+++ b/src/base/core/owl_exception.mli
@@ -44,7 +44,7 @@ val pp_exception : Format.formatter -> exn -> unit
 (** {6 Exception definition} *)
 
 exception CONV_INVALID_ARGUMENT
-(** Input arugments of convolution operations are invalid. *)
+(** Input arguments of convolution operations are invalid. *)
 
 exception NOT_IMPLEMENTED of string
 (** Exception of not implemented yet. *)
@@ -65,10 +65,10 @@ exception TEST_FAIL
 (** Unit Test fails. *)
 
 exception INVALID_ARGUMENT of string
-(** Input arugments are invalid. *)
+(** Input arguments are invalid. *)
 
 exception INVALID_PROBABILITY of float
-(** Invalide probability value, not within [0,1] range. *)
+(** Invalid probability value, not within [0,1] range. *)
 
 exception LINALG_MATRIX_DOT_SHAPE of (int * int * int * int)
 (** Invalid matrix shapes for matrix dot product. *)

--- a/src/base/core/owl_graph.mli
+++ b/src/base/core/owl_graph.mli
@@ -116,7 +116,7 @@ from all its parent nodes and child nodes.
 val remove_edge : 'a node -> 'a node -> unit
 (**
 ``remove_edge src dst`` removes a link ``src -> dst`` from the graph. Namely,
-the correponding entry of ``dst`` in ``src.next`` and ``src`` in ``dst.prev``
+the corresponding entry of ``dst`` in ``src.next`` and ``src`` in ``dst.prev``
 will be removed. Note that it does not remove [dst -> src] if there exists one.
  *)
 
@@ -144,7 +144,7 @@ val copy : ?dir:dir -> 'a node array -> 'a node array
 (if ``dir = Ancestor``) or all its descendants (if ``dir = Descendant``).
 
 Note that this function only makes a copy of the graph structure, ``attr``
-fileds of the nodes in the new graph share the same memory with those in the
+fields of the nodes in the new graph share the same memory with those in the
 original graph.
  *)
 
@@ -203,4 +203,4 @@ val pp_node : Format.formatter -> 'a node -> unit
 (** Pretty print a given node. *)
 
 val to_string : bool -> 'a node array -> string
-(** Convert a given node to its string representaion. *)
+(** Convert a given node to its string representation. *)

--- a/src/base/core/owl_lazy.mli
+++ b/src/base/core/owl_lazy.mli
@@ -107,7 +107,7 @@ module Make (A : Ndarray_Mutable) : sig
   val unsafe_assign_arr : arr -> A.arr -> unit
   (** TODO *)
 
-  (** {6 Maths funcitons} *)
+  (** {6 Maths functions} *)
 
   val noop : arr -> arr
   (** TODO *)

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -327,7 +327,7 @@ let strides x = x |> shape |> Owl_utils.calc_stride
 let slice_size x = x |> shape |> Owl_utils.calc_slice
 
 (* TODO: performance can be optimised by removing embedded loops *)
-(* generic fold funtion *)
+(* generic fold function *)
 let foldi ?axis f a x =
   let x' = flatten x |> array1_of_genarray in
   match axis with
@@ -3101,7 +3101,7 @@ let avg_pool1d ?(padding = SAME) input kernel stride =
   output
 
 
-(* simiar to max_pool3d *)
+(* similar to max_pool3d *)
 let avg_pool3d ?(padding = SAME) input kernel stride =
   let sum_pool = ref 0. in
   let cnt = ref 0. in
@@ -5352,7 +5352,7 @@ let dot varr_a varr_b =
   let cdim = dims_a.(1) in
   let n = dims_b.(1) in
   if dims_b.(0) != cdim
-  then raise (Invalid_argument "Matrices cannot be multipled")
+  then raise (Invalid_argument "Matrices cannot be multiplied")
   else (
     let varr_c = empty (kind varr_a) [| m; n |] in
     let sum = ref 0. in

--- a/src/base/linalg/owl_base_linalg_generic.ml
+++ b/src/base/linalg/owl_base_linalg_generic.ml
@@ -350,7 +350,7 @@ let det a =
 
 
 (* Solver for tridiagonal matrix
- * Input: a[n], b[n], c[n], which together consit the tridiagonal matrix A, and the right side vector r[n]. Return: x[n].
+ * Input: a[n], b[n], c[n], which together consist the tridiagonal matrix A, and the right side vector r[n]. Return: x[n].
  *)
 
 let tridiag_solve_vec a b c r =

--- a/src/base/maths/owl_maths_root.ml
+++ b/src/base/maths/owl_maths_root.ml
@@ -236,7 +236,7 @@ let fzero ?(solver = Brent) ?(max_iter = 1000) ?(xtol = 1e-6) f a b =
 
 let bracket_expand ?(rate = 1.6) ?(max_iter = 100) f a b =
   let error () =
-    let s = Printf.sprintf "bracket_expand requries a < b, but a = %g and b = %g" a b in
+    let s = Printf.sprintf "bracket_expand requires a < b, but a = %g and b = %g" a b in
     Owl_exception.INVALID_ARGUMENT s
   in
   Owl_exception.verify (a < b) error;

--- a/src/base/misc/owl_dataframe.mli
+++ b/src/base/misc/owl_dataframe.mli
@@ -245,7 +245,7 @@ val iteri_row : (int -> elt array -> unit) -> t -> unit
 (** ``iteri_row f x`` iterates the rows of ``x`` and applies ``f``. *)
 
 val iter_row : (elt array -> unit) -> t -> unit
-(** ``iter_row`` is simiar to ``iteri_row`` without passing in row indices. *)
+(** ``iter_row`` is similar to ``iteri_row`` without passing in row indices. *)
 
 val mapi_row : (int -> elt array -> elt array) -> t -> t
 (**
@@ -256,7 +256,7 @@ will occur.
  *)
 
 val map_row : (elt array -> elt array) -> t -> t
-(** ``map_row`` is simiar to ``mapi_row`` but without passing in row indices. *)
+(** ``map_row`` is similar to ``mapi_row`` but without passing in row indices. *)
 
 val filteri_row : (int -> elt array -> bool) -> t -> t
 (**

--- a/src/base/misc/owl_log.mli
+++ b/src/base/misc/owl_log.mli
@@ -16,7 +16,7 @@ type level =
       (**
 Type definition of log levels, priority is from low to high. Using ``set_level``
 function to set global logging level to high one can mask the output from low
-level loggging.
+level logging.
 *)
 
 (** {6 Configuration functions} *)

--- a/src/base/misc/owl_utils_array.mli
+++ b/src/base/misc/owl_utils_array.mli
@@ -134,7 +134,7 @@ val set_slice : int array -> 'a array -> 'a array -> unit
 (**
 ``set_slice slice x y`` sets the elements in ``x`` to the corresponding value
 of the elements in ``y`` based on the slice definition ``slice``. Please refer
-to ``get_slice`` function for the information on the format of slice definiton.
+to ``get_slice`` function for the information on the format of slice definition.
  *)
 
 val flatten : 'a array array -> 'a array

--- a/src/base/misc/owl_view.mli
+++ b/src/base/misc/owl_view.mli
@@ -59,7 +59,7 @@ module Make (A : Ndarray_Basic) : sig
   val iteri : (int -> A.elt -> unit) -> t -> unit
   (**
 ``iteri f x`` iterates and applies ``f`` to every element in ``x``. ``f`` has type
-``f : int array -> elt -> unit``, the first paramater is index. 1d indices are
+``f : int array -> elt -> unit``, the first parameter is index. 1d indices are
 passed to the user function.
    *)
 

--- a/src/base/neural/owl_neural_compiler.ml
+++ b/src/base/neural/owl_neural_compiler.ml
@@ -263,7 +263,7 @@ module Make (E : Owl_types_computation_engine.Sig) = struct
         Owl_graph.set_name c0 s0;
         Owl_graph.set_name c1 s1)
       ch';
-    (* contruct a computation graph with inputs and outputs *)
+    (* construct a computation graph with inputs and outputs *)
     let network_name = Graph.get_network_name network in
     let ch, ch' = Owl_utils_array.(flatten ch, flatten ch') in
     let _to_nodes = Array.map (fun v -> unpack_arr v |> Engine.arr_to_node) in

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -92,7 +92,7 @@ module type Sig = sig
   (** Initialise the network. *)
 
   val reset : network -> unit
-  (** Reset the network, i.e. all the paramters in the neurons. *)
+  (** Reset the network, i.e. all the parameters in the neurons. *)
 
   val mktag : int -> network -> unit
   (** Tag the neurons, used by ``Algodiff`` module. *)

--- a/src/base/optimise/owl_optimise_generic_sig.ml
+++ b/src/base/optimise/owl_optimise_generic_sig.ml
@@ -241,7 +241,7 @@ number of batches per epoch and the number of epochs in total.
       ; mutable checkpoint : Checkpoint.typ
       ; mutable verbosity : bool
       }
-    (** Type definition of paramater. *)
+    (** Type definition of parameter. *)
 
     val default : unit -> typ
     (** Create module ``typ`` with default values. *)

--- a/src/opencl/bindings/owl_opencl_parser.ml
+++ b/src/opencl/bindings/owl_opencl_parser.ml
@@ -561,7 +561,7 @@ let parse_opencl_header_funlist fname funlist =
        let _fun_name = Str.matched_group 2 _s in
        let _fun_vars = Str.matched_group 3 _s in
        let _fun_vers = Str.matched_group 4 _s in
-       (* only accept thos in funlist *)
+       (* only accept those in funlist *)
        if is_in_funlist t _fun_name = true
        then funs := Array.append !funs [| _fun_rval, _fun_name, _fun_vars, _fun_vers |]
        else Printf.printf "opencl %s @ %s\n" _fun_name _fun_vars;

--- a/src/opencl/compute/owl_computation_opencl_eval.ml
+++ b/src/opencl/compute/owl_computation_opencl_eval.ml
@@ -250,7 +250,7 @@ module Make (Device : Owl_types_computation_opencl_device.Sig) = struct
   (* dummy map *)
   and _eval_map_xx _ = ()
 
-  (* varibles and consts, copy cpu -> gpu *)
+  (* variables and consts, copy cpu -> gpu *)
   and _eval_map_00 x param =
     if is_valid x = false
     then (

--- a/src/opencl/compute/owl_computation_opencl_init.ml
+++ b/src/opencl/compute/owl_computation_opencl_init.ml
@@ -275,7 +275,7 @@ module Make (Device : Owl_types_computation_opencl_device.Sig) = struct
 
   and _init_xx _ _ = ()
 
-  (* varibles, consts, creation *)
+  (* variables, consts, creation *)
   and _init_00 x param =
     let ctx, _, _ = param in
     allocate_from_parent_0 ctx x

--- a/src/opencl/owl_opencl_base.ml
+++ b/src/opencl/owl_opencl_base.ml
@@ -891,6 +891,6 @@ module Image = struct end
 (** image definition *)
 
 module SVM = struct end
-(** shared virtual memroy definition, required opencl 2.0 *)
+(** shared virtual memory definition, required opencl 2.0 *)
 
 (* ends here *)

--- a/src/opencl/owl_opencl_primitive.ml
+++ b/src/opencl/owl_opencl_primitive.ml
@@ -134,7 +134,7 @@ let allocate_from_arr ctx a =
   (a_val, a_mem, a_ptr), (b_val, b_mem, b_ptr)
 
 
-(* evalution function for the map-reduce primitives *)
+(* evaluation function for the map-reduce primitives *)
 
 (* FIXME: scalar is not taken into account *)
 let allocate_from_inputs ctx x =

--- a/src/opencl/prng/clrng/Random123/array.h
+++ b/src/opencl/prng/clrng/Random123/array.h
@@ -133,7 +133,7 @@ inline R123_CUDA_DEVICE value_type assemble_from_u32(uint32_t *p32){
     R123_CUDA_DEVICE r123array##_N##x##W& incr(R123_ULONG_LONG n=1){                         \
         /* This test is tricky because we're trying to avoid spurious   \
            complaints about illegal shifts, yet still be compile-time   \
-           evaulated. */                                                \
+           evaluated. */                                                \
         if(sizeof(T)<sizeof(n) && n>>((sizeof(T)<sizeof(n))?8*sizeof(T):0) ) \
             return incr_carefully(n);                                   \
         if(n==1){                                                       \
@@ -147,7 +147,7 @@ inline R123_CUDA_DEVICE value_type assemble_from_u32(uint32_t *p32){
            constant-folded/optimized away by the compiler, so only the  \
            overflow tests (!!v[i]) remain to be done at runtime.  For  \
            small values of N, it would be better to do this as an       \
-           uncondtional sequence of adc.  An experiment/optimization    \
+           unconditional sequence of adc.  An experiment/optimization    \
            for another day...                                           \
            N.B.  The weird subscripting: v[_N>3?3:0] is to silence      \
            a spurious error from icpc                                   \

--- a/src/opencl/prng/clrng/Random123/features/compilerfeatures.h
+++ b/src/opencl/prng/clrng/Random123/features/compilerfeatures.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The Random123 library is portable across C, C++, CUDA, OpenCL environments,
 and multiple operating systems (Linux, Windows 7, Mac OS X, FreeBSD, Solaris).
 This level of portability requires the abstraction of some features
-and idioms that are either not standardized (e.g., asm statments), or for which 
+and idioms that are either not standardized (e.g., asm statements), or for which 
 different vendors have their own standards (e.g., SSE intrinsics) or for
 which vendors simply refuse to conform to well-established standards (e.g., <inttypes.h>).
 
@@ -116,7 +116,7 @@ If the XXXINTRIN_H macros are true, then one should
 @code
 #include <xxxintrin.h>
 @endcode
-to gain accesss to compiler intrinsics.
+to gain access to compiler intrinsics.
 
 The CXX11_SOME_FEATURE macros allow the code to use specific
 features of the C++11 language and library.  The catchall

--- a/src/opencl/prng/clrng/Random123/features/sse.h
+++ b/src/opencl/prng/clrng/Random123/features/sse.h
@@ -150,7 +150,7 @@ struct r123m128i{
 #if R123_USE_CXX11_UNRESTRICTED_UNIONS
     // C++98 forbids a union member from having *any* constructors.
     // C++11 relaxes this, and allows union members to have constructors
-    // as long as there is a "trivial" default construtor.  So in C++11
+    // as long as there is a "trivial" default constructor.  So in C++11
     // we can provide a r123m128i constructor with an __m128i argument, and still
     // have the default (and hence trivial) default constructor.
     r123m128i() = default;

--- a/src/opencl/prng/clrng/philox432.c
+++ b/src/opencl/prng/clrng/philox432.c
@@ -156,7 +156,7 @@ clrngStatus clrngPhilox432ChangeStreamsSpacing(clrngPhilox432StreamCreator* crea
 	clrngPhilox432AdvanceStreams(1, dumpStream, e, c);
 	creator->JumpDistance = dumpStream->current.ctr;
 
-	//Free ressources
+	//Free resources
 	clrngPhilox432DestroyStreamCreator(baseCreator);
 	clrngPhilox432DestroyStreams(dumpStream);
 

--- a/src/opencl/prng/clrng/philox432.c.h
+++ b/src/opencl/prng/clrng/philox432.c.h
@@ -88,7 +88,7 @@ void clrngPhilox432GenerateDeck(clrngPhilox432StreamState *currentState)
 	//Default key
 	philox4x32_key_t k = { { 0, 0 } };
 
-	//get the currect state
+	//get the current state
 	philox4x32_ctr_t c = { { 0 } };
 	c.v[0] = currentState->ctr.L.lsb;
 	c.v[1] = currentState->ctr.L.msb;

--- a/src/owl/cblas/owl_cblas_basic.mli
+++ b/src/owl/cblas/owl_cblas_basic.mli
@@ -4,7 +4,7 @@
  *)
 
 (**
-  CBLAS interface: high-level interface beween Owl and level-1, level-2,
+  CBLAS interface: high-level interface between Owl and level-1, level-2,
   level-3 BLAS functions.
  *)
 

--- a/src/owl/core/openmp/owl_core_engine.h
+++ b/src/owl/core/openmp/owl_core_engine.h
@@ -31,7 +31,7 @@
 #endif  /* _OPENMP */
 
 
-/* Default tunable OpemMP paramters */
+/* Default tunable OpemMP parameters */
 
 #define OWL_OMP_THRESHOLD_FUN_(A) OMP_THRESHOLD ## _ ## A
 #define OWL_OMP_THRESHOLD_FUN(A) OWL_OMP_THRESHOLD_FUN_(A)

--- a/src/owl/core/openmp/owl_matrix_swap_impl_omp.h
+++ b/src/owl/core/openmp/owl_matrix_swap_impl_omp.h
@@ -47,7 +47,7 @@ CAMLprim value FUNCTION (stub, swap_rows) (value vX, value vM, value vN, value v
 }
 
 
-// swap column i and colum j in x(m,n)
+// swap column i and column j in x(m,n)
 void FUNCTION (c, swap_cols) (TYPE *x, int m, int n, int i, int j) {
   if (i != j) {
     TYPE * src = x + i;

--- a/src/owl/core/openmp/owl_ndarray_maths_fold_omp.h
+++ b/src/owl/core/openmp/owl_ndarray_maths_fold_omp.h
@@ -184,7 +184,7 @@ CAMLprim value FUN11(value vN, value vX, value vY)
 #endif /* FUN11 */
 
 
-// function to fold all the elements in x with extra paramaters A and B
+// function to fold all the elements in x with extra parameters A and B
 #ifdef FUN23
 
 CAMLprim value FUN23(value vN, value vX, value vA, vB)

--- a/src/owl/core/owl_matrix_swap_impl.h
+++ b/src/owl/core/owl_matrix_swap_impl.h
@@ -37,7 +37,7 @@ CAMLprim value FUNCTION (stub, swap_rows) (value vX, value vM, value vN, value v
 }
 
 
-// swap column i and colum j in x(m,n)
+// swap column i and column j in x(m,n)
 void FUNCTION (c, swap_cols) (TYPE *x, int m, int n, int i, int j) {
   if (i != j) {
     TYPE * src = x + i;

--- a/src/owl/core/owl_ndarray_contract.h
+++ b/src/owl/core/owl_ndarray_contract.h
@@ -15,15 +15,15 @@ struct contract_pair {
   long drt;         // number of outer loops.
   long *n;          // number of iteration in each dimension, i.e. y's shape
   void *x;          // x, operand.
-  long posx;        // current offest of x.
+  long posx;        // current offset of x.
   long *ofsx;       // offset of x in each dimension.
   long *incx;       // stride size of x in each dimension.
   void *y;          // y, operand.
-  long posy;        // current offest of y.
+  long posy;        // current offset of y.
   long *ofsy;       // offset of y in each dimension.
   long *incy;       // stride size of y in each dimension.
   void *z;          // z, operand.
-  long posz;        // current offest of z.
+  long posz;        // current offset of z.
   long *ofsz;       // offset of z in each dimension.
   long *incz;       // stride size of z in each dimension.
 };

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -95,7 +95,7 @@ void compute_block_sizes(int* kp, int* mp, int* np, int typesize) {
 
 /*
  * Fill in temporary input matrix from input tensor with vectorisation.
- * Currently only support AVX instruciton set.
+ * Currently only support AVX instruction set.
  */
 
 void ACX_FUN_LOAD (load_sub_matrix_fast, spatial) (

--- a/src/owl/core/owl_ndarray_maths_fold.h
+++ b/src/owl/core/owl_ndarray_maths_fold.h
@@ -184,7 +184,7 @@ CAMLprim value FUN11(value vN, value vX, value vY)
 #endif /* FUN11 */
 
 
-// function to fold all the elements in x with extra paramaters A and B
+// function to fold all the elements in x with extra parameters A and B
 #ifdef FUN23
 
 CAMLprim value FUN23(value vN, value vX, value vA, vB)

--- a/src/owl/core/owl_slicing.h
+++ b/src/owl/core/owl_slicing.h
@@ -14,11 +14,11 @@ struct slice_pair {
   int64_t dep;          // the depth of current recursion.
   intnat *n;            // number of iteration in each dimension, i.e. y's shape
   void *x;              // x, source if operation is get, destination if set.
-  int64_t posx;         // current offest of x.
+  int64_t posx;         // current offset of x.
   int64_t *ofsx;        // offset of x in each dimension.
   int64_t *incx;        // stride size of x in each dimension.
   void *y;              // y, destination if operation is get, source if set.
-  int64_t posy;         // current offest of y.
+  int64_t posy;         // current offset of y.
   int64_t *ofsy;        // offset of y in each dimension.
   int64_t *incy;        // stride size of y in each dimension.
 };
@@ -49,11 +49,11 @@ struct fancy_pair {
   int64_t *slice;       // (a,b,c) triplet, if a >= 0 then normal slice.
   int64_t *index;       // combined use with slice, check the details above.
   void *x;              // x, source if operation is get, destination if set.
-  int64_t posx;         // current offest of x.
+  int64_t posx;         // current offset of x.
   int64_t *ofsx;        // offset of x in each dimension.
   int64_t *incx;        // stride size of x in each dimension.
   void *y;              // y, destination if operation is get, source if set.
-  int64_t posy;         // current offest of y.
+  int64_t posy;         // current offset of y.
   int64_t *ofsy;        // offset of y in each dimension.
   int64_t *incy;        // stride size of y in each dimension.
 };

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -242,7 +242,7 @@ length, the return will be an rectangular matrix.
 val hadamard : ('a, 'b) kind -> int -> ('a, 'b) t
 (**
 ``hadamard k n`` constructs a hadamard matrix of order ``n``. For a hadamard ``H``,
-we have ``H'*H = n*I``. Currrently, this function handles only the cases where
+we have ``H'*H = n*I``. Currently, this function handles only the cases where
 ``n``, ``n/12``, or ``n/20`` is a power of 2.
  *)
 
@@ -648,7 +648,7 @@ val foldi : ?axis:int -> (int -> 'a -> 'a -> 'a) -> 'a -> ('a, 'b) t -> ('a, 'b)
 ``foldi ~axis f a x`` folds (or reduces) the elements in ``x`` from left along
 the specified ``axis`` using passed in function ``f``. ``a`` is the initial
 element and in ``f i acc b`` ``acc`` is the accumulater and ``b`` is one of the
-elemets in ``x`` along the same axis. Note that ``i`` is 1d index of ``b``.
+elements in ``x`` along the same axis. Note that ``i`` is 1d index of ``b``.
  *)
 
 val fold : ?axis:int -> ('a -> 'a -> 'a) -> 'a -> ('a, 'b) t -> ('a, 'b) t
@@ -721,7 +721,7 @@ val iter2 : ('a -> 'b -> unit) -> ('a, 'c) t -> ('b, 'd) t -> unit
 val map2i : (int -> 'a -> 'a -> 'a) -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``map2i f x y`` applies ``f`` to two elements of the same position in both ``x``
-and ``y``. Note that 1d index is passed to funciton ``f``.
+and ``y``. Note that 1d index is passed to function ``f``.
  *)
 
 val map2 : ('a -> 'a -> 'a) -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
@@ -1520,7 +1520,7 @@ val reci_tol : ?tol:'a -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``reci_tol ~tol x`` computes the reciprocal of every element in ``x``. Different
 from ``reci``, ``reci_tol`` sets the elements whose ``abs`` value smaller than ``tol``
-to zeros. If ``tol`` is not specified, the defautl ``Owl_utils.eps Float32`` will
+to zeros. If ``tol`` is not specified, the default ``Owl_utils.eps Float32`` will
 be used. For complex numbers, refer to Owl's doc to see how to compare.
  *)
 
@@ -2188,151 +2188,151 @@ val max_ : out:('a, 'b) t -> axis:int -> ('a, 'b) t -> unit
 
 val add_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``add_ x y`` is simiar to ``add`` function but the output is written to
+``add_ x y`` is similar to ``add`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val sub_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``sub_ x y`` is simiar to ``sub`` function but the output is written to
+``sub_ x y`` is similar to ``sub`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val mul_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``mul_ x y`` is simiar to ``mul`` function but the output is written to
+``mul_ x y`` is similar to ``mul`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val div_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``div_ x y`` is simiar to ``div`` function but the output is written to
+``div_ x y`` is similar to ``div`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val pow_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``pow_ x y`` is simiar to ``pow`` function but the output is written to
+``pow_ x y`` is similar to ``pow`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val atan2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``atan2_ x y`` is simiar to ``atan2`` function but the output is written to
+``atan2_ x y`` is similar to ``atan2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val hypot_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``hypot_ x y`` is simiar to ``hypot`` function but the output is written to
+``hypot_ x y`` is similar to ``hypot`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val fmod_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``fmod_ x y`` is simiar to ``fmod`` function but the output is written to
+``fmod_ x y`` is similar to ``fmod`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val min2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``min2_ x y`` is simiar to ``min2`` function but the output is written to
+``min2_ x y`` is similar to ``min2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val max2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``max2_ x y`` is simiar to ``max2`` function but the output is written to
+``max2_ x y`` is similar to ``max2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val add_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``add_scalar_ x y`` is simiar to ``add_scalar`` function but the output is
+``add_scalar_ x y`` is similar to ``add_scalar`` function but the output is
 written to ``x``.
  *)
 
 val sub_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``sub_scalar_ x y`` is simiar to ``sub_scalar`` function but the output is
+``sub_scalar_ x y`` is similar to ``sub_scalar`` function but the output is
 written to ``x``.
  *)
 
 val mul_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``mul_scalar_ x y`` is simiar to ``mul_scalar`` function but the output is
+``mul_scalar_ x y`` is similar to ``mul_scalar`` function but the output is
 written to ``x``.
  *)
 
 val div_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``div_scalar_ x y`` is simiar to ``div_scalar`` function but the output is
+``div_scalar_ x y`` is similar to ``div_scalar`` function but the output is
 written to ``x``.
  *)
 
 val pow_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``pow_scalar_ x y`` is simiar to ``pow_scalar`` function but the output is
+``pow_scalar_ x y`` is similar to ``pow_scalar`` function but the output is
 written to ``x``.
  *)
 
 val atan2_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``atan2_scalar_ x y`` is simiar to ``atan2_scalar`` function but the output is
+``atan2_scalar_ x y`` is similar to ``atan2_scalar`` function but the output is
 written to ``x``.
  *)
 
 val fmod_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``fmod_scalar_ x y`` is simiar to ``fmod_scalar`` function but the output is
+``fmod_scalar_ x y`` is similar to ``fmod_scalar`` function but the output is
 written to ``x``.
  *)
 
 val scalar_add_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_add_ a x`` is simiar to ``scalar_add`` function but the output is
+``scalar_add_ a x`` is similar to ``scalar_add`` function but the output is
 written to ``x``.
  *)
 
 val scalar_sub_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_sub_ a x`` is simiar to ``scalar_sub`` function but the output is
+``scalar_sub_ a x`` is similar to ``scalar_sub`` function but the output is
 written to ``x``.
  *)
 
 val scalar_mul_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_mul_ a x`` is simiar to ``scalar_mul`` function but the output is
+``scalar_mul_ a x`` is similar to ``scalar_mul`` function but the output is
 written to ``x``.
  *)
 
 val scalar_div_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_div_ a x`` is simiar to ``scalar_div`` function but the output is
+``scalar_div_ a x`` is similar to ``scalar_div`` function but the output is
 written to ``x``.
  *)
 
 val scalar_pow_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_pow_ a x`` is simiar to ``scalar_pow`` function but the output is
+``scalar_pow_ a x`` is similar to ``scalar_pow`` function but the output is
 written to ``x``.
  *)
 
 val scalar_atan2_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_atan2_ a x`` is simiar to ``scalar_atan2`` function but the output is
+``scalar_atan2_ a x`` is similar to ``scalar_atan2`` function but the output is
 written to ``x``.
  *)
 
 val scalar_fmod_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_fmod_ a x`` is simiar to ``scalar_fmod`` function but the output is
+``scalar_fmod_ a x`` is similar to ``scalar_fmod`` function but the output is
 written to ``x``.
  *)
 
 val fma_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``fma_ ~out x y z`` is simiar to ``fma x y z`` function but the output is
+``fma_ ~out x y z`` is similar to ``fma x y z`` function but the output is
 written to ``out``.
  *)
 
@@ -2574,78 +2574,78 @@ val dropout_ : ?out:('a, 'b) t -> ?rate:float -> ('a, 'b) t -> unit
 
 val elt_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_equal_ x y`` is simiar to ``elt_equal`` function but the output is
+``elt_equal_ x y`` is similar to ``elt_equal`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_not_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_not_equal_ x y`` is simiar to ``elt_not_equal`` function but the output is
+``elt_not_equal_ x y`` is similar to ``elt_not_equal`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_less_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_less_ x y`` is simiar to ``elt_less`` function but the output is written
+``elt_less_ x y`` is similar to ``elt_less`` function but the output is written
 to ``out``. You need to make sure ``out`` is big enough to hold the output
 result.
  *)
 
 val elt_greater_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_greater_ x y`` is simiar to ``elt_greater`` function but the output is
+``elt_greater_ x y`` is similar to ``elt_greater`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_less_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_less_equal_ x y`` is simiar to ``elt_less_equal`` function but the output
+``elt_less_equal_ x y`` is similar to ``elt_less_equal`` function but the output
 is written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_greater_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_greater_equal_ x y`` is simiar to ``elt_greater_equal`` function but the
+``elt_greater_equal_ x y`` is similar to ``elt_greater_equal`` function but the
 output is written to ``out``. You need to make sure ``out`` is big enough to
 hold the output result.
  *)
 
 val elt_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_equal_scalar_ x a`` is simiar to ``elt_equal_scalar`` function but the
+``elt_equal_scalar_ x a`` is similar to ``elt_equal_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_not_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_not_equal_scalar_ x a`` is simiar to ``elt_not_equal_scalar`` function but
+``elt_not_equal_scalar_ x a`` is similar to ``elt_not_equal_scalar`` function but
 the output is written to ``x``.
  *)
 
 val elt_less_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_less_scalar_ x a`` is simiar to ``elt_less_scalar`` function but the
+``elt_less_scalar_ x a`` is similar to ``elt_less_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_greater_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_greater_scalar_ x a`` is simiar to ``elt_greater_scalar`` function but the
+``elt_greater_scalar_ x a`` is similar to ``elt_greater_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_less_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_less_equal_scalar_ x a`` is simiar to ``elt_less_equal_scalar`` function
+``elt_less_equal_scalar_ x a`` is similar to ``elt_less_equal_scalar`` function
 but the output is written to ``x``.
  *)
 
 val elt_greater_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_greater_equal_scalar_ x a`` is simiar to ``elt_greater_equal_scalar``
+``elt_greater_equal_scalar_ x a`` is similar to ``elt_greater_equal_scalar``
 function but the output is written to ``x``.
  *)

--- a/src/owl/dense/owl_dense_matrix_intf.ml
+++ b/src/owl/dense/owl_dense_matrix_intf.ml
@@ -266,7 +266,7 @@ module type Common = sig
 
   val map_at_col : (elt -> elt) -> mat -> int -> mat
 
-  (** {6 Examin elements and compare two matrices} *)
+  (** {6 Examine elements and compare two matrices} *)
 
   val exists : (elt -> bool) -> mat -> bool
 
@@ -612,7 +612,7 @@ module type Common = sig
 
   val fma : mat -> mat -> mat -> mat
 
-  (** {6 Fucntions of in-place modification } *)
+  (** {6 Functions of in-place modification } *)
 
   val create_ : out:mat -> elt -> unit
 

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -245,7 +245,7 @@ let repeat_ ~out x reps =
 
 let tile x reps =
   (* check the validity of reps *)
-  if Array.exists (( > ) 1) reps then failwith "tile: repitition must be >= 1";
+  if Array.exists (( > ) 1) reps then failwith "tile: repetition must be >= 1";
   (* case 1: all repeats equal to 1 *)
   if Array.for_all (( = ) 1) reps = true
   then copy x
@@ -301,7 +301,7 @@ let tile x reps =
 
 let tile_ ~out x reps =
   (* check the validity of reps *)
-  if Array.exists (( > ) 1) reps then failwith "tile: repitition must be >= 1";
+  if Array.exists (( > ) 1) reps then failwith "tile: repetition must be >= 1";
   (* case 1: all repeats equal to 1 *)
   if Array.for_all (( = ) 1) reps = true
   then copy_ x ~out
@@ -2151,7 +2151,7 @@ let rec _copy_to_padding p1 ls l0 l1 i0 i1 d0 d1 s0 s1 x0 x1 =
     _owl_copy (kind x0) ls.(d0) ~ofsx:j0 ~incx:1 ~ofsy:j1 ~incy:1 x0 x1)
 
 
-(* according to the expanded padding index, calcuate the highest dimension
+(* according to the expanded padding index, calculate the highest dimension
   with padding, so we can figure out the minimum continuous block size.
  *)
 let _highest_padding_dimension p =
@@ -7286,7 +7286,7 @@ let max_pool3d_ ~out ?(padding = SAME) input kernel stride =
     pad_typ
 
 
-(* simiar to max_pool3d *)
+(* similar to max_pool3d *)
 let avg_pool3d ?(padding = SAME) input kernel stride =
   let p0 = num_dims input = 5 in
   let p1 = Array.length kernel = 3 in
@@ -8410,7 +8410,7 @@ let sum' x = _owl_sum (kind x) (numel x) x
 let prod' x = _owl_prod (kind x) (numel x) x
 
 (* TODO: performance can be optimised by removing embedded loops *)
-(* generic fold funtion *)
+(* generic fold function *)
 let foldi ?axis f a x =
   let x' = flatten x |> array1_of_genarray in
   match axis with
@@ -9972,7 +9972,7 @@ let draw_cols2 ?(replacement = true) x y c =
 
 
 (*
-  simiar to sum_rows in matrix, sum all the slices along an axis.
+  similar to sum_rows in matrix, sum all the slices along an axis.
   The default [axis] is the highest dimension. E.g., for [x] of [|2;3;4;5|],
   [sum_slices ~axis:2] returns an ndarray of shape [|4;5|].
 
@@ -9999,7 +9999,7 @@ let sum_slices ?axis x =
 
 
 (*
-  Simiar to ``sum``, but sums the elements along multiple axes specified in an
+  Similar to ``sum``, but sums the elements along multiple axes specified in an
   array. E.g., for [x] of [|2;3;4;5|], [sum_reduce ~axis:[|1;3|] x] returns an
   ndarray of shape [|2;1;4;1|]; if axis not specified, it returns an ndarray of
   shape [|1;1;1;1|].

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -386,11 +386,11 @@ val resize : ?head:bool -> ('a, 'b) t -> int array -> ('a, 'b) t
 (**
 ``resize ~head x d`` resizes the ndarray ``x``. If there are less number of
 elelments in the new shape than the old one, the new ndarray shares part of
-the memeory with the old ``x``. ``head`` indicates the alignment between the
+the memory with the old ``x``. ``head`` indicates the alignment between the
 new and old data, either from head or from tail. Note the data is flattened
 before the operation.
 
-If there are more elements in the new shape ``d``. Then new memeory space will
+If there are more elements in the new shape ``d``. Then new memory space will
 be allocated and the content of ``x`` will be copied to the new memory. The
 rest of the allocated space will be filled with zeros. The default value of
 ``head`` is ``true``.
@@ -632,7 +632,7 @@ is passed to function ``f``, you need to convert it to nd-index by yourself.
 
 val iter : ('a -> unit) -> ('a, 'b) t -> unit
 (**
-``iter f x`` is similar to ``iteri f x``, excpet the index is not passed to ``f``.
+``iter f x`` is similar to ``iteri f x``, except the index is not passed to ``f``.
  *)
 
 val mapi : (int -> 'a -> 'a) -> ('a, 'b) t -> ('a, 'b) t
@@ -649,7 +649,7 @@ val foldi : ?axis:int -> (int -> 'a -> 'a -> 'a) -> 'a -> ('a, 'b) t -> ('a, 'b)
 (**
 ``foldi ~axis f a x`` folds (or reduces) the elements in ``x`` from left along
 the specified ``axis`` using passed in function ``f``. ``a`` is the initial element
-and in ``f i acc b`` ``acc`` is the accumulater and ``b`` is one of the elemets in
+and in ``f i acc b`` ``acc`` is the accumulater and ``b`` is one of the elements in
 ``x`` along the same axis. Note that ``i`` is 1d index of ``b``.
  *)
 
@@ -677,7 +677,7 @@ val filteri : (int -> 'a -> bool) -> ('a, 'b) t -> int array
 ``filteri f x`` uses ``f`` to filter out certain elements in ``x``. An element
 will be included if ``f`` returns ``true``. The returned result is an array of
 1-dimensional indices of the selected elements. To obtain the n-dimensional
-indices, you need to convert it manulally with Owl's helper function.
+indices, you need to convert it manually with Owl's helper function.
  *)
 
 val filter : ('a -> bool) -> ('a, 'b) t -> int array
@@ -697,7 +697,7 @@ val iter2 : ('a -> 'b -> unit) -> ('a, 'c) t -> ('b, 'd) t -> unit
 val map2i : (int -> 'a -> 'a -> 'a) -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``map2i f x y`` applies ``f`` to two elements of the same position in both ``x``
-and ``y``. Note that 1d index is passed to funciton ``f``.
+and ``y``. Note that 1d index is passed to function ``f``.
  *)
 
 val map2 : ('a -> 'a -> 'a) -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
@@ -1079,7 +1079,7 @@ val of_array : ('a, 'b) kind -> 'a array -> int array -> ('a, 'b) t
 val to_array : ('a, 'b) t -> 'a array
 (**
 ``to_array x`` converts an ndarray ``x`` to OCaml's array type. Note that the
-ndarray ``x`` is flattened before convertion.
+ndarray ``x`` is flattened before conversion.
  *)
 
 val print
@@ -1111,7 +1111,7 @@ val save : out:string -> ('a, 'b) t -> unit
 val load : ('a, 'b) kind -> string -> ('a, 'b) t
 (**
 ``load k s`` loads previously serialised ndarray from file ``s`` into memory.
-It is necesssary to specify the type of the ndarray with paramater ``k``.
+It is necessary to specify the type of the ndarray with parameter ``k``.
 *)
 
 val save_npy : out:string -> ('a, 'b) t -> unit
@@ -1337,7 +1337,7 @@ val reci_tol : ?tol:'a -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``reci_tol ~tol x`` computes the reciprocal of every element in ``x``. Different
 from ``reci``, ``reci_tol`` sets the elements whose ``abs`` value smaller than ``tol``
-to zeros. If ``tol`` is not specified, the defautl ``Owl_utils.eps Float32`` will
+to zeros. If ``tol`` is not specified, the default ``Owl_utils.eps Float32`` will
 be used. For complex numbers, refer to Owl's doc to see how to compare.
  *)
 
@@ -1898,7 +1898,7 @@ val contract1 : (int * int) array -> ('a, 'b) t -> ('a, 'b) t
 contraction) on ``x``. ``index_pairs`` is an array of contracted indices.
 
 Caveat: Not well tested yet, use with care! Also, consider to use TTGT in
-future for better perfomance.
+future for better performance.
  *)
 
 val contract2 : (int * int) array -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
@@ -1909,7 +1909,7 @@ contracted indices, the first element is the index of ``x``, the second is that
 of ``y``.
 
 Caveat: Not well tested yet, use with care! Also, consider to use TTGT in
-future for better perfomance.
+future for better performance.
  *)
 
 (** {6 Cast functions}  *)
@@ -2399,145 +2399,145 @@ val max_ : out:('a, 'b) t -> axis:int -> ('a, 'b) t -> unit
 
 val add_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``add_ x y`` is simiar to ``add`` function but the output is written to
+``add_ x y`` is similar to ``add`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val sub_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``sub_ x y`` is simiar to ``sub`` function but the output is written to
+``sub_ x y`` is similar to ``sub`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val mul_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``mul_ x y`` is simiar to ``mul`` function but the output is written to
+``mul_ x y`` is similar to ``mul`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val div_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``div_ x y`` is simiar to ``div`` function but the output is written to
+``div_ x y`` is similar to ``div`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val pow_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``pow_ x y`` is simiar to ``pow`` function but the output is written to
+``pow_ x y`` is similar to ``pow`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val atan2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``atan2_ x y`` is simiar to ``atan2`` function but the output is written to
+``atan2_ x y`` is similar to ``atan2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val hypot_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``hypot_ x y`` is simiar to ``hypot`` function but the output is written to
+``hypot_ x y`` is similar to ``hypot`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val fmod_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``fmod_ x y`` is simiar to ``fmod`` function but the output is written to
+``fmod_ x y`` is similar to ``fmod`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val min2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``min2_ x y`` is simiar to ``min2`` function but the output is written to
+``min2_ x y`` is similar to ``min2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val max2_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``max2_ x y`` is simiar to ``max2`` function but the output is written to
+``max2_ x y`` is similar to ``max2`` function but the output is written to
 ``out``. You need to make sure ``out`` is big enough to hold the output result.
  *)
 
 val add_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``add_scalar_ x y`` is simiar to ``add_scalar`` function but the output is
+``add_scalar_ x y`` is similar to ``add_scalar`` function but the output is
 written to ``x``.
  *)
 
 val sub_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``sub_scalar_ x y`` is simiar to ``sub_scalar`` function but the output is
+``sub_scalar_ x y`` is similar to ``sub_scalar`` function but the output is
 written to ``x``.
  *)
 
 val mul_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``mul_scalar_ x y`` is simiar to ``mul_scalar`` function but the output is
+``mul_scalar_ x y`` is similar to ``mul_scalar`` function but the output is
 written to ``x``.
  *)
 
 val div_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``div_scalar_ x y`` is simiar to ``div_scalar`` function but the output is
+``div_scalar_ x y`` is similar to ``div_scalar`` function but the output is
 written to ``x``.
  *)
 
 val pow_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``pow_scalar_ x y`` is simiar to ``pow_scalar`` function but the output is
+``pow_scalar_ x y`` is similar to ``pow_scalar`` function but the output is
 written to ``x``.
  *)
 
 val atan2_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``atan2_scalar_ x y`` is simiar to ``atan2_scalar`` function but the output is
+``atan2_scalar_ x y`` is similar to ``atan2_scalar`` function but the output is
 written to ``x``.
  *)
 
 val fmod_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``fmod_scalar_ x y`` is simiar to ``fmod_scalar`` function but the output is
+``fmod_scalar_ x y`` is similar to ``fmod_scalar`` function but the output is
 written to ``x``.
  *)
 
 val scalar_add_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_add_ a x`` is simiar to ``scalar_add`` function but the output is
+``scalar_add_ a x`` is similar to ``scalar_add`` function but the output is
 written to ``x``.
  *)
 
 val scalar_sub_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_sub_ a x`` is simiar to ``scalar_sub`` function but the output is
+``scalar_sub_ a x`` is similar to ``scalar_sub`` function but the output is
 written to ``x``.
  *)
 
 val scalar_mul_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_mul_ a x`` is simiar to ``scalar_mul`` function but the output is
+``scalar_mul_ a x`` is similar to ``scalar_mul`` function but the output is
 written to ``x``.
  *)
 
 val scalar_div_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_div_ a x`` is simiar to ``scalar_div`` function but the output is
+``scalar_div_ a x`` is similar to ``scalar_div`` function but the output is
 written to ``x``.
  *)
 
 val scalar_pow_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_pow_ a x`` is simiar to ``scalar_pow`` function but the output is
+``scalar_pow_ a x`` is similar to ``scalar_pow`` function but the output is
 written to ``x``.
  *)
 
 val scalar_atan2_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_atan2_ a x`` is simiar to ``scalar_atan2`` function but the output is
+``scalar_atan2_ a x`` is similar to ``scalar_atan2`` function but the output is
 written to ``x``.
  *)
 
 val scalar_fmod_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 (**
-``scalar_fmod_ a x`` is simiar to ``scalar_fmod`` function but the output is
+``scalar_fmod_ a x`` is similar to ``scalar_fmod`` function but the output is
 written to ``x``.
  *)
 
@@ -2549,7 +2549,7 @@ val clip_by_l2norm_ : ?out:('a, 'b) t -> 'a -> ('a, 'b) t -> unit
 
 val fma_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``fma_ ~out x y z`` is simiar to ``fma x y z`` function but the output is
+``fma_ ~out x y z`` is similar to ``fma x y z`` function but the output is
 written to ``out``.
  *)
 
@@ -2791,79 +2791,79 @@ val dropout_ : ?out:('a, 'b) t -> ?rate:float -> ('a, 'b) t -> unit
 
 val elt_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_equal_ x y`` is simiar to ``elt_equal`` function but the output is
+``elt_equal_ x y`` is similar to ``elt_equal`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_not_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_not_equal_ x y`` is simiar to ``elt_not_equal`` function but the output is
+``elt_not_equal_ x y`` is similar to ``elt_not_equal`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_less_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_less_ x y`` is simiar to ``elt_less`` function but the output is written
+``elt_less_ x y`` is similar to ``elt_less`` function but the output is written
 to ``out``. You need to make sure ``out`` is big enough to hold the output
 result.
  *)
 
 val elt_greater_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_greater_ x y`` is simiar to ``elt_greater`` function but the output is
+``elt_greater_ x y`` is similar to ``elt_greater`` function but the output is
 written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_less_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_less_equal_ x y`` is simiar to ``elt_less_equal`` function but the output
+``elt_less_equal_ x y`` is similar to ``elt_less_equal`` function but the output
 is written to ``out``. You need to make sure ``out`` is big enough to hold the
 output result.
  *)
 
 val elt_greater_equal_ : ?out:('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t -> unit
 (**
-``elt_greater_equal_ x y`` is simiar to ``elt_greater_equal`` function but the
+``elt_greater_equal_ x y`` is similar to ``elt_greater_equal`` function but the
 output is written to ``out``. You need to make sure ``out`` is big enough to
 hold the output result.
  *)
 
 val elt_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_equal_scalar_ x a`` is simiar to ``elt_equal_scalar`` function but the
+``elt_equal_scalar_ x a`` is similar to ``elt_equal_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_not_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_not_equal_scalar_ x a`` is simiar to ``elt_not_equal_scalar`` function but
+``elt_not_equal_scalar_ x a`` is similar to ``elt_not_equal_scalar`` function but
 the output is written to ``x``.
  *)
 
 val elt_less_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_less_scalar_ x a`` is simiar to ``elt_less_scalar`` function but the
+``elt_less_scalar_ x a`` is similar to ``elt_less_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_greater_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_greater_scalar_ x a`` is simiar to ``elt_greater_scalar`` function but the
+``elt_greater_scalar_ x a`` is similar to ``elt_greater_scalar`` function but the
 output is written to ``x``.
  *)
 
 val elt_less_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_less_equal_scalar_ x a`` is simiar to ``elt_less_equal_scalar`` function
+``elt_less_equal_scalar_ x a`` is similar to ``elt_less_equal_scalar`` function
 but the output is written to ``x``.
  *)
 
 val elt_greater_equal_scalar_ : ?out:('a, 'b) t -> ('a, 'b) t -> 'a -> unit
 (**
-``elt_greater_equal_scalar_ x a`` is simiar to ``elt_greater_equal_scalar``
+``elt_greater_equal_scalar_ x a`` is similar to ``elt_greater_equal_scalar``
 function but the output is written to ``x``.
  *)
 

--- a/src/owl/dense/owl_dense_ndarray_intf.ml
+++ b/src/owl/dense/owl_dense_ndarray_intf.ml
@@ -273,7 +273,7 @@ module type Common = sig
 
   val slide : ?axis:int -> ?ofs:int -> ?step:int -> window:int -> arr -> arr
 
-  (** {6 Fucntions of in-place modification } *)
+  (** {6 Functions of in-place modification } *)
 
   val create_ : out:arr -> elt -> unit
 

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -164,7 +164,7 @@ val qr
 ``x = Q R``. ``Q`` is an ``m`` by ``n`` matrix (where ``Q^T Q = I``) and ``R`` is
 an ``n`` by ``n`` upper-triangular matrix.
 
-The function returns a 3-tuple, the first two are ``q`` and ``r``, and the thrid
+The function returns a 3-tuple, the first two are ``q`` and ``r``, and the third
 is the permutation vector of columns. The default value of ``pivot`` is ``false``,
 setting ``pivot = true`` lets ``qr`` performs pivoted factorisation. Note that
 the returned indices are not adjusted to 0-based C layout.

--- a/src/owl/maths/cdflib/owl_dcdflib.c
+++ b/src/owl/maths/cdflib/owl_dcdflib.c
@@ -1432,7 +1432,7 @@ void cdfbet(int *which,double *p,double *q,double *x,double *y,
      Digit Computation of the Incomplete  Beta  Function Ratios.  ACM
      Trans. Math.  Softw. 18 (1993), 360-373.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -1804,7 +1804,7 @@ void cdfbin(int *which,double *p,double *q,double *s,double *xn,
      Mathematical   Functions (1966) is   used  to reduce the  binomial
      distribution  to  the  cumulative incomplete    beta distribution.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -2165,7 +2165,7 @@ void cdfchi(int *which,double *p,double *q,double *x,double *df,
      Mathematical Functions   (1966) is used   to reduce the chisqure
      distribution to the incomplete distribution.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -2452,7 +2452,7 @@ void cdfchn(int *which,double *p,double *q,double *x,double *df,
      Mathematical  Functions (1966) is used to compute the cumulative
      distribution function.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -2723,7 +2723,7 @@ void cdff(int *which,double *p,double *q,double *f,double *dfn,
      of the  cumulative  distribution function for the  F  variate to
      that of an incomplete beta.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -3044,7 +3044,7 @@ void cdffnc(int *which,double *p,double *q,double *f,double *dfn,
      Mathematical  Functions (1966) is used to compute the cumulative
      distribution function.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -3368,7 +3368,7 @@ void cdfgam(int *which,double *p,double *q,double *x,double *shape,
      gamma function  ratios  and their  inverse.   ACM  Trans.  Math.
      Softw. 12 (1986), 377-393.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -3678,7 +3678,7 @@ void cdfnbn(int *which,double *p,double *q,double *s,double *xn,
      the cumulative distribution  function to that of  an  incomplete
      beta.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -4032,7 +4032,7 @@ void cdfnor(int *which,double *p,double *q,double *x,double *mean,
      Package of Special Function Routines and Test Drivers"
      acm Transactions on Mathematical Software. 19, 22-32.
 
-     is used to calulate the  cumulative standard normal distribution.
+     is used to calculate the  cumulative standard normal distribution.
 
      The rational functions from pages  90-95  of Kennedy and Gentle,
      Statistical  Computing,  Marcel  Dekker, NY,  1980 are  used  as
@@ -4232,7 +4232,7 @@ void cdfpoi(int *which,double *p,double *q,double *s,double *xlam,
      chi-square, hence an incomplete gamma function.
 
      Cumulative  distribution function  (P) is  calculated  directly.
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired value of  P.   The  search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -4487,7 +4487,7 @@ void cdft(int *which,double *p,double *q,double *t,double *df,
      of the cumulative distribution function to that of an incomplete
      beta.
 
-     Computation of other parameters involve a seach for a value that
+     Computation of other parameters involve a search for a value that
      produces  the desired  value  of P.   The search relies  on  the
      monotinicity of P with the other parameter.
 
@@ -4963,7 +4963,7 @@ S20:
     xnonc = *pnonc/2.0e0;
 /*
 **********************************************************************
-     The following code calcualtes the weight, chi-square, and
+     The following code calculates the weight, chi-square, and
      adjustment term for the central term in the infinite series.
      The central term is the one in which the poisson weight is
      greatest.  The adjustment term is the amount that must
@@ -5986,7 +5986,7 @@ S20:
     strtx = stvaln(&pp);
     xcur = strtx;
 /*
-     NEWTON INTERATIONS
+     NEWTON ITERATIONS
 */
     for(i=1; i<=maxit; i++) {
         cumnor(&xcur,&cum,&ccum);
@@ -6002,7 +6002,7 @@ S20:
     return dinvnr;
 S40:
 /*
-     IF WE GET HERE, NEWTON HAS SUCCEDED
+     IF WE GET HERE, NEWTON HAS SUCCEEDED
 */
     dinvnr = xcur;
     if(!qporq) dinvnr = -dinvnr;
@@ -6269,8 +6269,8 @@ void dinvr(int *status,double *x,double *fx,
 
      QLEFT <-- Defined only if QMFINV returns .FALSE.  In that
           case it is .TRUE. If the stepping search terminated
-          unsucessfully at SMALL.  If it is .FALSE. the search
-          terminated unsucessfully at BIG.
+          unsuccessfully at SMALL.  If it is .FALSE. the search
+          terminated unsuccessfully at BIG.
                     QLEFT is LOGICAL
 
      QHI <-- Defined only if QMFINV returns .FALSE.  In that
@@ -6803,7 +6803,7 @@ double dt1(double *p,double *q,double *df)
 **********************************************************************
 
      double dt1(double *p,double *q,double *df)
-     Double precision Initalize Approximation to
+     Double precision Initialize Approximation to
            INVerse of the cumulative T distribution
 
 
@@ -7070,16 +7070,16 @@ void dzror(int *status,double *x,double *fx,double *xlo,
                          DOUBLE PRECISION FX
 
      XLO <-- When ZROR returns with STATUS = 0, XLO bounds the
-             inverval in X containing the solution below.
+             interval in X containing the solution below.
                          DOUBLE PRECISION XLO
 
      XHI <-- When ZROR returns with STATUS = 0, XHI bounds the
-             inverval in X containing the solution above.
+             interval in X containing the solution above.
                          DOUBLE PRECISION XHI
 
-     QLEFT <-- .TRUE. if the stepping search terminated unsucessfully
+     QLEFT <-- .TRUE. if the stepping search terminated unsuccessfully
                 at XLO.  If it is .FALSE. the search terminated
-                unsucessfully at XHI.
+                unsuccessfully at XHI.
                     QLEFT is LOGICAL
 
      QHI <-- .TRUE. if F(X) .GT. Y at the termination of the
@@ -9170,7 +9170,7 @@ transfers the sign of the variable "sign" to the variable "mag"
 ************************************************************************/
 double fifdsign(double mag,double sign)
 /* mag     -     magnitude */
-/* sign    -     sign to be transfered */
+/* sign    -     sign to be transferred */
 {
   if (mag < 0) mag = -mag;
   if (sign < 0) mag = -mag;

--- a/src/owl/nlp/owl_nlp_corpus.ml
+++ b/src/owl/nlp/owl_nlp_corpus.ml
@@ -116,7 +116,7 @@ let get_tok corpus i : int array =
   doc
 
 
-(* reset all the file pointers at offest 0 *)
+(* reset all the file pointers at offset 0 *)
 let reset_iterators corpus =
   let _reset_offset = function
     | Some h -> seek_in h 0
@@ -180,12 +180,12 @@ let build ?docid ?stopwords ?lo ?hi ?vocab ?(minlen = 10) fname =
   let tok_f = fname ^ ".tok" |> open_out in
   set_binary_mode_out bin_f true;
   set_binary_mode_out tok_f true;
-  (* initalise the offset array *)
+  (* initialise the offset array *)
   let b_ofs = Owl_utils.Stack.make () in
   let t_ofs = Owl_utils.Stack.make () in
   Owl_utils.Stack.push b_ofs 0;
   Owl_utils.Stack.push t_ofs 0;
-  (* initalise the doc_id stack *)
+  (* initialise the doc_id stack *)
   let doc_s = Owl_utils.Stack.make () in
   (* binarise and tokenise at the same time *)
   Owl_log.info "convert to binary and tokenise ...";

--- a/src/owl/nlp/owl_nlp_corpus.mli
+++ b/src/owl/nlp/owl_nlp_corpus.mli
@@ -72,7 +72,7 @@ val next_batch_tok : ?size:int -> t -> int array array
 (** Return the next batch of tokenised documents in a corpus as a string array. The default ``size`` is 100. *)
 
 val reset_iterators : t -> unit
-(** Reset the iterator to the begining of the corpus. *)
+(** Reset the iterator to the beginning of the corpus. *)
 
 (** {6 Core functions} *)
 

--- a/src/owl/nlp/owl_nlp_tfidf.ml
+++ b/src/owl/nlp/owl_nlp_tfidf.ml
@@ -24,7 +24,7 @@ type t =
     mutable df_typ : df_typ
   ; (* function to calculate doc freq *)
     mutable offset : int array
-  ; (* record the offest each document *)
+  ; (* record the offset each document *)
     mutable doc_freq : float array
   ; (* document frequency *)
     mutable corpus : Owl_nlp_corpus.t
@@ -32,7 +32,7 @@ type t =
     mutable handle : in_channel option (* file descriptor of the tfidf *)
   }
 
-(* variouis types of TF and IDF fucntions *)
+(* various types of TF and IDF functions *)
 
 let term_freq = function
   | Binary    -> fun _tc _tn -> 1.
@@ -148,7 +148,7 @@ let _build_with norm sort tf_fun df_fun m =
   let fo = open_out fname in
   (* buffer for calculate term frequency *)
   let _h = Hashtbl.create 1024 in
-  (* variable for tracking the offest in output model *)
+  (* variable for tracking the offset in output model *)
   let offset = Owl_utils.Stack.make () in
   Owl_utils.Stack.push offset 0;
   Owl_io.iteri_lines_of_marshal

--- a/src/owl/nlp/owl_nlp_tfidf.mli
+++ b/src/owl/nlp/owl_nlp_tfidf.mli
@@ -81,13 +81,13 @@ val mapi : (int -> (int * float) array -> 'a) -> t -> 'a array
 (** Map all the document vectors in a TFIDF model. The format of document vector is ``(vocabulary index, weight)`` tuple array of a document. *)
 
 val reset_iterators : t -> unit
-(** Reset the iterator to the begining of the TFIDF model. *)
+(** Reset the iterator to the beginning of the TFIDF model. *)
 
 (** {6 Core functions} *)
 
 val build : ?norm:bool -> ?sort:bool -> ?tf:tf_typ -> ?df:df_typ -> Owl_nlp_corpus.t -> t
 (**
-This function builds up a TFIDF model according to the passed in paramaters.
+This function builds up a TFIDF model according to the passed in parameters.
 
 Parameters:
 * ``norm``: whether to normalise the vectors in the TFIDF model, default is ``false``.

--- a/src/owl/ppl/owl_distribution.mli
+++ b/src/owl/ppl/owl_distribution.mli
@@ -6,7 +6,7 @@
 (** Functor to generate distribution module *)
 
 module Make (A : Owl_types.Stats_Dist) : sig
-  (** {6 Uniform distribtion} *)
+  (** {6 Uniform distribution} *)
 
   module Uniform : sig
     type t =
@@ -46,7 +46,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Gaussian distribtion} *)
+  (** {6 Gaussian distribution} *)
 
   module Gaussian : sig
     type t =
@@ -86,7 +86,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Exponential distribtion} *)
+  (** {6 Exponential distribution} *)
 
   module Exponential : sig
     type t = { lambda : A.arr }
@@ -123,7 +123,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Poisson distribtion} *)
+  (** {6 Poisson distribution} *)
 
   module Poisson : sig
     type t = { mu : A.arr }
@@ -136,7 +136,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Sample a distribution of the given parameters. *)
   end
 
-  (** {6 Gamma distribtion} *)
+  (** {6 Gamma distribution} *)
 
   module Gamma : sig
     type t =
@@ -176,7 +176,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Beta distribtion} *)
+  (** {6 Beta distribution} *)
 
   module Beta : sig
     type t =
@@ -216,7 +216,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Chi2 distribtion} *)
+  (** {6 Chi2 distribution} *)
 
   module Chi2 : sig
     type t = { df : A.arr }
@@ -253,7 +253,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 F distribtion} *)
+  (** {6 F distribution} *)
 
   module F : sig
     type t =
@@ -293,7 +293,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Cauchy distribtion} *)
+  (** {6 Cauchy distribution} *)
 
   module Cauchy : sig
     type t =
@@ -333,7 +333,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Lomax distribtion} *)
+  (** {6 Lomax distribution} *)
 
   module Lomax : sig
     type t =
@@ -373,7 +373,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Weibull distribtion} *)
+  (** {6 Weibull distribution} *)
 
   module Weibull : sig
     type t =
@@ -413,7 +413,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Laplace distribtion} *)
+  (** {6 Laplace distribution} *)
 
   module Laplace : sig
     type t =
@@ -453,7 +453,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Gumbel1 distribtion} *)
+  (** {6 Gumbel1 distribution} *)
 
   module Gumbel1 : sig
     type t =
@@ -493,7 +493,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Gumbel2 distribtion} *)
+  (** {6 Gumbel2 distribution} *)
 
   module Gumbel2 : sig
     type t =
@@ -533,7 +533,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Logistic distribtion} *)
+  (** {6 Logistic distribution} *)
 
   module Logistic : sig
     type t =
@@ -573,7 +573,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Lognormal distribtion} *)
+  (** {6 Lognormal distribution} *)
 
   module Lognormal : sig
     type t =
@@ -613,7 +613,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     (** Inverse survival function of the distribution. *)
   end
 
-  (** {6 Rayleigh distribtion} *)
+  (** {6 Rayleigh distribution} *)
 
   module Rayleigh : sig
     type t = { sigma : A.arr }
@@ -668,7 +668,7 @@ module Make (A : Owl_types.Stats_Dist) : sig
     | Gumbel2     of Gumbel2.t
     | Logistic    of Logistic.t
     | Lognormal   of Lognormal.t
-    | Rayleigh    of Rayleigh.t (** Type definition of various distribtions *)
+    | Rayleigh    of Rayleigh.t (** Type definition of various distributions *)
 
   (** {6 Core functions} *)
 
@@ -676,10 +676,10 @@ module Make (A : Owl_types.Stats_Dist) : sig
   (** Sample a given distribution of the given parameters. *)
 
   val prob : dist -> A.arr -> A.arr
-  (** Probability density/mass function of a given distribtion. *)
+  (** Probability density/mass function of a given distribution. *)
 
   val log_prob : dist -> A.arr -> A.arr
-  (** logarithmic probability density/mass function of a given distribtion. *)
+  (** logarithmic probability density/mass function of a given distribution. *)
 
   val cdf : dist -> A.arr -> A.arr
   (** Cumulative density/mass function of the distribution. *)

--- a/src/owl/sparse/owl_sparse_matrix_c.mli
+++ b/src/owl/sparse/owl_sparse_matrix_c.mli
@@ -147,7 +147,7 @@ val fold_rows_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
 val fold_cols_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
-(** {6 Examin elements and compare two matrices} *)
+(** {6 Examine elements and compare two matrices} *)
 
 val exists : (elt -> bool) -> mat -> bool
 

--- a/src/owl/sparse/owl_sparse_matrix_d.mli
+++ b/src/owl/sparse/owl_sparse_matrix_d.mli
@@ -149,7 +149,7 @@ val fold_rows_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
 val fold_cols_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
-(** {6 Examin elements and compare two matrices} *)
+(** {6 Examine elements and compare two matrices} *)
 
 val exists : (elt -> bool) -> mat -> bool
 

--- a/src/owl/sparse/owl_sparse_matrix_generic.mli
+++ b/src/owl/sparse/owl_sparse_matrix_generic.mli
@@ -136,7 +136,7 @@ val fill : ('a, 'b) t -> 'a -> unit
 val copy : ('a, 'b) t -> ('a, 'b) t
 (**
 ``copy x`` makes an exact copy of matrix ``x``. Note that the copy becomes
-mutable no matter ``w`` is mutable or not. This is expecially useful if you
+mutable no matter ``w`` is mutable or not. This is especially useful if you
 want to modify certain elements in an immutable matrix from math operations.
  *)
 
@@ -393,7 +393,7 @@ val fold_cols_nz : ('c -> ('a, 'b) t -> 'c) -> 'c -> ('a, 'b) t -> 'c
 columns in ``x`` using function ``f``. Zero columns will be dropped in iterating ``x``.
  *)
 
-(** {6 Examin elements and compare two matrices} *)
+(** {6 Examine elements and compare two matrices} *)
 
 val exists : ('a -> bool) -> ('a, 'b) t -> bool
 (**

--- a/src/owl/sparse/owl_sparse_matrix_s.mli
+++ b/src/owl/sparse/owl_sparse_matrix_s.mli
@@ -149,7 +149,7 @@ val fold_rows_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
 val fold_cols_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
-(** {6 Examin elements and compare two matrices} *)
+(** {6 Examine elements and compare two matrices} *)
 
 val exists : (elt -> bool) -> mat -> bool
 

--- a/src/owl/sparse/owl_sparse_matrix_z.mli
+++ b/src/owl/sparse/owl_sparse_matrix_z.mli
@@ -147,7 +147,7 @@ val fold_rows_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
 val fold_cols_nz : ('a -> mat -> 'a) -> 'a -> mat -> 'a
 
-(** {6 Examin elements and compare two matrices} *)
+(** {6 Examine elements and compare two matrices} *)
 
 val exists : (elt -> bool) -> mat -> bool
 

--- a/src/owl/stats/owl_stats.h
+++ b/src/owl/stats/owl_stats.h
@@ -561,7 +561,7 @@ extern long logseries_rvs(double);
 extern double loggam(double x);
 
 
-/** Basic Statistic funcitons **/
+/** Basic Statistic functions **/
 
 extern void owl_stats_shuffle(void* base, int n, int size);
 

--- a/src/owl/stats/owl_stats.mli
+++ b/src/owl/stats/owl_stats.mli
@@ -415,7 +415,7 @@ val runs_test : ?alpha:float -> ?side:tail -> ?v:float -> float array -> hypothe
 (**
 ``runs_test ~alpha ~v x`` returns a test decision for the null hypothesis that
 the data ``x`` comes in random order, against the alternative that they do not,
-by runnign Wald–Wolfowitz runs test. The test is based on the number of runs
+by running Wald–Wolfowitz runs test. The test is based on the number of runs
 of consecutive values above or below the mean of ``x``. ``~v`` is the reference
 value, the default value is the median of ``x``.
  *)
@@ -522,12 +522,12 @@ log-transformed result from ``hypergeometric_pdf``.
 val multinomial_rvs : int -> p:float array -> int array
 (**
 ``multinomial_rvs n ~p`` generates random numbers of multinomial distribution
-from ``n`` trials. The probabilty mass function is as follows.
+from ``n`` trials. The probability mass function is as follows.
 
 .. math::
   P(x) = \frac{n!}{{x_1}! \cdot\cdot\cdot {x_k}!} p_{1}^{x_1} \cdot\cdot\cdot p_{k}^{x_k}
 
-``p`` is the probabilty mass of ``k`` categories. The elements in ``p`` should
+``p`` is the probability mass of ``k`` categories. The elements in ``p`` should
 all be positive (result is undefined if there are negative values), but they 
 don't need to sum to 1: the result is the same whether or not ``p`` is normalized. 
 For implementation details, refer to :cite:`davis1993computer`.
@@ -535,14 +535,14 @@ For implementation details, refer to :cite:`davis1993computer`.
 
 val multinomial_pdf : int array -> p:float array -> float
 (**
-``multinomial_rvs x ~p`` return the probabilty of ``x`` given the probabilty
+``multinomial_rvs x ~p`` return the probability of ``x`` given the probability
 mass of a multinomial distribution.
  *)
 
 val multinomial_logpdf : int array -> p:float array -> float
 (**
-``multinomial_rvs x ~p`` returns the logarithm probabilty of ``x`` given the
-probabilty mass of a multinomial distribution.
+``multinomial_rvs x ~p`` returns the logarithm probability of ``x`` given the
+probability mass of a multinomial distribution.
  *)
 
 val categorical_rvs : float array -> int
@@ -1065,7 +1065,7 @@ val rayleigh_isf : float -> sigma:float -> float
 val dirichlet_rvs : alpha:float array -> float array
 (**
 ``dirichlet_rvs ~alpha`` returns random variables of ``K-1`` order Dirichlet
-distribution, follows the following probabilty dense function.
+distribution, follows the following probability dense function.
 
 .. math::
   f(x_1,...,x_K; \alpha_1,...,\alpha_K) = \frac{1}{\mathbf{B(\alpha)}} \prod_{i=1}^K x_i^{\alpha_i - 1}

--- a/src/owl/stats/owl_stats_extend_misc.c
+++ b/src/owl/stats/owl_stats_extend_misc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2016-2020 Liang Wang <liang.wang@cl.cam.ac.uk>
  */
 
-/** TODO recursive definiton of mean, etc., only need to traverse data once.
+/** TODO recursive definition of mean, etc., only need to traverse data once.
   Current implementation is very fast but may be subject to overflow.
  **/
 

--- a/src/owl/working/owl_parallel.ml
+++ b/src/owl/working/owl_parallel.ml
@@ -113,7 +113,7 @@ module Make_Distributed (M : Ndarray) (E : Mapre_Engine) = struct
   (* make a distributed version of [create_fun d], the elements will be
      distributed among the working nodes.
 
-     [create_fun] receives three paramaters: shape, starting pos (1d), and
+     [create_fun] receives three parameters: shape, starting pos (1d), and
      length of the chunk (1d).
   *)
   let distributed_create_basic create_fun d =

--- a/src/plplot/owl_plot.ml
+++ b/src/plplot/owl_plot.ml
@@ -1684,7 +1684,7 @@ let wblplot ?(h = _default_handle) ?(spec = []) ?(lambda = 1.) ?(k = 1.) x =
   let p3y, p3x = Owl_stats.third_quartile y, Owl_stats.third_quartile x in
   let left, right = Owl_stats.minmax x in
   let up, down = Owl_stats.minmax y in
-  (* prepare the closure; note the change to log sacle *)
+  (* prepare the closure; note the change to log scale *)
   let p = h.pages.(h.current_page) in
   let color = _get_rgb spec p.fgcolor in
   let r, g, b = color in

--- a/src/plplot/owl_plot.mli
+++ b/src/plplot/owl_plot.mli
@@ -412,7 +412,7 @@ val qqplot
 ``qqplot ~pd ~x y `` displays a quantile-quantile plot of the quantiles of the
 sample data x versus the theoretical quantiles values from ``pd``, which by
 default is standard normal distribution. If the second argument ``x`` is a
-vector, the empirical CDF of it is used as the distribtion of x-axis data,
+vector, the empirical CDF of it is used as the distribution of x-axis data,
 otherwise the qqplot is similar to ``probplot``, showing the inverseCDF of
 meadian ``(i - 0.5)/n`` on x-axis.
 

--- a/src/zoo/owl_zoo_path.ml
+++ b/src/zoo/owl_zoo_path.ml
@@ -33,7 +33,7 @@ let mk_temp_dir ?(mode = 0o700) ?dir pat =
   let raise_err msg = raise (Sys_error ("mk_temp_dir: " ^ msg)) in
   let rec loop count =
     if count < 0
-    then raise_err "too many failing attemps"
+    then raise_err "too many failing attempts"
     else (
       let dir = Printf.sprintf "%s/%s%s" dir pat (rand_digits ()) in
       try

--- a/src/zoo/owl_zoo_ver.ml
+++ b/src/zoo/owl_zoo_ver.ml
@@ -79,7 +79,7 @@ let get_latest_vid (gid : string) (tol : float) =
     v.(Array.length v - 1))
   else (
     Owl_log.debug
-      "owl-zoo: Gist %s exceeds time tolerence %f; fetching newest vid from server"
+      "owl-zoo: Gist %s exceeds time tolerance %f; fetching newest vid from server"
       gid
       tol;
     Hashtbl.replace tb gid (v, t);


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell