### PR TITLE
keep_dims option

### DIFF
--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -551,7 +551,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
             end : Siso))
 
 
-    and sum ?axis ?(keep_dims = false) = Lazy.force _sum ?axis ~keep_dims
+    and sum ?axis ?(keep_dims = true) = Lazy.force _sum ?axis ~keep_dims
 
     and _sum_reduce =
       lazy

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -157,10 +157,10 @@ module type Sig = sig
     val log_sum_exp' : t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val log_sum_exp : ?axis:int -> t -> t
+    val log_sum_exp : ?axis:int -> ?keep_dims:bool -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-    val sum : ?axis:int -> t -> t
+    val sum : ?axis:int -> ?keep_dims:bool -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
     val sum_reduce : ?axis:int array -> t -> t

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -103,14 +103,23 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
             | Acosh -> _eval_map_01 x (fun ~out x -> A.acosh_ ~out x.(0))
             | Atanh -> _eval_map_01 x (fun ~out x -> A.atanh_ ~out x.(0))
             | Min (keep_dims, axis) ->
+              (* reuse memory (_eval_map_01) when keep_dims=true else create new node 
+                 (_eval_map_00) *)
+              (* TODO: implement keep_dims for A.min_ in Ndarray to reuse memory *)
               if keep_dims
               then _eval_map_01 x (fun ~out x -> A.min_ ~out ~axis x.(0))
               else _eval_map_00 x (fun x -> A.min ~keep_dims ~axis x.(0))
             | Max (keep_dims, axis) ->
+              (* reuse memory (_eval_map_01) when keep_dims=true else create new node 
+                 (_eval_map_00) *)
+              (* TODO: implement keep_dims for A.max_ in Ndarray to reuse memory *)
               if keep_dims
               then _eval_map_01 x (fun ~out x -> A.max_ ~out ~axis x.(0))
               else _eval_map_00 x (fun x -> A.max ~keep_dims ~axis x.(0))
             | Sum (keep_dims, axis) ->
+              (* reuse memory (_eval_map_01) when keep_dims=true else create new node 
+                 (_eval_map_00) *)
+              (* TODO: implement keep_dims for A.sum_ in Ndarray to reuse memory *)
               if keep_dims
               then _eval_map_01 x (fun ~out x -> A.sum_ ~out ~axis x.(0))
               else _eval_map_00 x (fun x -> A.sum ~keep_dims ~axis x.(0))

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -102,9 +102,18 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
             | Asinh -> _eval_map_01 x (fun ~out x -> A.asinh_ ~out x.(0))
             | Acosh -> _eval_map_01 x (fun ~out x -> A.acosh_ ~out x.(0))
             | Atanh -> _eval_map_01 x (fun ~out x -> A.atanh_ ~out x.(0))
-            | Min axis -> _eval_map_01 x (fun ~out x -> A.min_ ~out ~axis x.(0))
-            | Max axis -> _eval_map_01 x (fun ~out x -> A.max_ ~out ~axis x.(0))
-            | Sum axis -> _eval_map_01 x (fun ~out x -> A.sum_ ~out ~axis x.(0))
+            | Min (keep_dims, axis) ->
+              if keep_dims
+              then _eval_map_01 x (fun ~out x -> A.min_ ~out ~axis x.(0))
+              else _eval_map_00 x (fun x -> A.min ~keep_dims ~axis x.(0))
+            | Max (keep_dims, axis) ->
+              if keep_dims
+              then _eval_map_01 x (fun ~out x -> A.max_ ~out ~axis x.(0))
+              else _eval_map_00 x (fun x -> A.max ~keep_dims ~axis x.(0))
+            | Sum (keep_dims, axis) ->
+              if keep_dims
+              then _eval_map_01 x (fun ~out x -> A.sum_ ~out ~axis x.(0))
+              else _eval_map_00 x (fun x -> A.sum ~keep_dims ~axis x.(0))
             | SumReduce axis -> _eval_map_00 x (fun x -> A.sum_reduce ~axis x.(0))
             | Signum -> _eval_map_01 x (fun ~out x -> A.signum_ ~out x.(0))
             | Sigmoid -> _eval_map_01 x (fun ~out x -> A.sigmoid_ ~out x.(0))

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -103,9 +103,9 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
     | Asinh -> split_01 p
     | Acosh -> split_01 p
     | Atanh -> split_01 p
-    | Min _axis -> split_00 p (* ? *)
-    | Max _axis -> split_00 p (* ? *)
-    | Sum _axis -> split_00 p (* ? *)
+    | Min (_keep_dims, _axis) -> split_00 p (* ? *)
+    | Max (_keep_dims, _axis) -> split_00 p (* ? *)
+    | Sum (_keep_dims, _axis) -> split_00 p (* ? *)
     | SumReduce _axis -> split_00 p (* ? *)
     | Signum -> split_01 p
     | Sigmoid -> split_01 p
@@ -115,7 +115,7 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
     | Max' -> split_01 p
     | Sum' -> split_01 p
     | LogSumExp' -> split_01 p
-    | LogSumExp _axis -> split_00 p
+    | LogSumExp (_keep_dims, _axis) -> split_00 p
     | L1norm' -> split_01 p
     | L2norm' -> split_01 p
     | L2NormSqr' -> split_01 p

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -255,17 +255,17 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
 
   let atanh x = make_then_connect Atanh [| arr_to_node x |] |> node_to_arr
 
-  let min ?(axis = -1) ?(keep_dims = false) x =
+  let min ?(axis = -1) ?(keep_dims = true) x =
     ignore keep_dims;
     make_then_connect (Min axis) [| arr_to_node x |] |> node_to_arr
 
 
-  let max ?(axis = -1) ?(keep_dims = false) x =
+  let max ?(axis = -1) ?(keep_dims = true) x =
     ignore keep_dims;
     make_then_connect (Max axis) [| arr_to_node x |] |> node_to_arr
 
 
-  let sum ?(axis = -1) ?(keep_dims = false) x =
+  let sum ?(axis = -1) ?(keep_dims = true) x =
     ignore keep_dims;
     make_then_connect (Sum axis) [| arr_to_node x |] |> node_to_arr
 
@@ -290,7 +290,7 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
 
   let log_sum_exp' x = make_then_connect LogSumExp' [| arr_to_node x |] |> node_to_elt
 
-  let log_sum_exp ?(axis = 0) ?(keep_dims = false) x =
+  let log_sum_exp ?(axis = 0) ?(keep_dims = true) x =
     ignore keep_dims;
     make_then_connect (LogSumExp axis) [| arr_to_node x |] |> node_to_arr
 

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -256,18 +256,17 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
   let atanh x = make_then_connect Atanh [| arr_to_node x |] |> node_to_arr
 
   let min ?(axis = -1) ?(keep_dims = true) x =
-    ignore keep_dims;
-    make_then_connect (Min axis) [| arr_to_node x |] |> node_to_arr
+    make_then_connect (Min (keep_dims, axis)) [| arr_to_node x |] |> node_to_arr
 
 
   let max ?(axis = -1) ?(keep_dims = true) x =
     ignore keep_dims;
-    make_then_connect (Max axis) [| arr_to_node x |] |> node_to_arr
+    make_then_connect (Max (keep_dims, axis)) [| arr_to_node x |] |> node_to_arr
 
 
   let sum ?(axis = -1) ?(keep_dims = true) x =
     ignore keep_dims;
-    make_then_connect (Sum axis) [| arr_to_node x |] |> node_to_arr
+    make_then_connect (Sum (keep_dims, axis)) [| arr_to_node x |] |> node_to_arr
 
 
   let sum_reduce ?(axis = [| -1 |]) x =
@@ -291,8 +290,7 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
   let log_sum_exp' x = make_then_connect LogSumExp' [| arr_to_node x |] |> node_to_elt
 
   let log_sum_exp ?(axis = 0) ?(keep_dims = true) x =
-    ignore keep_dims;
-    make_then_connect (LogSumExp axis) [| arr_to_node x |] |> node_to_arr
+    make_then_connect (LogSumExp (keep_dims, axis)) [| arr_to_node x |] |> node_to_arr
 
 
   let l1norm' x = make_then_connect L1norm' [| arr_to_node x |] |> node_to_elt

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -255,11 +255,20 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
 
   let atanh x = make_then_connect Atanh [| arr_to_node x |] |> node_to_arr
 
-  let min ?(axis = -1) x = make_then_connect (Min axis) [| arr_to_node x |] |> node_to_arr
+  let min ?(axis = -1) ?(keep_dims = false) x =
+    ignore keep_dims;
+    make_then_connect (Min axis) [| arr_to_node x |] |> node_to_arr
 
-  let max ?(axis = -1) x = make_then_connect (Max axis) [| arr_to_node x |] |> node_to_arr
 
-  let sum ?(axis = -1) x = make_then_connect (Sum axis) [| arr_to_node x |] |> node_to_arr
+  let max ?(axis = -1) ?(keep_dims = false) x =
+    ignore keep_dims;
+    make_then_connect (Max axis) [| arr_to_node x |] |> node_to_arr
+
+
+  let sum ?(axis = -1) ?(keep_dims = false) x =
+    ignore keep_dims;
+    make_then_connect (Sum axis) [| arr_to_node x |] |> node_to_arr
+
 
   let sum_reduce ?(axis = [| -1 |]) x =
     make_then_connect (SumReduce axis) [| arr_to_node x |] |> node_to_arr
@@ -281,7 +290,8 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
 
   let log_sum_exp' x = make_then_connect LogSumExp' [| arr_to_node x |] |> node_to_elt
 
-  let log_sum_exp ?(axis = 0) x =
+  let log_sum_exp ?(axis = 0) ?(keep_dims = false) x =
+    ignore keep_dims;
     make_then_connect (LogSumExp axis) [| arr_to_node x |] |> node_to_arr
 
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -220,13 +220,13 @@ module type Sig = sig
   val atanh : arr -> arr
   (** TODO *)
 
-  val min : ?axis:int -> arr -> arr
+  val min : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
-  val max : ?axis:int -> arr -> arr
+  val max : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
-  val sum : ?axis:int -> arr -> arr
+  val sum : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
   val sum_reduce : ?axis:int array -> arr -> arr
@@ -256,7 +256,7 @@ module type Sig = sig
   val log_sum_exp' : arr -> elt
   (** TODO *)
 
-  val log_sum_exp : ?axis:int -> arr -> arr
+  val log_sum_exp : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
   val l1norm' : arr -> elt

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -74,9 +74,9 @@ module Make (Operator : Owl_computation_operator_sig.Sig) = struct
       | Asinh -> pattern_000 x
       | Acosh -> pattern_000 x
       | Atanh -> pattern_000 x
-      | Min (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
-      | Max (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
-      | Sum (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
+      | Min (_keep_dims, _axis) -> pattern_000 x
+      | Max (_keep_dims, _axis) -> pattern_000 x
+      | Sum (_keep_dims, _axis) -> pattern_000 x
       | SumReduce _axis -> pattern_024 x
       | Signum -> pattern_000 x
       | Sigmoid -> pattern_000 x

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -74,9 +74,9 @@ module Make (Operator : Owl_computation_operator_sig.Sig) = struct
       | Asinh -> pattern_000 x
       | Acosh -> pattern_000 x
       | Atanh -> pattern_000 x
-      | Min (_keep_dims, _axis) -> pattern_000 x
-      | Max (_keep_dims, _axis) -> pattern_000 x
-      | Sum (_keep_dims, _axis) -> pattern_000 x
+      | Min (_keep_dims, _axis) -> pattern_000 x 
+      | Max (_keep_dims, _axis) -> pattern_000 x 
+      | Sum (_keep_dims, _axis) -> pattern_000 x 
       | SumReduce _axis -> pattern_024 x
       | Signum -> pattern_000 x
       | Sigmoid -> pattern_000 x

--- a/src/base/compute/owl_computation_optimiser.ml
+++ b/src/base/compute/owl_computation_optimiser.ml
@@ -74,9 +74,9 @@ module Make (Operator : Owl_computation_operator_sig.Sig) = struct
       | Asinh -> pattern_000 x
       | Acosh -> pattern_000 x
       | Atanh -> pattern_000 x
-      | Min _axis -> pattern_000 x
-      | Max _axis -> pattern_000 x
-      | Sum _axis -> pattern_000 x
+      | Min (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
+      | Max (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
+      | Sum (keep_dims, _axis) -> if keep_dims then pattern_000 x else pattern_024 x
       | SumReduce _axis -> pattern_024 x
       | Signum -> pattern_000 x
       | Sigmoid -> pattern_000 x
@@ -612,7 +612,7 @@ module Make (Operator : Owl_computation_operator_sig.Sig) = struct
     | SumReduce axis ->
       if Array.length axis = 1
       then (
-        set_operator x (Sum axis.(0));
+        set_operator x (Sum (false, axis.(0)));
         _optimise_term x)
     | _              -> ()
 

--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -254,6 +254,12 @@ module Make (Type : Owl_computation_type_sig.Sig) = struct
     | _          -> [| None |]
 
 
+  let _infer_shape_31 keep_dims input_shapes axis =
+    if keep_dims
+    then _infer_shape_04 input_shapes axis
+    else _infer_shape_10 input_shapes [| axis |]
+
+
   let infer_shape operator args =
     let input_shapes = Array.map (fun a -> (Owl_graph.attr a).shape) args in
     match operator with
@@ -301,9 +307,9 @@ module Make (Type : Owl_computation_type_sig.Sig) = struct
     | Asinh -> _infer_shape_01 input_shapes
     | Acosh -> _infer_shape_01 input_shapes
     | Atanh -> _infer_shape_01 input_shapes
-    | Min axis -> _infer_shape_04 input_shapes axis
-    | Max axis -> _infer_shape_04 input_shapes axis
-    | Sum axis -> _infer_shape_04 input_shapes axis
+    | Min (keep_dims, axis) -> _infer_shape_31 keep_dims input_shapes axis
+    | Max (keep_dims, axis) -> _infer_shape_31 keep_dims input_shapes axis
+    | Sum (keep_dims, axis) -> _infer_shape_31 keep_dims input_shapes axis
     | SumReduce axis -> _infer_shape_10 input_shapes axis
     | Signum -> _infer_shape_01 input_shapes
     | Sigmoid -> _infer_shape_01 input_shapes
@@ -313,7 +319,7 @@ module Make (Type : Owl_computation_type_sig.Sig) = struct
     | Max' -> _infer_shape_00 input_shapes
     | Sum' -> _infer_shape_00 input_shapes
     | LogSumExp' -> _infer_shape_00 input_shapes
-    | LogSumExp axis -> _infer_shape_04 input_shapes axis
+    | LogSumExp (keep_dims, axis) -> _infer_shape_31 keep_dims input_shapes axis
     | L1norm' -> _infer_shape_00 input_shapes
     | L2norm' -> _infer_shape_00 input_shapes
     | L2NormSqr' -> _infer_shape_00 input_shapes

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -73,9 +73,9 @@ module Make (Shape : Owl_computation_shape_sig.Sig) = struct
     | Asinh -> "Asinh"
     | Acosh -> "Acosh"
     | Atanh -> "Atanh"
-    | Min axis -> Printf.sprintf "Min axis:%i" axis
-    | Max axis -> Printf.sprintf "Max axis:%i" axis
-    | Sum axis -> Printf.sprintf "Sum axis:%i" axis
+    | Min (keep_dims, axis) -> Printf.sprintf "Min keep_dims: %b, axis:%i" keep_dims axis
+    | Max (keep_dims, axis) -> Printf.sprintf "Max keep_dims: %b, axis:%i" keep_dims axis
+    | Sum (keep_dims, axis) -> Printf.sprintf "Sum keep_dims: %b, axis:%i" keep_dims axis
     | SumReduce _axis -> "SumReduce"
     | Signum -> "Signum"
     | Sigmoid -> "Sigmoid"
@@ -85,7 +85,7 @@ module Make (Shape : Owl_computation_shape_sig.Sig) = struct
     | Max' -> "Max'"
     | Sum' -> "Sum'"
     | LogSumExp' -> "LogSumExp'"
-    | LogSumExp axis -> Printf.sprintf "LogSumExp axis:%i" axis
+    | LogSumExp (keep_dims, axis) -> Printf.sprintf "LogSumExp keep_dims: %b, axis:%i" keep_dims axis
     | L1norm' -> "L1norm'"
     | L2norm' -> "L2norm'"
     | L2NormSqr' -> "L2NormSqr'"

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -85,7 +85,8 @@ module Make (Shape : Owl_computation_shape_sig.Sig) = struct
     | Max' -> "Max'"
     | Sum' -> "Sum'"
     | LogSumExp' -> "LogSumExp'"
-    | LogSumExp (keep_dims, axis) -> Printf.sprintf "LogSumExp keep_dims: %b, axis:%i" keep_dims axis
+    | LogSumExp (keep_dims, axis) ->
+      Printf.sprintf "LogSumExp keep_dims: %b, axis:%i" keep_dims axis
     | L1norm' -> "L1norm'"
     | L2norm' -> "L2norm'"
     | L2NormSqr' -> "L2NormSqr'"

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -116,9 +116,9 @@ module Make (Device : Owl_types_computation_device.Sig) = struct
     | Asinh
     | Acosh
     | Atanh
-    | Min                           of int
-    | Max                           of int
-    | Sum                           of int
+    | Min                           of bool * int
+    | Max                           of bool * int
+    | Sum                           of bool * int
     | SumReduce                     of int array
     | Signum
     | Sigmoid
@@ -128,7 +128,7 @@ module Make (Device : Owl_types_computation_device.Sig) = struct
     | Max'
     | Sum'
     | LogSumExp'
-    | LogSumExp                     of int
+    | LogSumExp                     of bool * int
     | L1norm'
     | L2norm'
     | L2NormSqr'

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -118,9 +118,9 @@ module type Sig = sig
     | Asinh
     | Acosh
     | Atanh
-    | Min                           of int
-    | Max                           of int
-    | Sum                           of int
+    | Min                           of bool * int
+    | Max                           of bool * int
+    | Sum                           of bool * int
     | SumReduce                     of int array
     | Signum
     | Sigmoid
@@ -130,7 +130,7 @@ module type Sig = sig
     | Max'
     | Sum'
     | LogSumExp'
-    | LogSumExp                     of int
+    | LogSumExp                     of bool * int
     | L1norm'
     | L2norm'
     | L2NormSqr'

--- a/src/base/core/owl_lazy.mli
+++ b/src/base/core/owl_lazy.mli
@@ -277,13 +277,13 @@ module Make (A : Ndarray_Mutable) : sig
   val atanh : arr -> arr
   (** TODO *)
 
-  val min : ?axis:int -> arr -> arr
+  val min : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
-  val max : ?axis:int -> arr -> arr
+  val max : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
-  val sum : ?axis:int -> arr -> arr
+  val sum : ?axis:int -> ?keep_dims:bool -> arr -> arr
   (** TODO *)
 
   val sum_reduce : ?axis:int array -> arr -> arr

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -1528,7 +1528,7 @@ let sum' x =
 let log_sum_exp' _ = raise (Owl_exception.NOT_IMPLEMENTED "base ndarray: log_sum_exp'")
 
 (* log sum of exp all elements *)
-let log_sum_exp ?axis:_ ?(keep_dims = false) _ =
+let log_sum_exp ?axis:_ ?(keep_dims = true) _ =
   ignore keep_dims;
   raise (Owl_exception.NOT_IMPLEMENTED "base ndarray: log_sum_exp")
 
@@ -1563,7 +1563,7 @@ let _fold_along ?out f m n o x ys nelem =
   reshape y ys
 
 
-let sum ?axis ?(keep_dims = false) x =
+let sum ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   let zero = Owl_const.zero _kind in
   match axis with
@@ -1615,7 +1615,7 @@ let sum_reduce ?axis x =
   | None   -> create (kind x) (Array.make _dims 1) (sum' x)
 
 
-let min ?axis ?(keep_dims = false) x =
+let min ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   let max_val = Owl_base_dense_common._max_val_elt _kind in
   match axis with
@@ -1640,7 +1640,7 @@ let min_ ~out ~axis x =
     set y [| 0 |] (min' x)
 
 
-let max ?axis ?(keep_dims = false) x =
+let max ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   let min_val = Owl_base_dense_common._min_val_elt _kind in
   match axis with

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -1528,7 +1528,8 @@ let sum' x =
 let log_sum_exp' _ = raise (Owl_exception.NOT_IMPLEMENTED "base ndarray: log_sum_exp'")
 
 (* log sum of exp all elements *)
-let log_sum_exp ?axis:_ _ =
+let log_sum_exp ?axis:_ ?(keep_dims = false) _ =
+  ignore keep_dims;
   raise (Owl_exception.NOT_IMPLEMENTED "base ndarray: log_sum_exp")
 
 
@@ -1562,14 +1563,15 @@ let _fold_along ?out f m n o x ys nelem =
   reshape y ys
 
 
-let sum ?axis x =
+let sum ?axis ?(keep_dims = false) x =
   let _kind = kind x in
   let zero = Owl_const.zero _kind in
   match axis with
   | Some a ->
     let m, n, o, s = Owl_utils.reduce_params a x in
     let _op = Owl_base_dense_common._add_elt _kind in
-    _fold_along _op m n o x s zero
+    let x = _fold_along _op m n o x s zero in
+    if keep_dims then x else squeeze ~axis:[| a |] x
   | None   -> create (kind x) (Array.make 1 1) (sum' x)
 
 
@@ -1613,13 +1615,14 @@ let sum_reduce ?axis x =
   | None   -> create (kind x) (Array.make _dims 1) (sum' x)
 
 
-let min ?axis x =
+let min ?axis ?(keep_dims = false) x =
   let _kind = kind x in
   let max_val = Owl_base_dense_common._max_val_elt _kind in
   match axis with
   | Some a ->
     let m, n, o, s = Owl_utils.reduce_params a x in
-    _fold_along (Owl_base_dense_common._min_elt _kind) m n o x s max_val
+    let x = _fold_along (Owl_base_dense_common._min_elt _kind) m n o x s max_val in
+    if keep_dims then x else squeeze ~axis:[| a |] x
   | None   -> min' x |> create _kind [| 1 |]
 
 
@@ -1637,13 +1640,14 @@ let min_ ~out ~axis x =
     set y [| 0 |] (min' x)
 
 
-let max ?axis x =
+let max ?axis ?(keep_dims = false) x =
   let _kind = kind x in
   let min_val = Owl_base_dense_common._min_val_elt _kind in
   match axis with
   | Some a ->
     let m, n, o, s = Owl_utils.reduce_params a x in
-    _fold_along (Owl_base_dense_common._max_elt _kind) m n o x s min_val
+    let x = _fold_along (Owl_base_dense_common._max_elt _kind) m n o x s min_val in
+    if keep_dims then x else squeeze ~axis:[| a |] x
   | None   -> max' x |> create _kind [| 1 |]
 
 

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -329,13 +329,13 @@ val load : ('a, 'b) kind -> string -> ('a, 'b) t
 
 (** {6 Unary math operators }  *)
 
-val min : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val min : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-val max : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val max : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-val sum : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val sum : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
 val sum' : ('a, 'b) t -> 'a
@@ -344,7 +344,7 @@ val sum' : ('a, 'b) t -> 'a
 val log_sum_exp' : ('a, 'b) t -> 'a
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
-val log_sum_exp : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val log_sum_exp : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
 val sum_reduce : ?axis:int array -> ('a, 'b) t -> ('a, 'b) t

--- a/src/base/dense/owl_base_dense_ndarray_intf.ml
+++ b/src/base/dense/owl_base_dense_ndarray_intf.ml
@@ -142,11 +142,11 @@ module type Common = sig
 
   val atanh : arr -> arr
 
-  val min : ?axis:int -> arr -> arr
+  val min : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val max : ?axis:int -> arr -> arr
+  val max : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val sum : ?axis:int -> arr -> arr
+  val sum : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val sum_reduce : ?axis:int array -> arr -> arr
 
@@ -320,7 +320,7 @@ module type Real = sig
 
   val log_sum_exp' : arr -> elt
 
-  val log_sum_exp : ?axis:int -> arr -> arr
+  val log_sum_exp : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val sum_slices : ?axis:int -> arr -> arr
 

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -140,11 +140,11 @@ module type Sig = sig
 
   val atanh : arr -> arr
 
-  val min : ?axis:int -> arr -> arr
+  val min : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val max : ?axis:int -> arr -> arr
+  val max : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val sum : ?axis:int -> arr -> arr
+  val sum : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val sum_reduce : ?axis:int array -> arr -> arr
 
@@ -164,7 +164,7 @@ module type Sig = sig
 
   val log_sum_exp' : arr -> elt
 
-  val log_sum_exp : ?axis:int -> arr -> arr
+  val log_sum_exp : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val l1norm' : arr -> elt
 

--- a/src/base/types/owl_types_ndarray_mutable.ml
+++ b/src/base/types/owl_types_ndarray_mutable.ml
@@ -200,23 +200,23 @@ module type Sig = sig
 
   val max_ : out:arr -> axis:int -> arr -> unit
 
-  val sum : ?axis:int -> arr -> arr
+  val sum : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val prod : ?axis:int -> arr -> arr
+  val prod : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val min : ?axis:int -> arr -> arr
+  val min : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val max : ?axis:int -> arr -> arr
+  val max : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val mean : ?axis:int -> arr -> arr
+  val mean : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val var : ?axis:int -> arr -> arr
+  val var : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val std : ?axis:int -> arr -> arr
+  val std : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val l1norm : ?axis:int -> arr -> arr
+  val l1norm : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val l2norm : ?axis:int -> arr -> arr
+  val l2norm : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val cumsum_ : ?out:arr -> ?axis:int -> arr -> unit
 

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -467,13 +467,13 @@ let map2i_2d f x y =
   z
 
 
-let sum_cols x = sum ~axis:1 x
+let sum_cols ?(keep_dims = false) x = sum ~axis:1 ~keep_dims x
 
-let sum_rows x = sum ~axis:0 x
+let sum_rows ?(keep_dims = false) x = sum ~axis:0 ~keep_dims x
 
-let mean_cols x = mean ~axis:1 x
+let mean_cols ?(keep_dims = false) x = mean ~axis:1 ~keep_dims x
 
-let mean_rows x = mean ~axis:0 x
+let mean_rows ?(keep_dims = false) x = mean ~axis:0 ~keep_dims x
 
 let min_cols x =
   mapi_cols

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -467,13 +467,13 @@ let map2i_2d f x y =
   z
 
 
-let sum_cols ?(keep_dims = false) x = sum ~axis:1 ~keep_dims x
+let sum_cols ?(keep_dims = true) x = sum ~axis:1 ~keep_dims x
 
-let sum_rows ?(keep_dims = false) x = sum ~axis:0 ~keep_dims x
+let sum_rows ?(keep_dims = true) x = sum ~axis:0 ~keep_dims x
 
-let mean_cols ?(keep_dims = false) x = mean ~axis:1 ~keep_dims x
+let mean_cols ?(keep_dims = true) x = mean ~axis:1 ~keep_dims x
 
-let mean_rows ?(keep_dims = false) x = mean ~axis:0 ~keep_dims x
+let mean_rows ?(keep_dims = true) x = mean ~axis:0 ~keep_dims x
 
 let min_cols x =
   mapi_cols

--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -1302,7 +1302,7 @@ val im_z2d : (Complex.t, complex64_elt) t -> (float, float64_elt) t
 ``im_d2z x`` returns all the imaginary components of ``x`` in a new ndarray of same shape.
  *)
 
-val min : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val min : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``min x`` returns the minimum of all elements in ``x`` along specified ``axis``.
 If no axis is specified, ``x`` will be flattened and the minimum of all the
@@ -1317,7 +1317,7 @@ val min' : ('a, 'b) t -> 'a
 in scalar value.
  *)
 
-val max : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val max : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``max x`` returns the maximum of all elements in ``x`` along specified ``axis``.
 If no axis is specified, ``x`` will be flattened and the maximum of all the
@@ -1332,7 +1332,7 @@ val max' : ('a, 'b) t -> 'a
 in scalar value.
  *)
 
-val minmax : ?axis:int -> ('a, 'b) t -> ('a, 'b) t * ('a, 'b) t
+val minmax : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t * ('a, 'b) t
 (**
 ``minmax' x`` returns ``(min_v, max_v)``, ``min_v`` is the minimum value in ``x``
 while ``max_v`` is the maximum.
@@ -1366,7 +1366,7 @@ val trace : ('a, 'b) t -> 'a
 ``trace x`` returns the sum of diagonal elements in ``x``.
  *)
 
-val sum : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val sum : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sum_ axis x`` sums the elements in ``x`` along specified ``axis``.
  *)
@@ -1376,7 +1376,7 @@ val sum' : ('a, 'b) t -> 'a
 ``sum x`` returns the summation of all the elements in ``x``.
  *)
 
-val prod : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val prod : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``prod_ axis x`` multiplies the elements in ``x`` along specified ``axis``.
  *)
@@ -1386,7 +1386,7 @@ val prod' : ('a, 'b) t -> 'a
 ``prod x`` returns the product of all the elements in ``x``.
  *)
 
-val mean : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val mean : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``mean ~axis x`` calculates the mean along specified ``axis``.
  *)
@@ -1396,7 +1396,7 @@ val mean' : ('a, 'b) t -> 'a
 ``mean' x`` calculates the mean of all the elements in ``x``.
  *)
 
-val var : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val var : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``var ~axis x`` calculates the variance along specified ``axis``.
  *)
@@ -1406,7 +1406,7 @@ val var' : ('a, 'b) t -> 'a
 ``var' x`` calculates the variance of all the elements in ``x``.
  *)
 
-val std : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val std : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``std ~axis`` calculates the standard deviation along specified ``axis``.
  *)
@@ -1416,7 +1416,7 @@ val std' : ('a, 'b) t -> 'a
 ``std' x`` calculates the standard deviation of all the elements in ``x``.
  *)
 
-val sem : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val sem : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sem ~axis`` calculates the standard deviation along specified ``axis``.
  *)
@@ -1426,23 +1426,23 @@ val sem' : ('a, 'b) t -> 'a
 ``sem' x`` calculates the standard deviation of all the elements in ``x``.
  *)
 
-val sum_rows : ('a, 'b) t -> ('a, 'b) t
+val sum_rows : ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sum_rows x`` returns the summation of all the row vectors in ``x``.
  *)
 
-val sum_cols : ('a, 'b) t -> ('a, 'b) t
+val sum_cols : ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sum_cols`` returns the summation of all the column vectors in ``x``.
  *)
 
-val mean_rows : ('a, 'b) t -> ('a, 'b) t
+val mean_rows : ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``mean_rows x`` returns the mean value of all row vectors in ``x``. It is
  equivalent to ``div_scalar (sum_rows x) (float_of_int (row_num x))``.
  *)
 
-val mean_cols : ('a, 'b) t -> ('a, 'b) t
+val mean_cols : ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``mean_cols x`` returns the mean value of all column vectors in ``x``.
  It is equivalent to ``div_scalar (sum_cols x) (float_of_int (col_num x))``.
@@ -1770,13 +1770,13 @@ val log_sum_exp' : (float, 'a) t -> float
 the elements in ``x``.
  *)
 
-val log_sum_exp : ?axis:int -> (float, 'a) t -> (float, 'a) t
+val log_sum_exp : ?axis:int -> ?keep_dims:bool -> (float, 'a) t -> (float, 'a) t
 (**
 ``log_sum_exp ~axis x`` computes the logarithm of the sum of exponentials of all
 the elements in ``x`` along axis ``axis``.
  *)
 
-val l1norm : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l1norm : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l1norm x`` calculates the l1-norm of of ``x`` along specified axis.
  *)
@@ -1786,7 +1786,7 @@ val l1norm' : ('a, 'b) t -> 'a
 ``l1norm x`` calculates the l1-norm of all the element in ``x``.
  *)
 
-val l2norm : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l2norm : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l2norm x`` calculates the l2-norm of of ``x`` along specified axis.
  *)
@@ -1796,7 +1796,7 @@ val l2norm' : ('a, 'b) t -> 'a
 ``l2norm x`` calculates the l2-norm of all the element in ``x``.
  *)
 
-val l2norm_sqr : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l2norm_sqr : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l2norm x`` calculates the square l2-norm of of ``x`` along specified axis.
  *)
@@ -1808,7 +1808,7 @@ of all elements in ``x``. The function uses conjugate transpose in the product,
 hence it always returns a float number.
  *)
 
-val vecnorm : ?axis:int -> ?p:float -> ('a, 'b) t -> ('a, 'b) t
+val vecnorm : ?axis:int -> ?p:float -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (** Refer to :doc:`owl_dense_ndarray_generic`. *)
 
 val vecnorm' : ?p:float -> ('a, 'b) t -> 'a

--- a/src/owl/dense/owl_dense_matrix_intf.ml
+++ b/src/owl/dense/owl_dense_matrix_intf.ml
@@ -402,15 +402,15 @@ module type Common = sig
 
   (** {6 Unary mathematical operations } *)
 
-  val min : ?axis:int -> mat -> mat
+  val min : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val min' : mat -> elt
 
-  val max : ?axis:int -> mat -> mat
+  val max : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val max' : mat -> elt
 
-  val minmax : ?axis:int -> mat -> mat * mat
+  val minmax : ?axis:int -> ?keep_dims:bool -> mat -> mat * mat
 
   val minmax' : mat -> elt * elt
 
@@ -422,37 +422,37 @@ module type Common = sig
 
   val trace : mat -> elt
 
-  val sum : ?axis:int -> mat -> mat
+  val sum : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val sum' : mat -> elt
 
-  val prod : ?axis:int -> mat -> mat
+  val prod : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val prod' : mat -> elt
 
-  val mean : ?axis:int -> mat -> mat
+  val mean : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val mean' : mat -> elt
 
-  val var : ?axis:int -> mat -> mat [@@warning "-32"]
+  val var : ?axis:int -> ?keep_dims:bool -> mat -> mat [@@warning "-32"]
 
   val var' : mat -> elt
 
-  val std : ?axis:int -> mat -> mat [@@warning "-32"]
+  val std : ?axis:int -> ?keep_dims:bool -> mat -> mat [@@warning "-32"]
 
   val std' : mat -> elt
 
-  val sem : ?axis:int -> mat -> mat [@@warning "-32"]
+  val sem : ?axis:int -> ?keep_dims:bool -> mat -> mat [@@warning "-32"]
 
   val sem' : mat -> elt
 
-  val sum_rows : mat -> mat
+  val sum_rows : ?keep_dims:bool -> mat -> mat
 
-  val sum_cols : mat -> mat
+  val sum_cols : ?keep_dims:bool -> mat -> mat
 
-  val mean_rows : mat -> mat
+  val mean_rows : ?keep_dims:bool -> mat -> mat
 
-  val mean_cols : mat -> mat
+  val mean_cols : ?keep_dims:bool -> mat -> mat
 
   val abs : mat -> mat
 
@@ -524,19 +524,19 @@ module type Common = sig
 
   val modf : mat -> mat * mat
 
-  val l1norm : ?axis:int -> mat -> mat
+  val l1norm : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val l1norm' : mat -> elt
 
-  val l2norm : ?axis:int -> mat -> mat
+  val l2norm : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val l2norm' : mat -> elt
 
-  val l2norm_sqr : ?axis:int -> mat -> mat
+  val l2norm_sqr : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val l2norm_sqr' : mat -> elt
 
-  val vecnorm : ?axis:int -> ?p:float -> mat -> mat
+  val vecnorm : ?axis:int -> ?p:float -> ?keep_dims:bool -> mat -> mat
 
   val vecnorm' : ?p:float -> mat -> elt
 
@@ -550,9 +550,9 @@ module type Common = sig
 
   val diff : ?axis:int -> ?n:int -> mat -> mat
 
-  val var : ?axis:int -> mat -> mat
+  val var : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
-  val std : ?axis:int -> mat -> mat
+  val std : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val mat2gray : ?amin:elt -> ?amax:elt -> mat -> mat
 
@@ -880,7 +880,7 @@ module type Real = sig
 
   val log_sum_exp' : mat -> elt
 
-  val log_sum_exp : ?axis:int -> mat -> mat
+  val log_sum_exp : ?axis:int -> ?keep_dims:bool -> mat -> mat
 
   val max_pool : ?padding:padding -> mat -> int array -> int array -> mat
 

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -8571,7 +8571,7 @@ let scan ?axis f x = scani ?axis (fun _ a b -> f a b) x
 
 let scani_nd ?axis f x = scani ?axis (fun i a b -> f (Owl_utils.ind x i) a b) x
 
-let sum ?axis ?(keep_dims = false) x =
+let sum ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8590,7 +8590,7 @@ let sum_ ~out ~axis x =
   _owl_sum_along _kind m n o x out
 
 
-let prod ?axis ?(keep_dims = false) x =
+let prod ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8601,7 +8601,7 @@ let prod ?axis ?(keep_dims = false) x =
   | None   -> _owl_prod _kind (numel x) x |> create _kind [| 1 |]
 
 
-let min ?axis ?(keep_dims = false) x =
+let min ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8620,7 +8620,7 @@ let min_ ~out ~axis x =
   _owl_min_along _kind m n o x out
 
 
-let max ?axis ?(keep_dims = false) x =
+let max ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8639,7 +8639,7 @@ let max_ ~out ~axis x =
   _owl_max_along _kind m n o x out
 
 
-let minmax ?axis ?(keep_dims = false) x = min ?axis ~keep_dims x, max ?axis ~keep_dims x
+let minmax ?axis ?(keep_dims = true) x = min ?axis ~keep_dims x, max ?axis ~keep_dims x
 
 let mean' x =
   let _kind = kind x in
@@ -8648,7 +8648,7 @@ let mean' x =
   _mean_elt _kind y _numel
 
 
-let mean ?axis ?(keep_dims = false) x =
+let mean ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8674,7 +8674,7 @@ let median' x =
   else get _rsht [| 0; _numel / 2 |]
 
 
-let median ?axis ?(keep_dims = false) x =
+let median ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   let x1 = copy x in
   match axis with
@@ -8702,7 +8702,7 @@ let var' x =
   _div_elt _kind y n
 
 
-let var ?axis ?(keep_dims = false) x =
+let var ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8727,7 +8727,7 @@ let std' x =
   _div_elt _kind y n |> _sqrt_elt _kind
 
 
-let std ?axis ?(keep_dims = false) x =
+let std ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8750,7 +8750,7 @@ let sem' x =
   _div_elt _kind y sqrt_n
 
 
-let sem ?axis ?(keep_dims = false) x =
+let sem ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | None   -> sem' x |> create _kind [| 1 |]
@@ -8761,7 +8761,7 @@ let sem ?axis ?(keep_dims = false) x =
     if keep_dims then y else squeeze ~axis:[| a |] y
 
 
-let l1norm ?axis ?(keep_dims = false) x =
+let l1norm ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8772,7 +8772,7 @@ let l1norm ?axis ?(keep_dims = false) x =
   | None   -> l1norm' x |> create _kind [| 1 |]
 
 
-let l2norm_sqr ?axis ?(keep_dims = false) x =
+let l2norm_sqr ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8783,7 +8783,7 @@ let l2norm_sqr ?axis ?(keep_dims = false) x =
   | None   -> l2norm_sqr' x |> create _kind [| 1 |]
 
 
-let l2norm ?axis ?(keep_dims = false) x =
+let l2norm ?axis ?(keep_dims = true) x =
   let _kind = kind x in
   match axis with
   | Some a ->
@@ -8795,7 +8795,7 @@ let l2norm ?axis ?(keep_dims = false) x =
   | None   -> l2norm' x |> create _kind [| 1 |]
 
 
-let vecnorm ?axis ?(p = 2.) ?(keep_dims = false) x =
+let vecnorm ?axis ?(p = 2.) ?(keep_dims = true) x =
   if p = 1.
   then l1norm ?axis ~keep_dims x
   else if p = 2.
@@ -9980,7 +9980,7 @@ let diag ?(k = 0) x =
 
 let trace x = sum' (diag x)
 
-let log_sum_exp ?(axis = 0) ?(keep_dims = false) x =
+let log_sum_exp ?(axis = 0) ?(keep_dims = true) x =
   let xmax = max ~axis ~keep_dims x in
   let y = sub x xmax in
   if keep_dims

--- a/src/owl/dense/owl_dense_ndarray_generic.mli
+++ b/src/owl/dense/owl_dense_ndarray_generic.mli
@@ -1151,7 +1151,7 @@ val im_z2d : (Complex.t, complex64_elt) t -> (float, float64_elt) t
 same shape.
  *)
 
-val sum : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val sum : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sum ~axis x`` sums the elements in ``x`` along specified ``axis``.
  *)
@@ -1167,7 +1167,7 @@ val sum_reduce : ?axis:int array -> ('a, 'b) t -> ('a, 'b) t
 in the ``axis`` array.
  *)
 
-val prod : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val prod : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``prod ~axis x`` multiples the elements in ``x`` along specified ``axis``.
  *)
@@ -1177,7 +1177,7 @@ val prod' : ('a, 'b) t -> 'a
 ``prod x`` returns the product of all elements in ``x`` along passed in axises.
  *)
 
-val mean : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val mean : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``mean ~axis x`` calculates the mean along specified ``axis``.
  *)
@@ -1187,7 +1187,7 @@ val mean' : ('a, 'b) t -> 'a
 ``mean' x`` calculates the mean of all the elements in ``x``.
  *)
 
-val median : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val median : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``median ~axis x`` calculates the median along specified ``axis`` of ``x``.
 *)
@@ -1197,7 +1197,7 @@ val median' : ('a, 'b) t -> 'a
 ``median x`` calculates the median of a flattened version of ``x``.
 *)
 
-val var : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val var : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``var ~axis x`` calculates the variance along specified ``axis``.
  *)
@@ -1207,7 +1207,7 @@ val var' : ('a, 'b) t -> 'a
 ``var' x`` calculates the variance of all the elements in ``x``.
  *)
 
-val std : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val std : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``std ~axis`` calculates the standard deviation along specified ``axis``.
  *)
@@ -1217,7 +1217,7 @@ val std' : ('a, 'b) t -> 'a
 ``std' x`` calculates the standard deviation of all the elements in ``x``.
  *)
 
-val sem : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val sem : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``sem ~axis`` calculates the standard error of mean along specified ``axis``.
  *)
@@ -1227,7 +1227,7 @@ val sem' : ('a, 'b) t -> 'a
 ``sem' x`` calculates the standard error of mean of all the elements in ``x``.
  *)
 
-val min : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val min : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``min x`` returns the minimum of all elements in ``x`` along specified ``axis``.
 If no axis is specified, ``x`` will be flattened and the minimum of all the
@@ -1242,7 +1242,7 @@ val min' : ('a, 'b) t -> 'a
 ``x`` in scalar value.
  *)
 
-val max : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val max : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``max x`` returns the maximum of all elements in ``x`` along specified ``axis``.
 If no axis is specified, ``x`` will be flattened and the maximum of all the
@@ -1257,7 +1257,7 @@ val max' : ('a, 'b) t -> 'a
 ``x`` in scalar value.
  *)
 
-val minmax : ?axis:int -> ('a, 'b) t -> ('a, 'b) t * ('a, 'b) t
+val minmax : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t * ('a, 'b) t
 (**
 ``minmax' x`` returns ``(min_v, max_v)``, ``min_v`` is the minimum value in
 ``x`` while ``max_v`` is the maximum.
@@ -1594,13 +1594,13 @@ val log_sum_exp' : (float, 'a) t -> float
 the elements in ``x``.
  *)
 
-val log_sum_exp : ?axis:int -> (float, 'a) t -> (float, 'a) t
+val log_sum_exp : ?axis:int -> ?keep_dims:bool -> (float, 'a) t -> (float, 'a) t
 (**
 ``log_sum_exp ~axis x`` computes the logarithm of the sum of exponentials of all
 the elements in ``x`` along axis ``axis``.
  *)
 
-val l1norm : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l1norm : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l1norm x`` calculates the l1-norm of of ``x`` along specified axis.
  *)
@@ -1610,7 +1610,7 @@ val l1norm' : ('a, 'b) t -> 'a
 ``l1norm x`` calculates the l1-norm of all the element in ``x``.
  *)
 
-val l2norm : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l2norm : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l2norm x`` calculates the l2-norm of of ``x`` along specified axis.
  *)
@@ -1620,7 +1620,7 @@ val l2norm' : ('a, 'b) t -> 'a
 ``l2norm x`` calculates the l2-norm of all the element in ``x``.
  *)
 
-val l2norm_sqr : ?axis:int -> ('a, 'b) t -> ('a, 'b) t
+val l2norm_sqr : ?axis:int -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``l2norm_sqr x`` calculates the square l2-norm of of ``x`` along specified axis.
  *)
@@ -1632,7 +1632,7 @@ of all elements in ``x``. The function uses conjugate transpose in the product,
 hence it always returns a float number.
  *)
 
-val vecnorm : ?axis:int -> ?p:float -> ('a, 'b) t -> ('a, 'b) t
+val vecnorm : ?axis:int -> ?p:float -> ?keep_dims:bool -> ('a, 'b) t -> ('a, 'b) t
 (**
 ``vecnorm ~axis ~p x`` calculates the generalised vector p-norm along the
 specified ``axis``. The generalised p-norm is defined as below.

--- a/src/owl/dense/owl_dense_ndarray_intf.ml
+++ b/src/owl/dense/owl_dense_ndarray_intf.ml
@@ -161,31 +161,31 @@ module type Common = sig
 
   (** {6 Unary mathematical operations } *)
 
-  val prod : ?axis:int -> arr -> arr
+  val prod : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val prod' : arr -> elt
 
-  val mean : ?axis:int -> arr -> arr
+  val mean : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val mean' : arr -> elt
 
   val median' : arr -> elt
 
-  val median : ?axis:int -> arr -> arr
+  val median : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
-  val var : ?axis:int -> arr -> arr
+  val var : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val var' : arr -> elt
 
-  val std : ?axis:int -> arr -> arr
+  val std : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val std' : arr -> elt
 
-  val sem : ?axis:int -> arr -> arr
+  val sem : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val sem' : arr -> elt
 
-  val minmax : ?axis:int -> arr -> arr * arr
+  val minmax : ?axis:int -> ?keep_dims:bool -> arr -> arr * arr
 
   val minmax' : arr -> elt * elt
 
@@ -219,19 +219,19 @@ module type Common = sig
 
   val modf : arr -> arr * arr
 
-  val l1norm : ?axis:int -> arr -> arr
+  val l1norm : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val l1norm' : arr -> elt
 
-  val l2norm : ?axis:int -> arr -> arr
+  val l2norm : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val l2norm' : arr -> elt
 
-  val l2norm_sqr : ?axis:int -> arr -> arr
+  val l2norm_sqr : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val l2norm_sqr' : arr -> elt
 
-  val vecnorm : ?axis:int -> ?p:float -> arr -> arr
+  val vecnorm : ?axis:int -> ?p:float -> ?keep_dims:bool -> arr -> arr
 
   val vecnorm' : ?p:float -> arr -> elt
 
@@ -569,7 +569,7 @@ module type Real = sig
 
   val log_sum_exp' : arr -> float
 
-  val log_sum_exp : ?axis:int -> arr -> arr
+  val log_sum_exp : ?axis:int -> ?keep_dims:bool -> arr -> arr
 
   val scalar_atan2 : elt -> arr -> arr
 

--- a/src/owl/ext/owl_ext_dense_matrix.ml
+++ b/src/owl/ext/owl_ext_dense_matrix.ml
@@ -401,13 +401,13 @@ module type BasicSig = sig
 
   val mean' : mat -> elt
 
-  val sum_rows : mat -> mat
+  val sum_rows : ?keep_dims:bool -> mat -> mat
 
-  val sum_cols : mat -> mat
+  val sum_cols : ?keep_dims:bool -> mat -> mat
 
-  val mean_rows : mat -> mat
+  val mean_rows : ?keep_dims:bool -> mat -> mat
 
-  val mean_cols : mat -> mat
+  val mean_cols : ?keep_dims:bool -> mat -> mat
 
   val add : mat -> mat -> mat
 

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -1,5 +1,4 @@
 (** Unit test for Algodiff module *)
-let () = Printexc.record_backtrace true
 
 open Owl_types
 

--- a/test/unit_dense_matrix.ml
+++ b/test/unit_dense_matrix.ml
@@ -207,12 +207,12 @@ module To_test = struct
 
 
   let sum_rows () =
-    let x = M.sum_rows x2 |> M.to_arrays in
+    let x = M.sum_rows ~keep_dims:true x2 |> M.to_arrays in
     x = [| [| 12.; 15.; 18.; 21. |] |]
 
 
   let sum_cols () =
-    let x = M.sum_cols x2 |> M.to_arrays in
+    let x = M.sum_cols ~keep_dims:true x2 |> M.to_arrays in
     x = [| [| 6. |]; [| 22. |]; [| 38. |] |]
 
 

--- a/test/unit_dense_ndarray.ml
+++ b/test/unit_dense_ndarray.ml
@@ -114,9 +114,9 @@ module To_test = struct
 
   (* [|[|2.;-1.;3.5|];[|0.4;0.6;0.2|]|] *)
   let median () =
-    let x1 = M.median ~axis:0 x5 in
+    let x1 = M.median ~axis:0 ~keep_dims:true x5 in
     let y1 = M.of_arrays Float64 [| [| 1.2; -0.2; 1.85 |] |] in
-    let x2 = M.median ~axis:1 x5 in
+    let x2 = M.median ~axis:1 ~keep_dims:true x5 in
     let y2 = M.of_arrays Float64 [| [| 2. |]; [| 0.4 |] |] in
     M.equal x1 y1 && M.equal x2 y2
 


### PR DESCRIPTION
As discussed in #529, I've added the `keep_dims` option for `sum`, `mean`, `var`, `std`, `sem`, `min`, `max`, `log_sum_exp`, `prod` and others.

The default option for `keep_dims` is `true` and is thus backward compatible.

@jzstark @ryanrhymes I'm not quite sure how `keep_dims` changes the computation graph in e.g., `owl_base_computation_operation.ml`. I've ignored the `keep_dims` option for now. Any ideas?