### PR TITLE
Upgrade to ocamlformat 0.15.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.14.2
+version=0.15.0
 profile=janestreet
 wrap-comments=false
 doc-comments=after-when-possible

--- a/src/base/core/owl_operator.ml
+++ b/src/base/core/owl_operator.ml
@@ -49,8 +49,7 @@ module Make_Basic (M : BasicSig) = struct
   let ( >= ) = M.greater_equal
 
   let ( <= ) = M.less_equal
-end
-[@warning "-34"]
+end [@warning "-34"]
 
 module Make_Extend (M : ExtendSig) = struct
   type ('a, 'b) op_t1 = ('a, 'b) M.t
@@ -142,8 +141,7 @@ module Make_Extend (M : ExtendSig) = struct
   let ( .${;..} ) x s = M.get_slice_ext s x
 
   let ( .${;..}<- ) x s = M.set_slice_ext s x
-end
-[@warning "-34"]
+end [@warning "-34"]
 
 module Make_Matrix (M : MatrixSig) = struct
   type ('a, 'b) op_t2 = ('a, 'b) M.t
@@ -153,8 +151,7 @@ module Make_Matrix (M : MatrixSig) = struct
   let ( .%{;..}<- ) x i = M.set x i.(0) i.(1)
 
   let ( *@ ) a b = M.dot a b
-end
-[@warning "-34"]
+end [@warning "-34"]
 
 module Make_Ndarray (M : NdarraySig) = struct
   type ('a, 'b) op_t3 = ('a, 'b) M.t
@@ -162,8 +159,7 @@ module Make_Ndarray (M : NdarraySig) = struct
   let ( .%{;..} ) x i = M.get x i
 
   let ( .%{;..}<- ) x i = M.set x i
-end
-[@warning "-34"]
+end [@warning "-34"]
 
 module Make_Linalg (M : LinalgSig) = struct
   type ('a, 'b) op_t4 = ('a, 'b) M.t
@@ -171,7 +167,6 @@ module Make_Linalg (M : LinalgSig) = struct
   let ( **@ ) x a = M.mpow x a
 
   let ( /@ ) a b = M.linsolve a b
-end
-[@warning "-34"]
+end [@warning "-34"]
 
 (* ends here *)


### PR DESCRIPTION
Hi, this is what the project would look like after being reformatted with the current version (candidate) of ocamlformat 0.15.0.
**Please do not merge until ocamlformat.0.15.0 is available with opam.**

The main changes you see are due to moving the attributes moving to be placed next to the `end` keyword of classes and modules. This change has been made for the `janestreet` profile because JaneStreet is postprocessing its code with ocp-indent and having the attribute on its own line after `end` was weirdly indented by ocp-indent.