### PR TITLE
Fixed bug in aiso + checks for grad and diff + forward-mode derivative for split

### DIFF
--- a/src/base/algodiff/owl_algodiff_generic.ml
+++ b/src/base/algodiff/owl_algodiff_generic.ml
@@ -48,6 +48,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
 
   (* derivative of f (scalar -> scalar) at x, forward ad *)
   let diff' f x =
+    if not (is_float x) then failwith "input of `diff` must be a scalar";
     let x = make_forward x (pack_flt 1.) (tag ()) in
     let y = f x in
     primal y, tangent y
@@ -60,6 +61,7 @@ module Make (A : Owl_types_ndarray_algodiff.Sig) = struct
   let grad' f x =
     let x = make_reverse x (tag ()) in
     let y = f x in
+    if not (is_float y) then failwith "output of `grad` must be a scalar";
     Reverse.reverse_reset y;
     Reverse.reverse_push (pack_flt 1.) y;
     primal y, x |> adjval

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -503,6 +503,25 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
     and get_slice i = Lazy.force _get_slice i
 
+    and _get_fancy =
+      lazy
+        (fun i ->
+          build_siso
+            (module struct
+              let label = "get_fancy"
+
+              let ff_f a = error_uniop label (pack_elt a)
+
+              let ff_arr a = Arr A.(get_fancy i a)
+
+              let df _cp _ap at = get_fancy i at
+
+              let dr a _cp ca = set_fancy i (zero a) !ca
+            end : Siso))
+
+
+    and get_fancy i = Lazy.force _get_fancy i
+
     and _sum' =
       lazy
         (build_siso
@@ -1302,6 +1321,41 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
 
     and set_slice i = Lazy.force _set_slice i
+
+    and _set_fancy =
+      lazy
+        (fun i ->
+          build_piso
+            (module struct
+              let label = "set_fancy"
+
+              let ff_aa a _b = error_uniop label (pack_elt a)
+
+              let ff_ab a _b = error_uniop label (pack_elt a)
+
+              let ff_ba _a b = error_uniop label (pack_elt b)
+
+              let ff_bb a b =
+                let a = A.copy a in
+                A.(set_fancy i a b);
+                Arr a
+
+
+              let df_da _cp _ap at bp = set_fancy i at (zero bp)
+
+              let df_db _cp ap _bp bt = set_fancy i (zero ap) bt
+
+              let df_dab _cp _ap at _bp bt = set_fancy i at bt
+
+              let dr_ab _a b _cp ca = set_fancy i !ca (zero b), get_fancy i !ca
+
+              let dr_a _a b _cp ca = set_fancy i !ca (zero b)
+
+              let dr_b _a _b _cp ca = get_fancy i !ca
+            end : Piso))
+
+
+    and set_fancy i = Lazy.force _set_fancy i
 
     and ( *@ ) a b = dot a b
 

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1623,9 +1623,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
 
               let ff_arr a = A.(split ~axis parts a) |> Array.map (fun x -> Arr x)
 
-              let df _cp _ap _at =
-                raise (Owl_exception.NOT_IMPLEMENTED "owl_algodiff_ops.split")
-
+              let df _cp _ap at = split ~axis parts at
 
               let dr _a _cp _cp_ref_arr ca_ref_arr =
                 concatenate ~axis (Array.map (fun ca -> !ca) ca_ref_arr)

--- a/src/base/algodiff/owl_algodiff_ops_builder.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder.ml
@@ -400,26 +400,26 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
           | `normal, DR (_, _, _, _, t', _) -> succ i, t', `reverse, [ i ]
           | `forward, DR (_, _, _, _, t', _) ->
             if t' > t
-            then succ i, t', `reverse, []
+            then succ i, t', `reverse, [ i ]
             else if t' = t
             then failwith "error: forward and reverse clash on the same level"
             else succ i, t, `forward, idxs
           | `reverse, DR (_, _, _, _, t', _) ->
             if t' > t
-            then succ i, t', `reverse, []
+            then succ i, t', `reverse, [ i ]
             else if t' = t
             then succ i, t', `reverse, i :: idxs
             else succ i, t, m, idxs
           | `normal, DF (_, _, t') -> succ i, t', `forward, [ i ]
           | `forward, DF (_, _, t') ->
             if t' > t
-            then succ i, t', `forward, []
+            then succ i, t', `forward, [ i ]
             else if t' = t
             then succ i, t', `forward, i :: idxs
             else succ i, t, `forward, idxs
           | `reverse, DF (_, _, t') ->
             if t' > t
-            then succ i, t', `forward, []
+            then succ i, t', `forward, [ i ]
             else if t' = t
             then failwith "error: forward and reverse clash on the same level"
             else succ i, t, `reverse, idxs)

--- a/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_builder_sig.ml
@@ -64,7 +64,7 @@ module type Sig = sig
 
     val ff_arr : arr -> t array
 
-    val df : t -> t -> t -> t
+    val df : t array -> t -> t -> t array
 
     val dr : t -> t -> t ref array -> t ref array -> t
   end

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -238,6 +238,12 @@ module type Sig = sig
     val set_slice : int list list -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+    val get_fancy : index list -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val set_fancy : index list -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
     val diag : ?k:int -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/compute/owl_computation_cpu_init.ml
+++ b/src/base/compute/owl_computation_cpu_init.ml
@@ -61,6 +61,8 @@ module Make (Graph : Owl_computation_graph_sig.Sig) = struct
     | Set _i -> split_01 p
     | GetSlice _slice -> split_00 p (* ? *)
     | SetSlice _slice -> split_00 p (* ? *)
+    | GetFancy _indices -> split_00 p (* ? *)
+    | SetFancy _indices -> split_00 p (* ? *)
     | Copy -> split_01 p
     | Reset -> split_01 p
     | Reshape _shape -> split_01 p

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -109,10 +109,14 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
   let get_slice slice x =
     make_then_connect (GetSlice slice) [| arr_to_node x |] |> node_to_arr
 
-
   let set_slice slice x y =
     make_then_connect (SetSlice slice) [| arr_to_node x; arr_to_node y |] |> ignore
 
+  let get_fancy indices x =
+    make_then_connect (GetFancy indices) [| arr_to_node x |] |> node_to_arr
+
+  let set_fancy indices x y =
+    make_then_connect (SetFancy indices) [| arr_to_node x; arr_to_node y |] |> ignore
 
   let copy x = make_then_connect Copy [| arr_to_node x |] |> node_to_arr
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -65,6 +65,12 @@ module type Sig = sig
   val set_slice : int list list -> arr -> arr -> unit
   (** TODO *)
 
+  val get_fancy : index list -> arr -> arr
+  (** TODO *)
+
+  val set_fancy : index list -> arr -> arr -> unit
+  (** TODO *)
+
   val copy : arr -> arr
   (** TODO *)
 

--- a/src/base/compute/owl_computation_symbol.ml
+++ b/src/base/compute/owl_computation_symbol.ml
@@ -32,6 +32,8 @@ module Make (Shape : Owl_computation_shape_sig.Sig) = struct
     | Set _i -> "Set"
     | GetSlice _slice -> "GetSlice"
     | SetSlice _slice -> "SetSlice"
+    | GetFancy _ -> "GetFancy"
+    | SetFancy _ -> "SetFancy"
     | Copy -> "Copy"
     | Reset -> "Reset"
     | Reshape _shape -> "Reshape"

--- a/src/base/compute/owl_computation_type.ml
+++ b/src/base/compute/owl_computation_type.ml
@@ -73,6 +73,8 @@ module Make (Device : Owl_types_computation_device.Sig) = struct
     | Set                           of int array
     | GetSlice                      of int list list
     | SetSlice                      of int list list
+    | GetFancy                      of index list
+    | SetFancy                      of index list
     | Copy
     | Reset
     | Reshape                       of int array

--- a/src/base/compute/owl_computation_type_sig.ml
+++ b/src/base/compute/owl_computation_type_sig.ml
@@ -3,7 +3,7 @@
  * Copyright (c) 2016-2020 Liang Wang <liang.wang@cl.cam.ac.uk>
  *)
 
-open Owl_types
+open Owl_types_common
 
 (* Functor of making the symbols of a computation graph. *)
 
@@ -75,6 +75,8 @@ module type Sig = sig
     | Set                           of int array
     | GetSlice                      of int list list
     | SetSlice                      of int list list
+    | GetFancy                      of index list
+    | SetFancy                      of index list
     | Copy
     | Reset
     | Reshape                       of int array

--- a/src/base/dense/owl_base_dense_ndarray_generic.ml
+++ b/src/base/dense/owl_base_dense_ndarray_generic.ml
@@ -214,6 +214,14 @@ let set_slice index_list varr slice_varr =
   done
 
 
+(*TODO: optimise, test *)
+let get_fancy _indices _varr = raise (Owl_exception.NOT_IMPLEMENTED "base: get_fancy")
+
+(*TODO: optimise, test *)
+let set_fancy _indices _target _input =
+  raise (Owl_exception.NOT_IMPLEMENTED "base: set_fancy")
+
+
 (* The result shares the underlying buffer with original, not a copy *)
 let reshape x d =
   let minus_one = Owl_utils.Array.count d (-1) in
@@ -2619,11 +2627,10 @@ let conv2d ?(padding = SAME) input kernel stride =
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
                 let in_val =
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
                   then get input [| b; in_col; in_row; q |]
                   else 0.
                 in
@@ -2792,13 +2799,12 @@ let conv3d ?(padding = SAME) input kernel stride =
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
                     let in_val =
-                      if
-                        0 <= in_col
-                        && in_col < input_cols
-                        && 0 <= in_row
-                        && in_row < input_rows
-                        && 0 <= in_dpt
-                        && in_dpt < input_dpts
+                      if 0 <= in_col
+                         && in_col < input_cols
+                         && 0 <= in_row
+                         && in_row < input_rows
+                         && 0 <= in_dpt
+                         && in_dpt < input_dpts
                       then get input [| b; in_col; in_row; in_dpt; q |]
                       else 0.
                     in
@@ -2981,13 +2987,12 @@ let _pool3d
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*d_dpt*)
@@ -3219,17 +3224,15 @@ let conv2d_backward_input input kernel stride output' =
           let sum = ref 0. in
           for di = 0 to kernel_cols - 1 do
             for dj = 0 to kernel_rows - 1 do
-              if
-                Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+              if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                 && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
               then (
                 let out_col = (in_i + pad_left - di) / col_stride in
                 let out_row = (in_j + pad_top - dj) / row_stride in
-                if
-                  0 <= out_col
-                  && out_col < output_cols
-                  && 0 <= out_row
-                  && out_row < output_rows
+                if 0 <= out_col
+                   && out_col < output_cols
+                   && 0 <= out_row
+                   && out_row < output_rows
                 then
                   for k = 0 to out_channel - 1 do
                     let out_grad = get output' [| b; out_col; out_row; k |] in
@@ -3344,8 +3347,10 @@ let conv2d_backward_kernel input kernel stride output' =
               for j = 0 to output_rows - 1 do
                 let in_col = (i * col_stride) + di - pad_left in
                 let in_row = (j * row_stride) + dj - pad_top in
-                if
-                  0 <= in_col && in_col < input_cols && 0 <= in_row && in_row < input_rows
+                if 0 <= in_col
+                   && in_col < input_cols
+                   && 0 <= in_row
+                   && in_row < input_rows
                 then (
                   let out_grad = get output' [| b; i; j; k |] in
                   let input_val = get input [| b; in_col; in_row; q |] in
@@ -4006,21 +4011,19 @@ let conv3d_backward_input input kernel stride output' =
             for di = 0 to kernel_cols - 1 do
               for dj = 0 to kernel_rows - 1 do
                 for d_dpt = 0 to kernel_dpts - 1 do
-                  if
-                    Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
-                    && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
-                    && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
+                  if Stdlib.( mod ) (in_i + pad_left - di) col_stride = 0
+                     && Stdlib.( mod ) (in_j + pad_top - dj) row_stride = 0
+                     && Stdlib.( mod ) (in_dpt + pad_shallow - d_dpt) dpt_stride = 0
                   then (
                     let out_col = (in_i + pad_left - di) / col_stride in
                     let out_row = (in_j + pad_top - dj) / row_stride in
                     let out_dpt = (in_dpt + pad_shallow - d_dpt) / dpt_stride in
-                    if
-                      0 <= out_col
-                      && out_col < output_cols
-                      && 0 <= out_row
-                      && out_row < output_rows
-                      && 0 <= out_dpt
-                      && out_dpt < output_dpts
+                    if 0 <= out_col
+                       && out_col < output_cols
+                       && 0 <= out_row
+                       && out_row < output_rows
+                       && 0 <= out_dpt
+                       && out_dpt < output_dpts
                     then
                       for k = 0 to out_channel - 1 do
                         let out_grad =
@@ -4152,13 +4155,12 @@ let conv3d_backward_kernel input kernel stride output' =
                     let in_col = (i * col_stride) + di - pad_left in
                     let in_row = (j * row_stride) + dj - pad_top in
                     let in_dpt = (dpt * dpt_stride) + d_dpt - pad_shallow in
-                    if
-                      0 <= in_col
-                      && in_col < input_cols
-                      && 0 <= in_row
-                      && in_row < input_rows
-                      && 0 <= in_dpt
-                      && in_dpt < input_dpts
+                    if 0 <= in_col
+                       && in_col < input_cols
+                       && 0 <= in_row
+                       && in_row < input_rows
+                       && 0 <= in_dpt
+                       && in_dpt < input_dpts
                     then (
                       let out_grad = get output' [| b; i; j; dpt; k |] in
                       let input_val = get input [| b; in_col; in_row; in_dpt; q |] in
@@ -4342,10 +4344,9 @@ let transpose_conv3d_backward_input input kernel stride output' =
       dpt_stride
   in
   let p =
-    if
-      output_cols_same = output_cols
-      && output_rows_same = output_rows
-      && output_dpts_same = output_dpts
+    if output_cols_same = output_cols
+       && output_rows_same = output_rows
+       && output_dpts_same = output_dpts
     then SAME
     else VALID
   in
@@ -4611,13 +4612,12 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then add_val_pool_fun (get input [| b; in_col; in_row; in_dpt; k |])
                 done
                 (*dk*)
@@ -4633,13 +4633,12 @@ let _pool3d_backward
                   let in_col = (i * col_stride) + di - pad_left in
                   let in_row = (j * row_stride) + dj - pad_top in
                   let in_dpt = (dpt * dpt_stride) + dk - pad_shallow in
-                  if
-                    0 <= in_col
-                    && in_col < input_cols
-                    && 0 <= in_row
-                    && in_row < input_rows
-                    && 0 <= in_dpt
-                    && in_dpt < input_dpts
+                  if 0 <= in_col
+                     && in_col < input_cols
+                     && 0 <= in_row
+                     && in_row < input_rows
+                     && 0 <= in_dpt
+                     && in_dpt < input_dpts
                   then (
                     let input_val = get input [| b; in_col; in_row; in_dpt; k |] in
                     let input_grad = get input' [| b; in_col; in_row; in_dpt; k |] in

--- a/src/base/dense/owl_base_dense_ndarray_generic.mli
+++ b/src/base/dense/owl_base_dense_ndarray_generic.mli
@@ -101,6 +101,12 @@ val get_slice : int list list -> ('a, 'b) t -> ('a, 'b) t
 val set_slice : int list list -> ('a, 'b) t -> ('a, 'b) t -> unit
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 
+val get_fancy : index list -> ('a, 'b) t -> ('a, 'b) t
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+val set_fancy : index list -> ('a, 'b) t -> ('a, 'b) t -> unit
+(** Refer to :doc:`owl_dense_ndarray_generic` *)
+
 val reset : ('a, 'b) t -> unit
 (** Refer to :doc:`owl_dense_ndarray_generic` *)
 

--- a/src/base/dense/owl_base_dense_ndarray_intf.ml
+++ b/src/base/dense/owl_base_dense_ndarray_intf.ml
@@ -54,6 +54,10 @@ module type Common = sig
 
   val set_slice : int list list -> arr -> arr -> unit
 
+  val get_fancy : index list -> arr -> arr
+
+  val set_fancy : index list -> arr -> arr -> unit
+
   val copy : arr -> arr
 
   val copy_ : out:arr -> arr -> unit

--- a/src/base/types/owl_types_ndarray_basic.ml
+++ b/src/base/types/owl_types_ndarray_basic.ml
@@ -48,6 +48,10 @@ module type Sig = sig
 
   val set_slice : int list list -> arr -> arr -> unit
 
+  val get_fancy : index list -> arr -> arr
+
+  val set_fancy : index list -> arr -> arr -> unit
+
   val copy : arr -> arr
 
   val copy_ : out:arr -> arr -> unit (* FIXME: move to mutable? *)

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -190,7 +190,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       let f =
         let y1 = Mat.gaussian 10 n in
         let y2 = Mat.gaussian 15 n in
-        let h x = Maths.(y1 *@ x) in
+        let h x = Maths.(sum' (y1 *@ x)) in
         let h' = grad h in
         fun x ->
           let y = Maths.concatenate ~axis:0 [| y1; x; y2; h' x |] in
@@ -203,7 +203,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       let f =
         let y1 = Mat.gaussian n n in
         let y2 = Mat.gaussian n n in
-        let h x = Maths.(y1 *@ x) in
+        let h x = Maths.(sum' (y1 *@ x)) in
         let h' = grad h in
         fun x -> Maths.stack ~axis:(-1) [| y1; x; y2; h' x |]
       in

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -91,6 +91,24 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
 
     let l2norm_sqr' () = test_func Maths.l2norm_sqr'
 
+    let get_slice () =
+      let f x =
+        let y1 = Maths.get_slice [ [ 0 ] ] x in
+        let y2 = Maths.get_slice [ [ 2 ] ] x in
+        Maths.(sum' (sin (y1 * y2)))
+      in
+      test_func f
+
+
+    let get_fancy () =
+      let f x =
+        let y1 = Maths.get_fancy [ R [ 0; 1 ]; L [ 0; 2 ] ] x in
+        let y2 = Maths.get_fancy [ R [ 1; 2 ]; L [ 0; 1 ] ] x in
+        Maths.(sum' (tan (y1 * y2)))
+      in
+      test_func f
+
+
     let tril () = test_func Maths.tril
 
     let triu () = test_func Maths.triu
@@ -337,10 +355,11 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       ; "cos", cos; "tan", tan; "sinh", sinh; "cosh", cosh; "tanh", tanh
       ; "sigmoid", sigmoid; "relu", relu; "dawsn", dawsn; "exp", exp
       ; "transpose", transpose; "diag", diag; "diagm", diagm; "trace", trace
-      ; "l1norm'", l1norm'; "l2norm'", l2norm'; "l2norm_sqr'", l2norm_sqr'; "tril", tril
-      ; "triu", triu; "inv", inv; "logdet", logdet; "chol", chol; "qr", qr; "lq", lq
-      ; "split", split; "concat", concat; "concatenate", concatenate; "stack", stack
-      ; "svd", svd; "of_arrays", of_arrays; "to_arrays", to_arrays; "init_2d", init_2d
+      ; "l1norm'", l1norm'; "l2norm'", l2norm'; "l2norm_sqr'", l2norm_sqr'
+      ; "get_slice", get_slice; "get_fancy", get_fancy; "tril", tril; "triu", triu
+      ; "inv", inv; "logdet", logdet; "chol", chol; "qr", qr; "lq", lq; "split", split
+      ; "concat", concat; "concatenate", concatenate; "stack", stack; "svd", svd
+      ; "of_arrays", of_arrays; "to_arrays", to_arrays; "init_2d", init_2d
       ; "sylvester", sylvester; "lyapunov", lyapunov
       ; "discrete_lyapunov", discrete_lyapunov; "linsolve", linsolve
       ; "linsolve_triangular", linsolve_triangular; "care", care


### PR DESCRIPTION
1. We now check that the output of `grad` and the input of `diff` are scalars (as referenced in #540)
2. There was a somewhat obscure bug in building AISO operations in Algodiff. The bug occurs when the input to an `aiso` operation (e.g. `concatenate`) include reverse-mode and forward-mode with tags at different levels. I've a new unit test `nested_grad2` in `unit_algodiff_matrix_generic.ml` to explicitly test for this.
3. I've also implemented the forward-mode derivative of `split`, which required changing `SIAO`  in `Builder`


