### PR TITLE
Added kron and swap to Algodiff operations

### DIFF
--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1043,6 +1043,23 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
     and div a = Lazy.force _div a
 
+    and kron a b =
+      let na, ma =
+        let s = shape a in
+        s.(0), s.(1)
+      in
+      let nb, mb =
+        let s = shape b in
+        s.(0), s.(1)
+      in
+      let a = reshape a [| -1; 1 |] in
+      let b = reshape a [| 1; -1 |] in
+      let c = a *@ b in
+      let c = reshape c [| na; ma; nb; mb |] in
+      let c = transpose ~axis:[| 0; 2; 1; 3 |] c in
+      reshape c [| Stdlib.(na * nb); Stdlib.(ma * mb) |]
+
+
     and ( ** ) a b = pow a b
 
     and _pow =

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -576,21 +576,31 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
     and _transpose =
       lazy
-        (build_siso
-           (module struct
-             let label = "transpose"
+        (fun ?axis ->
+          build_siso
+            (module struct
+              let label = "transpose"
 
-             let ff_f a = error_uniop label (pack_elt a)
+              let ff_f a = error_uniop label (pack_elt a)
 
-             let ff_arr a = Arr A.(transpose a)
+              let ff_arr a = Arr A.(transpose ?axis a)
 
-             let df _cp _ap at = transpose at
+              let df _cp _ap at = transpose ?axis at
 
-             let dr _a _cp ca = transpose !ca
-           end : Siso))
+              let dr _a _cp ca = transpose ?axis !ca
+            end : Siso))
 
 
-    and transpose a = Lazy.force _transpose a
+    and transpose ?axis = Lazy.force _transpose ?axis
+
+    and swap a0 a1 x =
+      let d = Array.length (shape x) in
+      let a = Array.init d (fun i -> i) in
+      let t = a.(a0) in
+      a.(a0) <- a.(a1);
+      a.(a1) <- t;
+      transpose ~axis:a x
+
 
     and _l1norm' =
       lazy

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1053,7 +1053,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
         s.(0), s.(1)
       in
       let a = reshape a [| -1; 1 |] in
-      let b = reshape a [| 1; -1 |] in
+      let b = reshape b [| 1; -1 |] in
       let c = a *@ b in
       let c = reshape c [| na; ma; nb; mb |] in
       let c = transpose ~axis:[| 0; 2; 1; 3 |] c in

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -55,6 +55,9 @@ module type Sig = sig
     val div : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val kron : t -> t -> t
+    (** Refer to :doc:`owl_dense_matrix_generic` *)
+
     val dot : t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -160,7 +160,10 @@ module type Sig = sig
     val mean : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val transpose : t -> t
+    val transpose : ?axis:int array -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val swap : int -> int -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val l1norm' : t -> t

--- a/test/unit_dense_ndarray.ml
+++ b/test/unit_dense_ndarray.ml
@@ -368,8 +368,7 @@ module To_test = struct
     let result_shp = M.shape y in
     let y0 =
       let idx = List.init ndim (fun i -> if i = axis then [ 0 ] else []) in
-      M.get_slice idx y
-      |> M.squeeze ~axis:[|axis|]
+      M.get_slice idx y |> M.squeeze ~axis:[| axis |]
     in
     result_shp = expected_shp && y0 = x.(0)
 


### PR DESCRIPTION
The main changes in this PR are:

1. can now do Ndarray `transpose` in Algodiff, by exposing the ?axis argument
2. use `transpose` to implement `swap` in Algodiff
3. implement `kron` product using `transpose` and matrix product in Algodiff (implementation thanks to @ghennequin )