### PR TITLE
Preview of ocamlformat 0.14.2

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,4 @@
+version=0.14.2
 profile=janestreet
 wrap-comments=false
 doc-comments=after

--- a/src/base/neural/owl_neural_graph_sig.ml
+++ b/src/base/neural/owl_neural_graph_sig.ml
@@ -678,7 +678,12 @@ Load the weights from a file of the given name. Note that the weights and the
 name of their associated neurons are saved as key-value pairs in a hash table.
   *)
 
-  val make_subnetwork : ?copy:bool -> ?make_inputs:string array -> network -> string array -> network
+  val make_subnetwork
+    :  ?copy:bool
+    -> ?make_inputs:string array
+    -> network
+    -> string array
+    -> network
   (**
    ``get_subnetwork ?copy ?make_inputs network output_names`` constructs a
    subnetwork of nodes on which ``output_names`` depend, replacing nodes with


### PR DESCRIPTION
As of the new release process we are implementing for ocamlformat here is the preview of what the codebase would look like after ocamlformat-0.14.2 has been applied.
This preview is not definitive, as we need to make sure it is fitting with other main ocaml projects as well, please do not merge this PR.

The .ocamlformat file has been updated for consistency (setting the ocamlformat version is advised) although the package has not been submitted to opam yet. If you wish to test this version, remove this line in the .ocamlformat file, and use the master version of ocamlformat (as of ocaml-ppx/ocamlformat@6fb5a8c)

The diff you can see can be explained by the function signature exceeding the margin.
Feel free to give your feedback on this PR or open an issue on https://github.com/ocaml-ppx/ocamlformat/issues