### PR TITLE
Graph subnetwork: Multiple outputs

### DIFF
--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -767,7 +767,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
       nn.topo
 
 
-  let get_subnetwork_array ?(copy = false) ?(make_inputs = [||]) nn outputs =
+  let get_subnetwork ?(copy = true) ?(make_inputs = [||]) nn output_names =
     let subnn = make_network 0 [||] [||] in
     let in_nodes = ref [] in
     (* collect neurons belonging to subnetwork *)
@@ -796,7 +796,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
       Array.fold_left
         (fun acc name -> collect_subnn_nodes (get_node nn name) acc)
         []
-        outputs
+        output_names
     in
     (* sorts the new topology *)
     let new_topo =
@@ -817,7 +817,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
         let node = get_node nn node'.name in
         if not (List.memq node' !in_nodes)
         then node'.prev <- Array.map (fun n -> get_node subnn n.name) node.prev;
-        if not (Array.mem node.name outputs)
+        if not (Array.mem node.name output_names)
         then (
           (* only process nodes that are part of the subnetwork *)
           let next =
@@ -831,11 +831,8 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
       subnn.topo;
     (* TODO: Warn if not all names in in_names were used? *)
     subnn.roots <- Array.of_list !in_nodes;
-    subnn.outputs <- Array.map (fun name -> get_node subnn name) outputs;
+    subnn.outputs <- Array.map (fun name -> get_node subnn name) output_names;
     subnn
-
-  let get_subnetwork ?copy ?make_inputs out_node =
-    get_subnetwork_array ?copy ?make_inputs (get_network out_node) [| out_node.name |]
 
 
   (* training functions *)

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -766,7 +766,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
         Neuron.load_weights n.neuron ws)
       nn.topo
 
-  let get_subnetwork_array ?(make_inputs = [||]) nn outputs =
+  let get_subnetwork_array ?(copy = false) ?(make_inputs = [||]) nn outputs =
     let subnn = make_network 0 [||] [||] in
     let in_nodes = ref [] in
     (* collect neurons belonging to subnetwork *)
@@ -781,8 +781,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
         in_nodes := new_in :: !in_nodes;
         new_in :: acc)
       else (
-        (* no neuron copy *)
-        let neur = n.neuron in
+        let neur = if copy then Neuron.copy n.neuron else n.neuron in
         let new_node = make_node ~name:n.name ~train:n.train [||] [||] neur None subnn in
         match neur with
         | Input _ ->
@@ -828,8 +827,8 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
     subnn.outputs <- Array.map (fun name -> get_node subnn name) outputs;
     subnn
 
-  let get_subnetwork ?make_inputs out_node =
-    get_subnetwork_array ?make_inputs (get_network out_node) [| out_node.name |]
+  let get_subnetwork ?copy ?make_inputs out_node =
+    get_subnetwork_array ?copy ?make_inputs (get_network out_node) [| out_node.name |]
 
 
   (* training functions *)

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -767,7 +767,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
       nn.topo
 
 
-  let get_subnetwork ?(copy = true) ?(make_inputs = [||]) nn output_names =
+  let make_subnetwork ?(copy = true) ?(make_inputs = [||]) nn output_names =
     let subnn = make_network 0 [||] [||] in
     let in_nodes = ref [] in
     (* collect neurons belonging to subnetwork *)

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -766,6 +766,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
         Neuron.load_weights n.neuron ws)
       nn.topo
 
+
   let get_subnetwork_array ?(copy = false) ?(make_inputs = [||]) nn outputs =
     let subnn = make_network 0 [||] [||] in
     let in_nodes = ref [] in
@@ -791,7 +792,12 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
           let acc = new_node :: acc in
           Array.fold_left (fun a prev -> collect_subnn_nodes prev a) acc n.prev)
     in
-    let new_nodes = Array.fold_left (fun acc name -> collect_subnn_nodes (get_node nn name) acc) [] outputs in
+    let new_nodes =
+      Array.fold_left
+        (fun acc name -> collect_subnn_nodes (get_node nn name) acc)
+        []
+        outputs
+    in
     (* sorts the new topology *)
     let new_topo =
       Array.fold_left
@@ -819,6 +825,7 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
               (fun n -> Array.exists (fun n' -> n'.name = n.name) subnn.topo)
               node.next
           in
+          (* With custom input nodes, next could contain an input node. *)
           node'.next <- Array.map (fun n -> get_node subnn n.name) next);
         connect_to_parents node'.prev node')
       subnn.topo;

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -673,18 +673,16 @@ Load the weights from a file of the given name. Note that the weights and the
 name of their associated neurons are saved as key-value pairs in a hash table.
   *)
 
-  val get_subnetwork : ?copy:bool -> ?make_inputs:string array -> node -> network
+  val get_subnetwork : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
   (**
-   Constructs a subnetwork of nodes on which ``node`` depends, replacing
-   nodes with names in ``make_inputs`` with input nodes. If ``make_inputs``
-   is empty or unspecified, the original input nodes are used.  ``copy`` is
-   a bool controlling whether the weights of the new network are copies or
-   references to those of the old network (defaults to ``false``).
-   *)
+   Constructs a subnetwork of nodes on which ``output_names`` depend,
+   replacing nodes with names in ``make_inputs`` with input nodes.
 
-  val get_subnetwork_array : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
-  (**
-   Like ``get_subnetwork``, but allows for multiple output nodes in the subnetwork.
+   Arguments:
+     ``copy``: Whether to copy or reference the original node weights. Defaults to true.
+     ``make_inputs``: Names of nodes to use as inputs to the subnetwork. Defaults to [||], which uses the original inputs.
+     ``nn``: The neural network from which the subnetwork is constructed.
+     ``output_names``: Names of nodes to use as outputs.
    *)
 
   (** {6 Train Networks} *)

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -673,17 +673,19 @@ Load the weights from a file of the given name. Note that the weights and the
 name of their associated neurons are saved as key-value pairs in a hash table.
   *)
 
-  val get_subnetwork : ?make_inputs:string array -> node -> network
+  val get_subnetwork : ?copy:bool -> ?make_inputs:string array -> node -> network
   (**
    Constructs a subnetwork of nodes on which ``node`` depends, replacing
    nodes with names in ``make_inputs`` with input nodes. If ``make_inputs``
-   is empty or unspecified, the original input nodes are used.
-   
-   Note: the weights in the new network are the references of those in
-   the old one.
+   is empty or unspecified, the original input nodes are used.  ``copy`` is
+   a bool controlling whether the weights of the new network are copies or
+   references to those of the old network (defaults to ``false``).
    *)
 
-  val get_subnetwork_array : ?make_inputs:string array -> network -> string array -> network
+  val get_subnetwork_array : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
+  (**
+   Like ``get_subnetwork``, but allows for multiple output nodes in the subnetwork.
+   *)
 
   (** {6 Train Networks} *)
 

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -683,6 +683,8 @@ name of their associated neurons are saved as key-value pairs in a hash table.
    the old one.
    *)
 
+  val get_subnetwork_array : ?make_inputs:string array -> network -> string array -> network
+
   (** {6 Train Networks} *)
 
   val train_generic

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -673,10 +673,11 @@ Load the weights from a file of the given name. Note that the weights and the
 name of their associated neurons are saved as key-value pairs in a hash table.
   *)
 
-  val get_subnetwork : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
+  val make_subnetwork : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
   (**
-   Constructs a subnetwork of nodes on which ``output_names`` depend,
-   replacing nodes with names in ``make_inputs`` with input nodes.
+   ``get_subnetwork ?copy ?make_inputs network output_names`` constructs a
+   subnetwork of nodes on which ``output_names`` depend, replacing nodes with
+   names in ``make_inputs`` with input nodes.
 
    Arguments:
      ``copy``: Whether to copy or reference the original node weights. Defaults to true.


### PR DESCRIPTION
Hi, I finally got around to adding this small change. This was discussed in https://github.com/owlbarn/owl/pull/491 I personally don't need it, but for the sake of completeness, here it is.

Example:
```
let nn = Graph.(
  let inp = input [| 2 |] in
  let x1 = lambda ~name:"x1" ~out_shape:[|1|] (fun x -> Algodiff.Maths.get_slice [[]; [0]] x) inp in
  let x2 = lambda ~name:"x2" ~out_shape:[|1|] (fun x -> Algodiff.Maths.get_slice [[]; [1]] x) inp in
  let f1 = fully_connected ~name:"f1" 1 x1 in
  let f2 = fully_connected ~name:"f2" 1 x2 in
  let sum = add ~name:"sum" [| f1; f2 |] in
  sum |> get_network);;
Graph.get_subnetwork ~make_inputs:[|"x1"; "x2"|] nn [| "f1"; "f2" |];;
```

Two comments:
 - I also added a flag for whether to copy the weights.
 - I did change the signature (likely not many are using this yet, so hopefully not a problem). This also allowed me to change the default copy behavior to `true`. If this is undesirable, d684020389524e5b35fbe62e87160a4d09e51b26 is a version without and I can PR that instead.

PS. I have myself found this subnetwork feature really useful :)