### PR TITLE
Graph Slice node (resolves #483)

### DIFF
--- a/src/base/misc/owl_utils_infer_shape.mli
+++ b/src/base/misc/owl_utils_infer_shape.mli
@@ -99,6 +99,8 @@ val concatenate : int array array -> int -> int array
 
 val split : int array -> int -> int array -> int array array
 
+val slice : int array -> int list list -> int array
+
 val draw : 'a array -> int -> 'a -> 'a array
 
 val reduce : int array -> int array -> int array

--- a/src/base/neural/owl_neural_graph.ml
+++ b/src/base/neural/owl_neural_graph.ml
@@ -651,6 +651,13 @@ module Make (Neuron : Owl_neural_neuron_sig.Sig) = struct
     add_node nn [| input_node |] n
 
 
+  let slice ?name slice input_node =
+    let neuron = Slice (Slice.create slice) in
+    let nn = get_network input_node in
+    let n = make_node ?name [||] [||] neuron None nn in
+    add_node nn [| input_node |] n
+
+
   let lambda ?name ?act_typ ?out_shape lambda input_node =
     let neuron = Lambda (Lambda.create ?out_shape lambda) in
     let nn = get_network input_node in

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -570,6 +570,11 @@ Arguments:
 ``flatten node`` flattens the input. Does not affect the batch size.
   *)
 
+  val slice : ?name:string -> int list list -> node -> node
+  (**
+``slice node`` slices the input. Does not affect the batch size.
+  *)
+
   val lambda
     :  ?name:string
     -> ?act_typ:Activation.typ

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2586,6 +2586,70 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     let to_name () = "flatten"
   end
 
+  (* definition of Slice neuron *)
+  module Slice = struct
+    type neuron_typ =
+      { mutable in_shape : int array
+      ; mutable out_shape : int array
+      ; mutable slice : int list list
+      }
+
+    let create slice = { in_shape = [||]; out_shape = [||]; slice }
+
+    let connect out_shape l =
+      assert (List.length l.slice <= Array.length out_shape);
+      (* Calculate the output shape based on input and slice *)
+      let deduce_shape orig_shape slice =
+        let slice_len length start stop ?step () =
+          let start = if start < 0 then length + start else start in
+          let stop = if stop < 0 then length + stop else stop in
+          let step =
+            match step with
+            | Some x -> x
+            | None   -> if start <= stop then 1 else -1
+          in
+          assert (
+            (start <= stop && step > 0 && stop < length)
+            || (start > stop && step < 0 && start < length));
+          let step_abs = abs step in
+          (abs (stop - start) + step_abs) / step_abs
+        in
+        let shape' =
+          List.mapi
+            (fun i slicei ->
+              let length = orig_shape.(i) in
+              let slicei_len = slice_len length in
+              match slicei with
+              | []                    -> length
+              | [ index ]             -> slicei_len index index ()
+              | [ start; stop ]       -> slicei_len start stop ()
+              | [ start; stop; step ] -> slicei_len start stop ~step ()
+              | _                     -> failwith
+                                           "owl_neural_neuron: invalid slice specification")
+            slice
+        in
+        let shape = Array.copy orig_shape in
+        List.iteri (fun i len -> shape.(i) <- len) shape';
+        shape
+      in
+      l.in_shape <- Array.copy out_shape;
+      l.out_shape <- deduce_shape out_shape l.slice
+
+
+    let copy l = create l.slice
+
+    let run x l = Maths.get_slice ([] :: l.slice) x
+
+    let to_string l =
+      (* TODO: print slice? *)
+      let in_str = Owl_utils_array.to_string string_of_int l.in_shape in
+      let out_str = Owl_utils_array.to_string string_of_int l.out_shape in
+      Printf.sprintf "    Slice : in:[*,%s] out:[*,%s]\n" in_str out_str
+
+
+    let to_name () = "slice"
+  end
+
   (* definition of Add neuron *)
   module Add = struct
     type neuron_typ =
@@ -3191,6 +3255,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout         of Dropout.neuron_typ
     | Reshape         of Reshape.neuron_typ
     | Flatten         of Flatten.neuron_typ
+    | Slice           of Slice.neuron_typ
     | Lambda          of Lambda.neuron_typ
     | LambdaArray     of LambdaArray.neuron_typ
     | Activation      of Activation.neuron_typ
@@ -3236,6 +3301,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout l         -> Dropout.(l.in_shape, l.out_shape)
     | Reshape l         -> Reshape.(l.in_shape, l.out_shape)
     | Flatten l         -> Flatten.(l.in_shape, l.out_shape)
+    | Slice l           -> Slice.(l.in_shape, l.out_shape)
     | Lambda l          -> Lambda.(l.in_shape, l.out_shape)
     | LambdaArray l     -> LambdaArray.(l.in_shape, l.out_shape)
     | Activation l      -> Activation.(l.in_shape, l.out_shape)
@@ -3287,6 +3353,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout l         -> Dropout.connect out_shapes.(0) l
     | Reshape l         -> Reshape.connect out_shapes.(0) l
     | Flatten l         -> Flatten.connect out_shapes.(0) l
+    | Slice l           -> Slice.connect out_shapes.(0) l
     | Lambda l          -> Lambda.connect out_shapes.(0) l
     | LambdaArray l     -> LambdaArray.connect out_shapes l
     | Activation l      -> Activation.connect out_shapes.(0) l
@@ -3507,6 +3574,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout l         -> Dropout Dropout.(copy l)
     | Reshape l         -> Reshape Reshape.(copy l)
     | Flatten l         -> Flatten Flatten.(copy l)
+    | Slice l           -> Slice Slice.(copy l)
     | Lambda l          -> Lambda Lambda.(copy l)
     | LambdaArray l     -> LambdaArray LambdaArray.(copy l)
     | Activation l      -> Activation Activation.(copy l)
@@ -3554,6 +3622,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout l         -> Dropout.run a.(0) l
     | Reshape l         -> Reshape.run a.(0) l
     | Flatten l         -> Flatten.run a.(0) l
+    | Slice l           -> Slice.run a.(0) l
     | Lambda l          -> Lambda.run a.(0) l
     | LambdaArray l     -> LambdaArray.run a l
     | Activation l      -> Activation.run a.(0) l
@@ -3600,6 +3669,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout l         -> Dropout.to_string l
     | Reshape l         -> Reshape.to_string l
     | Flatten l         -> Flatten.to_string l
+    | Slice l           -> Slice.to_string l
     | Lambda l          -> Lambda.to_string l
     | LambdaArray l     -> LambdaArray.to_string l
     | Activation l      -> Activation.to_string l
@@ -3646,6 +3716,7 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     | Dropout _         -> Dropout.to_name ()
     | Reshape _         -> Reshape.to_name ()
     | Flatten _         -> Flatten.to_name ()
+    | Slice _           -> Slice.to_name ()
     | Lambda _          -> Lambda.to_name ()
     | LambdaArray _     -> LambdaArray.to_name ()
     | Activation _      -> Activation.to_name ()

--- a/src/base/neural/owl_neural_neuron.ml
+++ b/src/base/neural/owl_neural_neuron.ml
@@ -2641,10 +2641,18 @@ module Make (Optimise : Owl_optimise_generic_sig.Sig) = struct
     let run x l = Maths.get_slice ([] :: l.slice) x
 
     let to_string l =
-      (* TODO: print slice? *)
       let in_str = Owl_utils_array.to_string string_of_int l.in_shape in
       let out_str = Owl_utils_array.to_string string_of_int l.out_shape in
+      let slice_str =
+        List.mapi
+          (fun i l ->
+            let s = List.map string_of_int l |> String.concat "; " in
+            Printf.sprintf "%i:[%s]" i s)
+          l.slice
+        |> String.concat " "
+      in
       Printf.sprintf "    Slice : in:[*,%s] out:[*,%s]\n" in_str out_str
+      ^ Printf.sprintf "    Axes  : %s\n" slice_str
 
 
     let to_name () = "slice"

--- a/src/base/neural/owl_neural_neuron_sig.ml
+++ b/src/base/neural/owl_neural_neuron_sig.ml
@@ -1462,6 +1462,36 @@ module type Sig = sig
     (** Return the name of the neuron. *)
   end
 
+  (** {6 Slice neuron} *)
+
+  module Slice : sig
+    type neuron_typ =
+      { mutable in_shape : int array
+      ; mutable out_shape : int array
+      ; mutable slice : int list list
+      }
+
+    (** Neuron type definition. *)
+
+    val create : int list list -> neuron_typ
+    (** Create the neuron. *)
+
+    val connect : int array -> neuron_typ -> unit
+    (** Connect this neuron to others in a neural network. *)
+
+    val copy : neuron_typ -> neuron_typ
+    (** Make a deep copy of the neuron and its parameters. *)
+
+    val run : t -> neuron_typ -> t
+    (** Execute the computation in this neuron. *)
+
+    val to_string : neuron_typ -> string
+    (** Convert the neuron to its string representation. The string is often a summary of the parameters defined in the neuron. *)
+
+    val to_name : unit -> string
+    (** Return the name of the neuron. *)
+  end
+
   (** {6 Add neuron} *)
 
   module Add : sig
@@ -1875,6 +1905,7 @@ module type Sig = sig
     | Dropout         of Dropout.neuron_typ
     | Reshape         of Reshape.neuron_typ
     | Flatten         of Flatten.neuron_typ
+    | Slice           of Slice.neuron_typ
     | Lambda          of Lambda.neuron_typ
     | LambdaArray     of LambdaArray.neuron_typ
     | Activation      of Activation.neuron_typ


### PR DESCRIPTION
A node producing a `get_slice` on its input.

Most code that is not boilerplate is for computing the output dimension. The calculation itself is pretty much the same as in `_enumerate_slice_def` (https://github.com/owlbarn/owl/blob/master/src/base/dense/owl_base_dense_ndarray_generic.ml#L99). The `assert` is a bit more aggressive (checks bounds) to avoid `Assert_failure ("src/base/core/owl_base_slicing.ml", 90, 10).` when running.

I am aware of special cases like that "later" axes do not need to be specified, and handle that. Are there others that I might have missed?

~~There is one potential extra feature: A bool flag to set whether trivial dimensions (those with length 1) should be remove, i.e., reshaped away. Is this too niche/specialized?~~

~~There is still a TODO for prettier (more detailed) printing.~~

Example:
```
# let nn = Neural.D.Graph.(input [| 5; 2 |] |> slice [[1; -1; 3]] |> get_network);;
val nn : Owl_neural.D.Graph.network =
  42878

[ Node input_0 ]:
    Input : in/out:[*,3,2]
    prev:[] next:[slice_1]

[ Node slice_1 ]:
    Slice : in:[*,3,2] out:[*,2,2]
    prev:[input_0] next:[]

# Neural.D.Graph.model nn (Arr.sequential [| 1; 5; 2 |]);;
- : Owl_algodiff_primal_ops.D.arr =

       C0 C1
R[0,0]  2  3
R[0,1]  8  9
```
```
# Arr.(sequential [|5;2|] |> get_slice [[1;-1;3]]);;
- : Arr.arr =
   C0 C1
R0  2  3
R1  8  9
```