### PR TITLE
Preview of ocamlformat.0.16.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.15.0
+version=0.16.0
 profile=janestreet
 wrap-comments=false
 doc-comments=after-when-possible

--- a/src/base/compute/owl_computation_cpu_engine.ml
+++ b/src/base/compute/owl_computation_cpu_engine.ml
@@ -36,9 +36,9 @@ end
 (* Functor of making CPU-based engine with unrolled module hierarchy *)
 
 module Make (A : Ndarray_Mutable) = struct
-  include Owl_computation_engine.Flatten
-            (Make_Nested
-               (Owl_computation_engine.Make_Graph (Owl_computation_cpu_device.Make (A))))
+  include
+    Owl_computation_engine.Flatten
+      (Make_Nested (Owl_computation_engine.Make_Graph (Owl_computation_cpu_device.Make (A))))
 end
 
 (* Make functor ends *)

--- a/src/base/compute/owl_computation_cpu_eval.ml
+++ b/src/base/compute/owl_computation_cpu_eval.ml
@@ -37,7 +37,7 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
             | Noop -> _eval_map_00 x (fun x -> x.(0))
             | Var -> check_assigned x
             | Const -> check_assigned x
-            | Empty _shape -> (_eval_map_01 x (fun ~out _x -> ()) [@warning "-27"])
+            | Empty _shape -> _eval_map_01 x (fun ~out _x -> ()) [@warning "-27"]
             | Zeros _shape -> _eval_map_01 x (fun ~out _x -> A.zeros_ ~out)
             | Ones _shape -> _eval_map_01 x (fun ~out _x -> A.ones_ ~out)
             | Create _shape -> _eval_map_02 x (fun ~out x -> A.create_ ~out x.(0))
@@ -56,7 +56,7 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
               _eval_map_01 x (fun ~out x -> A.get_slice_ ~out slice x.(0))
             | SetSlice slice ->
               _eval_map_01 x (fun ~out x -> A.set_slice_ ~out slice x.(0) x.(1))
-            | Copy -> (_eval_map_01 x (fun ~out x -> A.copy_ ~out x.(0)) [@warning "-27"])
+            | Copy -> _eval_map_01 x (fun ~out x -> A.copy_ ~out x.(0)) [@warning "-27"]
             | Reset -> _eval_map_01 x (fun ~out _x -> A.reset out)
             | Reshape _shape -> _eval_map_01 x (fun ~out x -> A.reshape_ ~out x.(0))
             | Reverse -> _eval_map_01 x (fun ~out x -> A.reverse_ ~out x.(0))

--- a/src/base/compute/owl_computation_engine.ml
+++ b/src/base/compute/owl_computation_engine.ml
@@ -9,11 +9,12 @@
  *)
 
 module Make_Graph (Device : Owl_types_computation_device.Sig) = struct
-  include Owl_computation_graph.Make
-            (Owl_computation_optimiser.Make
-               (Owl_computation_operator.Make
-                  (Owl_computation_symbol.Make
-                     (Owl_computation_shape.Make (Owl_computation_type.Make (Device))))))
+  include
+    Owl_computation_graph.Make
+      (Owl_computation_optimiser.Make
+         (Owl_computation_operator.Make
+            (Owl_computation_symbol.Make
+               (Owl_computation_shape.Make (Owl_computation_type.Make (Device))))))
 end
 
 (**

--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -55,11 +55,12 @@ module Make (Type : Owl_computation_type_sig.Sig) = struct
 
   let _infer_shape_07 input_shapes axis =
     let s0 = Array.map (fun s -> s.(0)) input_shapes in
-    if Array.exists
-         (function
-           | Some _ -> false
-           | None   -> true)
-         s0
+    if
+      Array.exists
+        (function
+          | Some _ -> false
+          | None   -> true)
+        s0
     then [| None |]
     else (
       let s1 =

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -2619,10 +2619,11 @@ let conv2d ?(padding = SAME) input kernel stride =
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
                 let in_val =
-                  if 0 <= in_col
-                     && in_col < input_cols
-                     && 0 <= in_row
-                     && in_row < input_rows
+                  if
+                    0 <= in_col
+                    && in_col < input_cols
+                    && 0 <= in_row
+                    && in_row < input_rows
                   then get input [| b; in_col; in_row; q |]
                   else 0.
                 in
@@ -2791,12 +2792,13 @@ let conv3d ?(padding = SAME) input kernel stride =
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
                     let in_val =
-                      if 0 <= in_col
-                         && in_col < input_cols
-                         && 0 <= in_row
-                         && in_row < input_rows
-                         && 0 <= in_dpt
-                         && in_dpt < input_dpts
+                      if
+                        0 <= in_col
+                        && in_col < input_cols
+                        && 0 <= in_row
+                        && in_row < input_rows
+                        && 0 <= in_dpt
+                        && in_dpt < input_dpts
                       then get input [| b; in_col; in_row; in_dpt; q |]
                       else 0.
                     in
@@ -2979,12 +2981,13 @@ let _pool3d
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                  if 0 <= in_col
-                     && in_col < input_cols
-                     && 0 <= in_row
-                     && in_row < input_rows
-                     && 0 <= in_dpt
-                     && in_dpt < input_dpts
+                  if
+                    0 <= in_col
+                    && in_col < input_cols
+                    && 0 <= in_row
+                    && in_row < input_rows
+                    && 0 <= in_dpt
+                    && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*d_dpt*)
@@ -3216,15 +3219,17 @@ let conv2d_backward_input input kernel stride output' =
           let sum = ref 0. in
           for di = 0 to kernel_cols - 1 do
             for dj = 0 to kernel_rows - 1 do
-              if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                 && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+              if
+                Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
               then (
                 let out_col = (in_i + pad_left - di) / col_stride in
                 let out_row = (in_j + pad_top - dj) / row_stride in
-                if 0 <= out_col
-                   && out_col < output_cols
-                   && 0 <= out_row
-                   && out_row < output_rows
+                if
+                  0 <= out_col
+                  && out_col < output_cols
+                  && 0 <= out_row
+                  && out_row < output_rows
                 then
                   for k = 0 to out_channel - 1 do
                     let out_grad = get output' [| b; out_col; out_row; k |] in
@@ -3339,10 +3344,8 @@ let conv2d_backward_kernel input kernel stride output' =
               for j = 0 to output_rows - 1 do
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
-                if 0 <= in_col
-                   && in_col < input_cols
-                   && 0 <= in_row
-                   && in_row < input_rows
+                if
+                  0 <= in_col && in_col < input_cols && 0 <= in_row && in_row < input_rows
                 then (
                   let out_grad = get output' [| b; i; j; k |] in
                   let input_val = get input [| b; in_col; in_row; q |] in
@@ -4003,19 +4006,21 @@ let conv3d_backward_input input kernel stride output' =
             for di = 0 to kernel_cols - 1 do
               for dj = 0 to kernel_rows - 1 do
                 for d_dpt = 0 to kernel_dpts - 1 do
-                  if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                     && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
-                     && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
+                  if
+                    Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                    && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+                    && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
                   then (
                     let out_col = (in_i + pad_left - di) / col_stride in
                     let out_row = (in_j + pad_top - dj) / row_stride in
                     let out_dpt = (in_dpt + pad_shallow - d_dpt) / dpt_stride in
-                    if 0 <= out_col
-                       && out_col < output_cols
-                       && 0 <= out_row
-                       && out_row < output_rows
-                       && 0 <= out_dpt
-                       && out_dpt < output_dpts
+                    if
+                      0 <= out_col
+                      && out_col < output_cols
+                      && 0 <= out_row
+                      && out_row < output_rows
+                      && 0 <= out_dpt
+                      && out_dpt < output_dpts
                     then
                       for k = 0 to out_channel - 1 do
                         let out_grad =
@@ -4147,12 +4152,13 @@ let conv3d_backward_kernel input kernel stride output' =
                     let in_col = (i * col_stride) + di - pad_left in
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                    if 0 <= in_col
-                       && in_col < input_cols
-                       && 0 <= in_row
-                       && in_row < input_rows
-                       && 0 <= in_dpt
-                       && in_dpt < input_dpts
+                    if
+                      0 <= in_col
+                      && in_col < input_cols
+                      && 0 <= in_row
+                      && in_row < input_rows
+                      && 0 <= in_dpt
+                      && in_dpt < input_dpts
                     then (
                       let out_grad = get output' [| b; i; j; dpt; k |] in
                       let input_val = get input [| b; in_col; in_row; in_dpt; q |] in
@@ -4336,9 +4342,10 @@ let transpose_conv3d_backward_input input kernel stride output' =
       dpt_stride
   in
   let p =
-    if output_cols_same = output_cols
-       && output_rows_same = output_rows
-       && output_dpts_same = output_dpts
+    if
+      output_cols_same = output_cols
+      && output_rows_same = output_rows
+      && output_dpts_same = output_dpts
     then SAME
     else VALID
   in
@@ -4604,12 +4611,13 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if 0 <= in_col
-                     && in_col < input_cols
-                     && 0 <= in_row
-                     && in_row < input_rows
-                     && 0 <= in_dpt
-                     && in_dpt < input_dpts
+                  if
+                    0 <= in_col
+                    && in_col < input_cols
+                    && 0 <= in_row
+                    && in_row < input_rows
+                    && 0 <= in_dpt
+                    && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*dk*)
@@ -4625,12 +4633,13 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if 0 <= in_col
-                     && in_col < input_cols
-                     && 0 <= in_row
-                     && in_row < input_rows
-                     && 0 <= in_dpt
-                     && in_dpt < input_dpts
+                  if
+                    0 <= in_col
+                    && in_col < input_cols
+                    && 0 <= in_row
+                    && in_row < input_rows
+                    && 0 <= in_dpt
+                    && in_dpt < input_dpts
                   then (
                     let input_val = get input [| b; in_col; in_row; in_dpt; k |] in
                     let input_grad = get input' [| b; in_col; in_row; in_dpt; k |] in

--- a/src/base/neural/owl_neural_generic.ml
+++ b/src/base/neural/owl_neural_generic.ml
@@ -6,9 +6,9 @@
 (** Functor to create neural networks of different precision. *)
 
 module Make_Embedded (A : Owl_types_ndarray_algodiff.Sig) = struct
-  include Owl_neural_graph.Make
-            (Owl_neural_neuron.Make
-               (Owl_optimise_generic.Make (Owl_algodiff_generic.Make (A))))
+  include
+    Owl_neural_graph.Make
+      (Owl_neural_neuron.Make (Owl_optimise_generic.Make (Owl_algodiff_generic.Make (A))))
 end
 
 module Flatten (Graph : Owl_neural_graph_sig.Sig) = struct

--- a/src/base/stats/owl_base_stats.ml
+++ b/src/base/stats/owl_base_stats.ml
@@ -181,8 +181,9 @@ let concordant x0 x1 =
   let c = ref 0 in
   for i = 0 to Array.length x0 - 2 do
     for j = i + 1 to Array.length x0 - 1 do
-      if i <> j
-         && ((x0.(i) < x0.(j) && x1.(i) < x1.(j)) || (x0.(i) > x0.(j) && x1.(i) > x1.(j)))
+      if
+        i <> j
+        && ((x0.(i) < x0.(j) && x1.(i) < x1.(j)) || (x0.(i) > x0.(j) && x1.(i) > x1.(j)))
       then c := !c + 1
     done
   done;
@@ -193,8 +194,9 @@ let discordant x0 x1 =
   let c = ref 0 in
   for i = 0 to Array.length x0 - 2 do
     for j = i + 1 to Array.length x0 - 1 do
-      if i <> j
-         && ((x0.(i) < x0.(j) && x1.(i) > x1.(j)) || (x0.(i) > x0.(j) && x1.(i) < x1.(j)))
+      if
+        i <> j
+        && ((x0.(i) < x0.(j) && x1.(i) > x1.(j)) || (x0.(i) > x0.(j) && x1.(i) < x1.(j)))
       then c := !c + 1
     done
   done;

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -198,12 +198,13 @@ let () =
           ~default:openblas_default
           (C.Pkg_config.get c >>= C.Pkg_config.query ~package:"openblas")
       in
-      if not
-         @@ C.c_test
-              c
-              test_linking
-              ~c_flags:openblas_conf.cflags
-              ~link_flags:openblas_conf.libs
+      if
+        not
+        @@ C.c_test
+             c
+             test_linking
+             ~c_flags:openblas_conf.cflags
+             ~link_flags:openblas_conf.libs
       then (
         Printf.printf
           {|

--- a/src/owl/optimise/owl_regression.ml
+++ b/src/owl/optimise/owl_regression.ml
@@ -10,8 +10,8 @@
 *)
 
 module Make_Embedded (A : Owl_types_ndarray_algodiff.Sig) = struct
-  include Owl_regression_generic.Make
-            (Owl_optimise_generic.Make (Owl_algodiff_generic.Make (A)))
+  include
+    Owl_regression_generic.Make (Owl_optimise_generic.Make (Owl_algodiff_generic.Make (A)))
 end
 
 module S = Make_Embedded (Owl_algodiff_primal_ops.S)


### PR DESCRIPTION
Hi, this pull-request is a preview of the soon to be released ocamlformat.0.16.0. The main changes in this diff are:

- the indentation of module includes has been fixed;
- the expressions following an `if` keyword are now properly broken.

Let me now if you notice any regressions.