### PR TITLE
Add initial FFT 2D implementation

### DIFF
--- a/src/owl/fftpack/owl_fft_d.mli
+++ b/src/owl/fftpack/owl_fft_d.mli
@@ -13,3 +13,7 @@ val ifft : ?axis:int -> (Complex.t, complex64_elt) t -> (Complex.t, complex64_el
 val rfft : ?axis:int -> (float, float64_elt) t -> (Complex.t, complex64_elt) t
 
 val irfft : ?axis:int -> ?n:int -> (Complex.t, complex64_elt) t -> (float, float64_elt) t
+
+val fft2 : (Complex.t, complex64_elt) t -> (Complex.t, complex64_elt) t
+
+val ifft2 : (Complex.t, complex64_elt) t -> (Complex.t, complex64_elt) t

--- a/src/owl/fftpack/owl_fft_generic.ml
+++ b/src/owl/fftpack/owl_fft_generic.ml
@@ -17,6 +17,7 @@ let fft ?axis x =
   y
 
 
+
 let ifft ?axis x =
   let axis =
     match axis with
@@ -29,7 +30,6 @@ let ifft ?axis x =
   let norm = Complex.{ re = float_of_int (shape y).(axis); im = 0. } in
   div_scalar_ y norm;
   y
-
 
 let rfft ?axis ~otyp x =
   let axis =
@@ -65,3 +65,9 @@ let irfft ?axis ?n ~otyp x =
   let norm = float_of_int s.(axis) in
   div_scalar_ y norm;
   y
+
+let fft2 x =
+  fft ~axis:0 x |> fft ~axis:1
+
+let ifft2 x =
+  ifft ~axis:0 x |> ifft ~axis:1

--- a/src/owl/fftpack/owl_fft_generic.ml
+++ b/src/owl/fftpack/owl_fft_generic.ml
@@ -17,7 +17,6 @@ let fft ?axis x =
   y
 
 
-
 let ifft ?axis x =
   let axis =
     match axis with
@@ -30,6 +29,7 @@ let ifft ?axis x =
   let norm = Complex.{ re = float_of_int (shape y).(axis); im = 0. } in
   div_scalar_ y norm;
   y
+
 
 let rfft ?axis ~otyp x =
   let axis =
@@ -68,6 +68,7 @@ let irfft ?axis ?n ~otyp x =
 
 let fft2 x =
   fft ~axis:0 x |> fft ~axis:1
+
 
 let ifft2 x =
   ifft ~axis:0 x |> ifft ~axis:1

--- a/src/owl/fftpack/owl_fft_generic.mli
+++ b/src/owl/fftpack/owl_fft_generic.mli
@@ -39,3 +39,12 @@ val irfft
 ``irfft ~axis ~n x`` is the inverse function of ``rfft``. Note the ``n`` parameter
 is used to specified the size of output.
  *)
+
+val fft2 : (Complex.t, 'a) t -> (Complex.t, 'a) t
+(**
+``fft2 x`` performs 2-dimensional FFT on a complex input. The return is not scaled.
+ *)
+
+val ifft2 : (Complex.t, 'a) t -> (Complex.t, 'a) t
+(**
+``ifft2 x`` performs inverse 2-dimensional FFT on a complex input. *)

--- a/src/owl/fftpack/owl_fft_generic.mli
+++ b/src/owl/fftpack/owl_fft_generic.mli
@@ -47,4 +47,5 @@ val fft2 : (Complex.t, 'a) t -> (Complex.t, 'a) t
 
 val ifft2 : (Complex.t, 'a) t -> (Complex.t, 'a) t
 (**
-``ifft2 x`` performs inverse 2-dimensional FFT on a complex input. *)
+``ifft2 x`` performs inverse 2-dimensional FFT on a complex input.
+ *)

--- a/src/owl/fftpack/owl_fft_s.mli
+++ b/src/owl/fftpack/owl_fft_s.mli
@@ -13,3 +13,7 @@ val ifft : ?axis:int -> (Complex.t, complex32_elt) t -> (Complex.t, complex32_el
 val rfft : ?axis:int -> (float, float32_elt) t -> (Complex.t, complex32_elt) t
 
 val irfft : ?axis:int -> ?n:int -> (Complex.t, complex32_elt) t -> (float, float32_elt) t
+
+val fft2 : (Complex.t, complex32_elt) t -> (Complex.t, complex32_elt) t
+
+val ifft2 : (Complex.t, complex32_elt) t -> (Complex.t, complex32_elt) t


### PR DESCRIPTION
This PR adds simple implementation of 2D fft and ifft operations, as required by the example in owl book. 