### PR TITLE
fix portability issue of 'long int'

### DIFF
--- a/src/owl/core/owl_ndarray_contract.h
+++ b/src/owl/core/owl_ndarray_contract.h
@@ -10,22 +10,22 @@
 /* Define structure for contracting indices of a tensor. */
 
 struct contract_pair {
-  long dim;         // number of dimensions, x and y must be the same.
-  long dep;         // the depth of current recursion.
-  long drt;         // number of outer loops.
+  int64_t dim;         // number of dimensions, x and y must be the same.
+  int64_t dep;         // the depth of current recursion.
+  int64_t drt;         // number of outer loops.
   int64_t *n;       // number of iteration in each dimension, i.e. y's shape
   void *x;          // x, operand.
-  long posx;        // current offset of x.
-  long *ofsx;       // offset of x in each dimension.
-  long *incx;       // stride size of x in each dimension.
+  int64_t posx;        // current offset of x.
+  int64_t *ofsx;       // offset of x in each dimension.
+  int64_t *incx;       // stride size of x in each dimension.
   void *y;          // y, operand.
-  long posy;        // current offset of y.
-  long *ofsy;       // offset of y in each dimension.
-  long *incy;       // stride size of y in each dimension.
+  int64_t posy;        // current offset of y.
+  int64_t *ofsy;       // offset of y in each dimension.
+  int64_t *incy;       // stride size of y in each dimension.
   void *z;          // z, operand.
-  long posz;        // current offset of z.
-  long *ofsz;       // offset of z in each dimension.
-  long *incz;       // stride size of z in each dimension.
+  int64_t posz;        // current offset of z.
+  int64_t *ofsz;       // offset of z in each dimension.
+  int64_t *incz;       // stride size of z in each dimension.
 };
 
 

--- a/src/owl/core/owl_ndarray_contract.h
+++ b/src/owl/core/owl_ndarray_contract.h
@@ -13,7 +13,7 @@ struct contract_pair {
   long dim;         // number of dimensions, x and y must be the same.
   long dep;         // the depth of current recursion.
   long drt;         // number of outer loops.
-  long *n;          // number of iteration in each dimension, i.e. y's shape
+  int64_t *n;       // number of iteration in each dimension, i.e. y's shape
   void *x;          // x, operand.
   long posx;        // current offset of x.
   long *ofsx;       // offset of x in each dimension.

--- a/src/owl/core/owl_ndarray_contract_impl.h
+++ b/src/owl/core/owl_ndarray_contract_impl.h
@@ -11,13 +11,13 @@
 void FUNCTION (c, contract_one_1) (struct contract_pair *p) {
   TYPE *x = (TYPE *) p->x;
   TYPE *y = (TYPE *) p->y;
-  long d = p->dim - 2;
-  long n = p->n[d];
-  long posx = p->posx + p->ofsx[d];
-  long posy = p->posy + p->ofsy[d];
-  long incx = p->incx[d] + p->incx[d + 1];
+  int64_t d = p->dim - 2;
+  int64_t n = p->n[d];
+  int64_t posx = p->posx + p->ofsx[d];
+  int64_t posy = p->posy + p->ofsy[d];
+  int64_t incx = p->incx[d] + p->incx[d + 1];
 
-  for (long i = 0; i < n; i++) {
+  for (int64_t i = 0; i < n; i++) {
     MAPFUN (*(x + posx), *(y + posy));
     posx += incx;
   }
@@ -29,18 +29,18 @@ void FUNCTION (c, contract_one) (struct contract_pair *p) {
   if (p->dep == p->dim - 2)
     FUNCTION (c, contract_one_1) (p);
   else {
-    long d = p->dep;
-    long n = p->n[d];
-    long incx = p->incx[d];
-    long incy = p->incy[d];
-    long save_posx = p->posx;
-    long save_posy = p->posy;
+    int64_t d = p->dep;
+    int64_t n = p->n[d];
+    int64_t incx = p->incx[d];
+    int64_t incy = p->incy[d];
+    int64_t save_posx = p->posx;
+    int64_t save_posy = p->posy;
     p->posx += p->ofsx[d];
     p->posy += p->ofsy[d];
 
     if (p->dep < p->drt) {
       // outer loop
-      for (long i = 0; i < n; i++) {
+      for (int64_t i = 0; i < n; i++) {
         p->dep += 1;
         FUNCTION (c, contract_one) (p);
         p->dep -= 1;
@@ -51,7 +51,7 @@ void FUNCTION (c, contract_one) (struct contract_pair *p) {
     else {
       // inner loop
       incx += p->incx[d + 1];
-      for (long i = 0; i < n; i++) {
+      for (int64_t i = 0; i < n; i++) {
         p->dep += 2;
         FUNCTION (c, contract_one) (p);
         p->dep -= 2;
@@ -74,12 +74,12 @@ CAMLprim value FUNCTION (stub, contract_one) (value vX, value vY, value vA, valu
   TYPE *Y_data = (TYPE *) Y->data;
 
   struct caml_ba_array *A = Caml_ba_array_val(vA);
-  long *incx = (long *) A->data;
+  int64_t *incx = (int64_t *) A->data;
 
   struct caml_ba_array *B = Caml_ba_array_val(vB);
-  long *incy = (long *) B->data;
+  int64_t *incy = (int64_t *) B->data;
 
-  long N = Int64_val(vN);
+  int64_t N = Int64_val(vN);
 
   struct contract_pair * cp = calloc(1, sizeof(struct contract_pair));
   cp->dim = X->num_dims;
@@ -90,8 +90,8 @@ CAMLprim value FUNCTION (stub, contract_one) (value vX, value vY, value vA, valu
   cp->y = Y_data;
   cp->posx = 0;
   cp->posy = 0;
-  cp->ofsx = calloc(cp->dim, sizeof(long));
-  cp->ofsy = calloc(cp->dim, sizeof(long));
+  cp->ofsx = calloc(cp->dim, sizeof(int64_t));
+  cp->ofsy = calloc(cp->dim, sizeof(int64_t));
   cp->incx = incx;
   cp->incy = incy;
 
@@ -111,16 +111,16 @@ void FUNCTION (c, contract_two_1) (struct contract_pair *p) {
   TYPE *x = (TYPE *) p->x;
   TYPE *y = (TYPE *) p->y;
   TYPE *z = (TYPE *) p->z;
-  long d = p->dim - 1;
-  long n = p->n[d];
-  long posx = p->posx + p->ofsx[d];
-  long posy = p->posy + p->ofsy[d];
-  long posz = p->posz + p->ofsz[d];
-  long incx = p->incx[d];
-  long incy = p->incy[d];
-  long incz = p->incz[d];
+  int64_t d = p->dim - 1;
+  int64_t n = p->n[d];
+  int64_t posx = p->posx + p->ofsx[d];
+  int64_t posy = p->posy + p->ofsy[d];
+  int64_t posz = p->posz + p->ofsz[d];
+  int64_t incx = p->incx[d];
+  int64_t incy = p->incy[d];
+  int64_t incz = p->incz[d];
 
-  for (long i = 0; i < n; i++) {
+  for (int64_t i = 0; i < n; i++) {
     *(z + posz) += *(x + posx) * *(y + posy);
     posx += incx;
     posy += incy;
@@ -134,19 +134,19 @@ void FUNCTION (c, contract_two) (struct contract_pair *p) {
   if (p->dep == p->dim - 1)
     FUNCTION (c, contract_two_1) (p);
   else {
-    long d = p->dep;
-    long n = p->n[d];
-    long incx = p->incx[d];
-    long incy = p->incy[d];
-    long incz = p->incz[d];
-    long save_posx = p->posx;
-    long save_posy = p->posy;
-    long save_posz = p->posz;
+    int64_t d = p->dep;
+    int64_t n = p->n[d];
+    int64_t incx = p->incx[d];
+    int64_t incy = p->incy[d];
+    int64_t incz = p->incz[d];
+    int64_t save_posx = p->posx;
+    int64_t save_posy = p->posy;
+    int64_t save_posz = p->posz;
     p->posx += p->ofsx[d];
     p->posy += p->ofsy[d];
     p->posz += p->ofsz[d];
 
-    for (long i = 0; i < n; i++) {
+    for (int64_t i = 0; i < n; i++) {
       p->dep += 1;
       FUNCTION (c, contract_two) (p);
       p->dep -= 1;
@@ -178,18 +178,18 @@ CAMLprim value FUNCTION (stub, contract_two) (
   TYPE *Z_data = (TYPE *) Z->data;
 
   struct caml_ba_array *A = Caml_ba_array_val(vA);
-  long *incx = (long *) A->data;
+  int64_t *incx = (int64_t *) A->data;
 
   struct caml_ba_array *B = Caml_ba_array_val(vB);
-  long *incy = (long *) B->data;
+  int64_t *incy = (int64_t *) B->data;
 
   struct caml_ba_array *C = Caml_ba_array_val(vC);
-  long *incz = (long *) C->data;
+  int64_t *incz = (int64_t *) C->data;
 
   struct caml_ba_array *D = Caml_ba_array_val(vD);
-  long *loops = (long *) D->data;
+  int64_t *loops = (int64_t *) D->data;
 
-  long dim = Int64_val(vN);
+  int64_t dim = Int64_val(vN);
 
   struct contract_pair * cp = calloc(1, sizeof(struct contract_pair));
   cp->dim = dim;
@@ -201,9 +201,9 @@ CAMLprim value FUNCTION (stub, contract_two) (
   cp->posx = 0;
   cp->posy = 0;
   cp->posz = 0;
-  cp->ofsx = calloc(cp->dim, sizeof(long));
-  cp->ofsy = calloc(cp->dim, sizeof(long));
-  cp->ofsz = calloc(cp->dim, sizeof(long));
+  cp->ofsx = calloc(cp->dim, sizeof(int64_t));
+  cp->ofsy = calloc(cp->dim, sizeof(int64_t));
+  cp->ofsz = calloc(cp->dim, sizeof(int64_t));
   cp->incx = incx;
   cp->incy = incy;
   cp->incz = incz;

--- a/src/owl/maths/owl_maths.h
+++ b/src/owl/maths/owl_maths.h
@@ -10,6 +10,7 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
 #include <math.h>
 #include <assert.h>
 
@@ -207,9 +208,9 @@ extern double sf_combination(int n, int m);
 
 extern double sf_log_combination(int n, int m);
 
-extern long mulmod(long a, long b, long m);
+extern int64_t mulmod(int64_t a, int64_t b, int64_t m);
 
-extern long powmod(long a, long b, long m);
+extern int64_t powmod(int64_t a, int64_t b, int64_t m);
 
 
 #ifdef __cplusplus

--- a/src/owl/maths/owl_maths_special_impl.c
+++ b/src/owl/maths/owl_maths_special_impl.c
@@ -78,7 +78,7 @@ double erfcinv(double x) {
 }
 
 
-long mulmod(long a, long b, long m) {
+int64_t mulmod(int64_t a, int64_t b, int64_t m) {
   if (a >= m) a %= m;
   if (b >= m) b %= m;
 
@@ -86,12 +86,12 @@ long mulmod(long a, long b, long m) {
     return 0;
 
   // check if a * b overflows
-  if (b < LONG_MAX / a) {
-    long c = a * b;
+  if (b < INT64_MAX / a) {
+    int64_t c = a * b;
     return c < m ? c : c % m;
   }
 
-  long r = 0;
+  int64_t r = 0;
   while (b) {
     if (b & 1) {
       // r = (r + a) % m
@@ -114,13 +114,13 @@ long mulmod(long a, long b, long m) {
 }
 
 
-long powmod(long a, long b, long m) {
+int64_t powmod(int64_t a, int64_t b, int64_t m) {
   if (m == 1 && b == 0)
     return 0;
 
   if (a >= m) a %= m;
 
-  long r = 1;
+  int64_t r = 1;
   while (b) {
     if (b & 1)
       r = mulmod(r, a, m);

--- a/src/owl/maths/owl_maths_special_stub.c
+++ b/src/owl/maths/owl_maths_special_stub.c
@@ -625,18 +625,18 @@ value owl_stub_sf_expm1(value vX) {
 
 
 value owl_stub_mulmod(value vA, value vB, value vM) {
-  long a = Long_val(vA);
-  long b = Long_val(vB);
-  long m = Long_val(vM);
-  long r = mulmod(a, b, m);
+  int64_t a = Long_val(vA);
+  int64_t b = Long_val(vB);
+  int64_t m = Long_val(vM);
+  int64_t r = mulmod(a, b, m);
   return Val_long(r);
 }
 
 
 value owl_stub_powmod(value vA, value vB, value vM) {
-  long a = Long_val(vA);
-  long b = Long_val(vB);
-  long m = Long_val(vM);
-  long r = powmod(a, b, m);
+  int64_t a = Long_val(vA);
+  int64_t b = Long_val(vB);
+  int64_t m = Long_val(vM);
+  int64_t r = powmod(a, b, m);
   return Val_long(r);
 }


### PR DESCRIPTION
This PR replaces `long` with `int64_t` from `<stdint.h>`. This improves portability, as according to C standard, `long` is only guaranteed to be at least 32 bit (it is 64 bit on Linux with gcc, but 32 bit with mingw on Windows). This PR fixes #550 and has been tested on Windows10/Cygwin with `x86_64-w64-mingw32-gcc` and with `gcc` on Ubuntu 20.04 (WSL2).