### PR TITLE
Windows compatibility

### DIFF
--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -1,0 +1,51 @@
+# Owl on Windows
+
+This document gives instructions on how to install Owl on Windows, natively. For use within `WSL2`, please refer to the ordinary instruction and use the standard `opam` installation procedure.
+
+## OCaml
+
+The recommended way to build native apps from OCaml is the [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw/) setup, which uses a `Cygwin` environment, but compiles to native Windows (without relying on `Cygwin.dll`). OCaml for Windows (_OfW_) features an opam repository and sets up the needed toolchains, e.g., `gcc`, `make`, `pc-config`, so that most opam packages build out-of-the-box, even the ones relying on C-code.
+
+Please make sure the path is correctly setup, as described on the OfW website: [depext cygwin](https://fdopen.github.io/opam-repository-mingw/depext-cygwin/). Otherwise, theh cross-compiling tools might not find the correct binaries.
+
+## Pre-Requisites
+
+### OpenBLAS
+
+OpenBLAS supports cross-compiling, like it is used in _OfW_, when building from source. One might need to install the FORTRAN crosscompiler `x86_64-w64-mingw32-gfortran` via Cygwins package manager beforehand. Also, the generated binaries have to be installed at the cross compilers `sys-root` location instead under `/usr/local`. Note that during cross-compiling the target CPU has to be given explicitely (`HASWELL` needs to be replaced with your own model, please consult OpenBLAS documentation for available CPUs).
+
+```
+git clone https://github.com/xianyi/OpenBLAS.git
+cd OpenBLAS
+make CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran TARGET=HASWELL
+make CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran TARGET=HASWELL PREFIX=/usr/x86_64-w64-mingw32/sys-root/mingw install
+```
+
+### PlPLot
+
+__TODO__
+
+## Owl
+
+Now we can install Owl via the usual `opam` tool.
+
+### conf-openblas
+
+`conf-openblas.0.2.1` currently needs a manual installation of the `OpenBLAS` library as described above.
+
+### eigen
+
+`eigen.0.3.0` should work on _OfW_ out of the box.
+
+### Installation
+
+If all prerequisites are setup, installation of `owl` and `owl-top` can be done via `opam`:
+
+```
+opam install owl owl-top
+```
+
+## Status
+
+Porting to Windows is still work-in-progress. At the moment `owl`, `owl-top`, and `owl-zoo` can be installed and basic functionality works. Netherless, compiling `owl` still generates quite a lot fo warnings and at least one test fails (crashes).
+

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -47,5 +47,13 @@ opam install owl owl-top
 
 ## Status
 
-Porting to Windows is still work-in-progress. At the moment `owl`, `owl-top`, and `owl-zoo` can be installed and basic functionality works. Netherless, compiling `owl` still generates quite a lot fo warnings and at least one test fails (crashes).
+Porting to Windows is still work-in-progress. At the moment `owl`, `owl-top`, and `owl-zoo` can be installed and basic functionality works. Netherless, compiling `owl` still generates quite a lot of warnings and test failures:
+
+Crashed tests:
+* `math`: test `mulmod`
+* `math`: test `pow_mod`
+
+Failed tests:
+* `dense matrix`: test `save_load` (-> maybe a Windows filesystem issue?)
+
 

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -54,6 +54,6 @@ Crashed tests:
 * `math`: test `pow_mod`
 
 Failed tests:
-* `dense matrix`: test `save_load` (-> maybe a Windows filesystem issue?)
+_none_
 
 

--- a/INSTALL_WINDOWS.md
+++ b/INSTALL_WINDOWS.md
@@ -6,7 +6,7 @@ This document gives instructions on how to install Owl on Windows, natively. For
 
 The recommended way to build native apps from OCaml is the [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw/) setup, which uses a `Cygwin` environment, but compiles to native Windows (without relying on `Cygwin.dll`). OCaml for Windows (_OfW_) features an opam repository and sets up the needed toolchains, e.g., `gcc`, `make`, `pc-config`, so that most opam packages build out-of-the-box, even the ones relying on C-code.
 
-Please make sure the path is correctly setup, as described on the OfW website: [depext cygwin](https://fdopen.github.io/opam-repository-mingw/depext-cygwin/). Otherwise, theh cross-compiling tools might not find the correct binaries.
+Please make sure the path is correctly setup, as described on the OfW website: [depext cygwin](https://fdopen.github.io/opam-repository-mingw/depext-cygwin/). Otherwise, the cross-compiling tools might not find the correct binaries.
 
 ## Pre-Requisites
 
@@ -21,7 +21,7 @@ make CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran TARGET=HASWELL
 make CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran TARGET=HASWELL PREFIX=/usr/x86_64-w64-mingw32/sys-root/mingw install
 ```
 
-### PlPLot
+### PLplot
 
 __TODO__
 

--- a/owl.opam
+++ b/owl.opam
@@ -26,11 +26,11 @@ depends: [
   "alcotest" {with-test}
   "base" {build}
   "base-bigarray"
-  "conf-openblas" {>= "0.2.0"}
+  "conf-openblas" {>= "0.2.1"}
   "ctypes" {>= "0.16.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"
-  "eigen" {>= "0.1.0"}
+  "eigen" {>= "0.3.0"}
   "owl-base" {= version}
   "stdio" {build}
   "npy"

--- a/src/base/misc/owl_io.ml
+++ b/src/base/misc/owl_io.ml
@@ -82,7 +82,7 @@ let mapi_lines_of_file f fname =
 (* similar to iteri_lines_of_file but for marshaled file *)
 let iteri_lines_of_marshal ?(verbose = true) f fname =
   let i = ref 0 in
-  let h = open_in fname in
+  let h = open_in_bin fname in
   Fun.protect
     (fun () ->
       let t1 = ref (Unix.gettimeofday ()) in
@@ -116,13 +116,13 @@ let mapi_lines_of_marshal f fname =
 
 (* save a marshalled object to a file *)
 let marshal_to_file ?(flags = []) x f =
-  let h = open_out f in
+  let h = open_out_bin f in
   Fun.protect (fun () -> Marshal.to_channel h x flags) ~finally:(fun () -> close_out h)
 
 
 (* load a marshalled object from a file *)
 let marshal_from_file f =
-  let h = open_in f in
+  let h = open_in_bin f in
   Fun.protect
     (fun () ->
       let s = really_input_string h (in_channel_length h) in

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -344,7 +344,7 @@ CAMLprim value FUN_NATIVE (spatial) (
 
 #ifdef AVX_PSIZE && _WIN32
   int fast_flag = (in_channel % AVX_PSIZE == 0);
-  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
 #elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);
@@ -557,7 +557,7 @@ CAMLprim value FUN_NATIVE (spatial_backward_input) (
 
 #ifdef AVX_PSIZE && _WIN32
   int fast_flag = (in_channel % AVX_PSIZE == 0);
-  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
 #elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);
@@ -778,7 +778,7 @@ CAMLprim value FUN_NATIVE (spatial_backward_kernel) (
 
 #ifdef AVX_PSIZE && _WIN32
   int fast_flag = (in_channel % AVX_PSIZE == 0);
-  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
 #elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -342,7 +342,11 @@ CAMLprim value FUN_NATIVE (spatial) (
   int nc = out_channel;
   compute_block_sizes(&kc, &nc, &mc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE
+#ifdef AVX_PSIZE && _WIN32
+  int fast_flag = (in_channel % AVX_PSIZE == 0);
+  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  if (temp_mk == NULL) exit(1);
+#elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))
@@ -551,7 +555,11 @@ CAMLprim value FUN_NATIVE (spatial_backward_input) (
   int nc = out_channel;
   compute_block_sizes(&mc, &kc, &nc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE
+#ifdef AVX_PSIZE && _WIN32
+  int fast_flag = (in_channel % AVX_PSIZE == 0);
+  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  if (temp_mk == NULL) exit(1);
+#elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))
@@ -768,7 +776,11 @@ CAMLprim value FUN_NATIVE (spatial_backward_kernel) (
   int nc = out_channel;
   compute_block_sizes(&mc, &kc, &nc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE
+#ifdef AVX_PSIZE && _WIN32
+  int fast_flag = (in_channel % AVX_PSIZE == 0);
+  TYPE *temp_mk = aligned_alloc(ALIGN_SIZE, mc * kc * sizeof(TYPE));
+  if (temp_mk == NULL) exit(1);
+#elif AVX_PSIZE
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))

--- a/src/owl/core/owl_ndarray_conv_impl.h
+++ b/src/owl/core/owl_ndarray_conv_impl.h
@@ -342,11 +342,11 @@ CAMLprim value FUN_NATIVE (spatial) (
   int nc = out_channel;
   compute_block_sizes(&kc, &nc, &mc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE && _WIN32
+#if defined(AVX_PSIZE) && defined(_WIN32)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
-#elif AVX_PSIZE
+#elif defined(AVX_PSIZE)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))
@@ -555,11 +555,11 @@ CAMLprim value FUN_NATIVE (spatial_backward_input) (
   int nc = out_channel;
   compute_block_sizes(&mc, &kc, &nc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE && _WIN32
+#if defined(AVX_PSIZE) && defined(_WIN32)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
-#elif AVX_PSIZE
+#elif defined(AVX_PSIZE)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))
@@ -776,11 +776,11 @@ CAMLprim value FUN_NATIVE (spatial_backward_kernel) (
   int nc = out_channel;
   compute_block_sizes(&mc, &kc, &nc, sizeof(TYPE));
 
-#ifdef AVX_PSIZE && _WIN32
+#if defined(AVX_PSIZE) && defined(_WIN32)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = _aligned_malloc(mc * kc * sizeof(TYPE), ALIGN_SIZE);
   if (temp_mk == NULL) exit(1);
-#elif AVX_PSIZE
+#elif defined(AVX_PSIZE)
   int fast_flag = (in_channel % AVX_PSIZE == 0);
   TYPE *temp_mk = NULL;
   if (posix_memalign((void**) &temp_mk, ALIGN_SIZE, mc * kc * sizeof(TYPE)))


### PR DESCRIPTION
This is a first step towards Windows compatibility. Feel free to start merging or wait for the remaining issues to be fixed, depending on your release plans.
Currently, `Owl_maths.mulmod` and `Owl_maths.powmod` crash; other tests pass. I don't see any special reason for this, but compilation warnings give hints that there are symbol clashes "around" `math.h`. I will further investigate this.
You can find some docs and status in `INSTALL_WINDOWS.md`