### PR TITLE
Revert some changes (ocamlformat.0.16.0-rc2)

### DIFF
--- a/src/base/compute/owl_computation_shape.ml
+++ b/src/base/compute/owl_computation_shape.ml
@@ -55,12 +55,11 @@ module Make (Type : Owl_computation_type_sig.Sig) = struct
 
   let _infer_shape_07 input_shapes axis =
     let s0 = Array.map (fun s -> s.(0)) input_shapes in
-    if
-      Array.exists
-        (function
-          | Some _ -> false
-          | None   -> true)
-        s0
+    if Array.exists
+         (function
+           | Some _ -> false
+           | None   -> true)
+         s0
     then [| None |]
     else (
       let s1 =

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -2619,11 +2619,10 @@ let conv2d ?(padding = SAME) input kernel stride =
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
                 let in_val =
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
                   then get input [| b; in_col; in_row; q |]
                   else 0.
                 in
@@ -2792,13 +2791,12 @@ let conv3d ?(padding = SAME) input kernel stride =
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
                     let in_val =
-                      if
-                        0 <= in_col
-                        && in_col < input_cols
-                        && 0 <= in_row
-                        && in_row < input_rows
-                        && 0 <= in_dpt
-                        && in_dpt < input_dpts
+                      if 0 <= in_col
+                         && in_col < input_cols
+                         && 0 <= in_row
+                         && in_row < input_rows
+                         && 0 <= in_dpt
+                         && in_dpt < input_dpts
                       then get input [| b; in_col; in_row; in_dpt; q |]
                       else 0.
                     in
@@ -2981,13 +2979,12 @@ let _pool3d
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*d_dpt*)
@@ -3219,17 +3216,15 @@ let conv2d_backward_input input kernel stride output' =
           let sum = ref 0. in
           for di = 0 to kernel_cols - 1 do
             for dj = 0 to kernel_rows - 1 do
-              if
-                Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+              if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                 && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
               then (
                 let out_col = (in_i + pad_left - di) / col_stride in
                 let out_row = (in_j + pad_top - dj) / row_stride in
-                if
-                  0 <= out_col
-                  && out_col < output_cols
-                  && 0 <= out_row
-                  && out_row < output_rows
+                if 0 <= out_col
+                   && out_col < output_cols
+                   && 0 <= out_row
+                   && out_row < output_rows
                 then
                   for k = 0 to out_channel - 1 do
                     let out_grad = get output' [| b; out_col; out_row; k |] in
@@ -3344,8 +3339,10 @@ let conv2d_backward_kernel input kernel stride output' =
               for j = 0 to output_rows - 1 do
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
-                if
-                  0 <= in_col && in_col < input_cols && 0 <= in_row && in_row < input_rows
+                if 0 <= in_col
+                   && in_col < input_cols
+                   && 0 <= in_row
+                   && in_row < input_rows
                 then (
                   let out_grad = get output' [| b; i; j; k |] in
                   let input_val = get input [| b; in_col; in_row; q |] in
@@ -4006,21 +4003,19 @@ let conv3d_backward_input input kernel stride output' =
             for di = 0 to kernel_cols - 1 do
               for dj = 0 to kernel_rows - 1 do
                 for d_dpt = 0 to kernel_dpts - 1 do
-                  if
-                    Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                    && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
-                    && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
+                  if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                     && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+                     && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
                   then (
                     let out_col = (in_i + pad_left - di) / col_stride in
                     let out_row = (in_j + pad_top - dj) / row_stride in
                     let out_dpt = (in_dpt + pad_shallow - d_dpt) / dpt_stride in
-                    if
-                      0 <= out_col
-                      && out_col < output_cols
-                      && 0 <= out_row
-                      && out_row < output_rows
-                      && 0 <= out_dpt
-                      && out_dpt < output_dpts
+                    if 0 <= out_col
+                       && out_col < output_cols
+                       && 0 <= out_row
+                       && out_row < output_rows
+                       && 0 <= out_dpt
+                       && out_dpt < output_dpts
                     then
                       for k = 0 to out_channel - 1 do
                         let out_grad =
@@ -4152,13 +4147,12 @@ let conv3d_backward_kernel input kernel stride output' =
                     let in_col = (i * col_stride) + di - pad_left in
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                    if
-                      0 <= in_col
-                      && in_col < input_cols
-                      && 0 <= in_row
-                      && in_row < input_rows
-                      && 0 <= in_dpt
-                      && in_dpt < input_dpts
+                    if 0 <= in_col
+                       && in_col < input_cols
+                       && 0 <= in_row
+                       && in_row < input_rows
+                       && 0 <= in_dpt
+                       && in_dpt < input_dpts
                     then (
                       let out_grad = get output' [| b; i; j; dpt; k |] in
                       let input_val = get input [| b; in_col; in_row; in_dpt; q |] in
@@ -4342,10 +4336,9 @@ let transpose_conv3d_backward_input input kernel stride output' =
       dpt_stride
   in
   let p =
-    if
-      output_cols_same = output_cols
-      && output_rows_same = output_rows
-      && output_dpts_same = output_dpts
+    if output_cols_same = output_cols
+       && output_rows_same = output_rows
+       && output_dpts_same = output_dpts
     then SAME
     else VALID
   in
@@ -4611,13 +4604,12 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*dk*)
@@ -4633,13 +4625,12 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then (
                     let input_val = get input [| b; in_col; in_row; in_dpt; k |] in
                     let input_grad = get input' [| b; in_col; in_row; in_dpt; k |] in

--- a/src/base/stats/owl_base_stats.ml
+++ b/src/base/stats/owl_base_stats.ml
@@ -181,9 +181,8 @@ let concordant x0 x1 =
   let c = ref 0 in
   for i = 0 to Array.length x0 - 2 do
     for j = i + 1 to Array.length x0 - 1 do
-      if
-        i <> j
-        && ((x0.(i) < x0.(j) && x1.(i) < x1.(j)) || (x0.(i) > x0.(j) && x1.(i) > x1.(j)))
+      if i <> j
+         && ((x0.(i) < x0.(j) && x1.(i) < x1.(j)) || (x0.(i) > x0.(j) && x1.(i) > x1.(j)))
       then c := !c + 1
     done
   done;
@@ -194,9 +193,8 @@ let discordant x0 x1 =
   let c = ref 0 in
   for i = 0 to Array.length x0 - 2 do
     for j = i + 1 to Array.length x0 - 1 do
-      if
-        i <> j
-        && ((x0.(i) < x0.(j) && x1.(i) > x1.(j)) || (x0.(i) > x0.(j) && x1.(i) < x1.(j)))
+      if i <> j
+         && ((x0.(i) < x0.(j) && x1.(i) > x1.(j)) || (x0.(i) > x0.(j) && x1.(i) < x1.(j)))
       then c := !c + 1
     done
   done;

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -198,13 +198,12 @@ let () =
           ~default:openblas_default
           (C.Pkg_config.get c >>= C.Pkg_config.query ~package:"openblas")
       in
-      if
-        not
-        @@ C.c_test
-             c
-             test_linking
-             ~c_flags:openblas_conf.cflags
-             ~link_flags:openblas_conf.libs
+      if not
+         @@ C.c_test
+              c
+              test_linking
+              ~c_flags:openblas_conf.cflags
+              ~link_flags:openblas_conf.libs
       then (
         Printf.printf
           {|


### PR DESCRIPTION
Hi, after some discussions we chose to lower the amount of changes impacting the `if` expressions. The last build was breaking after the `if` keyword whenever the following expression didn't fit the line and that wasn't too pleasing to the eye whenever the keyword was alone on its line.
I should have made it more obvious in the previous PR that the diff wasn't definitive, it still isn't as long as ocamlformat 0.16.0 is not available on opam. Sorry for the inconvenience!

Here is the diff of #556 + #560 : https://github.com/gpetiot/owl/compare/master...gpetiot:preview-ocamlformat.0.16.0