### PR TITLE
ocamlformat: after -> after-when-possible

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,7 @@
 version=0.14.2
 profile=janestreet
 wrap-comments=false
-doc-comments=after
+doc-comments=after-when-possible
 align-cases=true
 align-constructors-decl
 let-binding-spacing=sparse


### PR DESCRIPTION
`after` becomes `after-when-possible` in ocamlformat version 0.14.2