### PR TITLE
Fixing typos

### DIFF
--- a/bin/owl_upload_gist.sh
+++ b/bin/owl_upload_gist.sh
@@ -15,7 +15,7 @@ cd $DIRNAME
 NAME=`head -n 1 \#readme.md`
 FILES=`ls * | xargs echo`
 
-# add new or upate a gist
+# add new or update a gist
 NAME="Owl's Gist"
 GISTFILE=gist.id
 if [ ! -f $GISTFILE ]; then

--- a/examples/custom_algodiff_op.ml
+++ b/examples/custom_algodiff_op.ml
@@ -11,7 +11,7 @@ open Algodiff.D
  * the `build_siso` function. This function takes a module of type 
  * Siso. Both of these are defined in side `Ops.Builder`. Inside, this
  * module we define the forward pass functions `ff_f` and `ff_arr` 
- * to handle float and Arr inputs repsectively. We define the 
+ * to handle float and Arr inputs respectively. We define the 
  * forward-mode and reverse-mode gradients with `df` and `dr` respectively.
  * Below the variable naming conventions here are based on c = cos(a). 
  * Therefore, `cp` is the primal of the output, `ca` is the adjoin of the 

--- a/examples/lazy_eval.ml
+++ b/examples/lazy_eval.ml
@@ -14,11 +14,11 @@ let lazy_eval x () =
   M.eval_arr [| z |]
 
 
-(* an exmaple for eager evaluation *)
+(* an example for eager evaluation *)
 let eager_eval x () =
   ignore Arr.(add x x |> log |> sin |> neg |> cos |> abs |> sinh |> round |> atan)
 
-(* test incremental compuation by changing part of inputs *)
+(* test incremental computation by changing part of inputs *)
 let incremental x =
   let a = M.var_arr "a" in
   let b = M.var_elt "b" in

--- a/test/unit_algodiff_diff_generic.ml
+++ b/test/unit_algodiff_diff_generic.ml
@@ -125,7 +125,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       an iterated mapping of each element of *xs* to a new element in a Bigarray
       for df. These two arrays are then compared using the Owl 'approx_equal'
       array comparison function, and if any elements differ by more than eps then
-      an error is displayed (the failing entry numebr is not displayed at
+      an error is displayed (the failing entry number is not displayed at
       present)
 
    **)

--- a/test/unit_stats_rvs.ml
+++ b/test/unit_stats_rvs.ml
@@ -211,7 +211,7 @@ let _ =
 
   'Correct' distribution parameters can be generated (e.g. in Scipy) - and checked elsewhere, and then these distributions can be used to validate the CDFs in Owl.
 
-  The Distribution can also then be mapped from an 'x' value to the CDF of x, for example to bucket up values from a continous random variable, where buckets can then be selected to determine patterns for checking for independence
+  The Distribution can also then be mapped from an 'x' value to the CDF of x, for example to bucket up values from a continuous random variable, where buckets can then be selected to determine patterns for checking for independence
 
 *)
 module Distribution = struct
@@ -305,7 +305,7 @@ module Distribution = struct
     Cubic.df t.cubics.(li) x
 
   (*f plot_comparison - plot comparison of CDF/PDF distributions
-   * disable this to avoid dependency on plplot, this simplies many things
+   * disable this to avoid dependency on plplot, this simplifies many things
    * including building docker images.
 
   let plot_comparison t dut_cdf dut_pdf filename  =
@@ -470,7 +470,7 @@ module BinaryTest = struct
                   = 4*p*(1-p)
                   = 4pq  (= 1 if p is 0.5)
 
-     For Y = N occurences of Yi:
+     For Y = N occurrences of Yi:
      Mean(Y) = N*(p-q) (= 0 if p=0.5)
      Variance(Y) = N*4pq = 4Npq (= N if p=0.5)
 
@@ -1193,7 +1193,7 @@ let test_uniform_ints_1_100_45 _ =
 
     The pattern tests are inherently based on the actual distribution probability, so they are
     not effected (except that large pattern lengths are less reliable as the expected number of a pattern
-    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probaby one should not go below about 10 for this...
+    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probably one should not go below about 10 for this...
     so max length of patterns should probably be 6
 
  *)
@@ -1251,7 +1251,7 @@ let test_gaussian_mean_0 _ =
 
     The pattern tests are inherently based on the actual distribution probability, so they are
     not effected (except that large pattern lengths are less reliable as the expected number of a pattern
-    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probaby one should not go below about 10 for this...
+    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probably one should not go below about 10 for this...
     so max length of patterns should probably be 6
 
  *)
@@ -1272,7 +1272,7 @@ let test_gaussian_mean_0_p0_3_left _ =
 
     The pattern tests are inherently based on the actual distribution probability, so they are
     not effected (except that large pattern lengths are less reliable as the expected number of a pattern
-    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probaby one should not go below about 10 for this...
+    of ten 1's in 10000 is (1/3)^10*10000 = 0.17; probably one should not go below about 10 for this...
     so max length of patterns should probably be 6
 
  *)


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell

I suppose the typos remaining in 'docs' will be corrected automatically.