### PR TITLE
Simplified + implemented Sylvester, Lyapunov, and Riccati derivatives

### DIFF
--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -2176,15 +2176,15 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
            let acl = a - (b *@ k) in
            let tr_acl = transpose acl in
            let dp_da () =
-             let pat = p *@ at in
-             discrete_lyapunov tr_acl (neg (transpose pat) - pat)
+             let g = tr_acl *@ p *@ at in
+             discrete_lyapunov tr_acl (g + transpose g)
            in
-           let dp_dq () = discrete_lyapunov tr_acl (neg qt) in
-           let dp_dr () = discrete_lyapunov tr_acl (neg (transpose k *@ rt *@ k)) in
            let dp_db () =
              let x = tr_acl *@ p *@ bt *@ k in
-             discrete_lyapunov tr_acl (x + transpose x)
+             discrete_lyapunov tr_acl (neg (x + transpose x))
            in
+           let dp_dq () = discrete_lyapunov tr_acl qt in
+           let dp_dr () = discrete_lyapunov tr_acl (transpose k *@ rt *@ k) in
            [| dp_da; dp_db; dp_dq; dp_dr |]
          in
          let dare_backward ~diag_r:_ a b _q r p pbar =
@@ -2199,7 +2199,7 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
            let s =
              (* we can symmetrise without loss of generality as p is symmetric *)
              let pbar = pack_flt 0.5 * (pbar + transpose pbar) in
-             let s = discrete_lyapunov acl (neg pbar) in
+             let s = discrete_lyapunov acl pbar in
              pack_flt 0.5 * (s + transpose s)
            in
            (* the following calculations are not calculated unless needed *)

--- a/src/base/algodiff/owl_algodiff_ops.ml
+++ b/src/base/algodiff/owl_algodiff_ops.ml
@@ -1929,12 +1929,12 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     and _lyapunov =
       let _lyapunov_backward_a a ca cp =
         let s = lyapunov (transpose a) (neg ca) in
-        pack_flt 2. * s *@ cp
+        (s *@ transpose cp) + (transpose s *@ cp)
       in
       let _lyapunov_backward_q a ca = neg (lyapunov (transpose a) (neg ca)) in
       let _lyapunov_backward_aq a ca cp =
         let s = lyapunov (transpose a) (neg ca) in
-        pack_flt 2. * s *@ cp, neg s
+        (s *@ transpose cp) + (transpose s *@ cp), neg s
       in
       lazy
         (build_piso
@@ -1975,12 +1975,12 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
     and _discrete_lyapunov =
       let _discrete_lyapunov_backward_a a ca cp =
         let s = discrete_lyapunov (transpose a) ca in
-        pack_flt 2. * s *@ a *@ cp
+        (s *@ a *@ transpose cp) + (transpose s *@ a *@ cp)
       in
       let _discrete_lyapunov_backward_q a ca = discrete_lyapunov (transpose a) ca in
       let _discrete_lyapunov_backward_aq a ca cp =
         let s = discrete_lyapunov (transpose a) ca in
-        pack_flt 2. * s *@ a *@ cp, s
+        (s *@ a *@ transpose cp) + (transpose s *@ a *@ cp), s
       in
       lazy
         (fun ~solver ->
@@ -1997,15 +1997,17 @@ module Make (Core : Owl_algodiff_core_sig.Sig) = struct
               let ff_bb a q = Arr A.(Linalg.discrete_lyapunov ~solver a q)
 
               let df_da cp ap at _qp =
-                let g = ap *@ cp *@ transpose at in
-                discrete_lyapunov ap (g + transpose g)
+                let g1 = ap *@ cp *@ transpose at in
+                let g2 = at *@ cp *@ transpose ap in
+                discrete_lyapunov ap (g1 + g2)
 
 
               let df_db _cp ap _qp qt = discrete_lyapunov ap qt
 
               let df_dab cp ap at _qp qt =
-                let g = ap *@ cp *@ transpose at in
-                discrete_lyapunov ap (g + transpose g) + discrete_lyapunov ap qt
+                let g1 = ap *@ cp *@ transpose at in
+                let g2 = at *@ cp *@ transpose ap in
+                discrete_lyapunov ap (g1 + g2) + discrete_lyapunov ap qt
 
 
               let dr_ab a _b cp ca =

--- a/src/base/algodiff/owl_algodiff_ops_sig.ml
+++ b/src/base/algodiff/owl_algodiff_ops_sig.ml
@@ -298,6 +298,9 @@ module type Sig = sig
 
     val care : ?diag_r:bool -> t -> t -> t -> t -> t
     (** Refer to :doc:`owl_dense_ndarray_generic` *)
+
+    val dare : ?diag_r:bool -> t -> t -> t -> t -> t
+    (** Refer to :doc:`owl_dense_ndarray_generic` *)
   end
 
   (** {5 Supported Neural Network functions} *)

--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -109,14 +109,18 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
   let get_slice slice x =
     make_then_connect (GetSlice slice) [| arr_to_node x |] |> node_to_arr
 
+
   let set_slice slice x y =
     make_then_connect (SetSlice slice) [| arr_to_node x; arr_to_node y |] |> ignore
+
 
   let get_fancy indices x =
     make_then_connect (GetFancy indices) [| arr_to_node x |] |> node_to_arr
 
+
   let set_fancy indices x y =
     make_then_connect (SetFancy indices) [| arr_to_node x; arr_to_node y |] |> ignore
+
 
   let copy x = make_then_connect Copy [| arr_to_node x |] |> node_to_arr
 
@@ -941,6 +945,11 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
     let care ?(diag_r = false) _a _b _q _r =
       diag_r |> ignore;
       raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.care")
+
+
+    let dare ?(diag_r = false) _a _b _q _r =
+      diag_r |> ignore;
+      raise (Owl_exception.NOT_IMPLEMENTED "owl_computation_operator.dare")
   end
 end
 

--- a/src/base/compute/owl_computation_operator_sig.ml
+++ b/src/base/compute/owl_computation_operator_sig.ml
@@ -728,5 +728,8 @@ module type Sig = sig
 
     val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
     (** TODO *)
+
+    val dare : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
+    (** TODO *)
   end
 end

--- a/src/base/linalg/owl_base_linalg_generic.ml
+++ b/src/base/linalg/owl_base_linalg_generic.ml
@@ -480,4 +480,8 @@ let care ?(diag_r = false) _a _b _q _r =
   diag_r |> ignore;
   raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.care")
 
+let dare ?(diag_r = false) _a _b _q _r =
+  diag_r |> ignore;
+  raise (Owl_exception.NOT_IMPLEMENTED "owl_base_dense_ndarray_generic.dare")
+
 (* ends here *)

--- a/src/base/linalg/owl_base_linalg_generic.mli
+++ b/src/base/linalg/owl_base_linalg_generic.mli
@@ -97,6 +97,15 @@ val care
   -> (float, 'b) t
 (** Refer to :doc:`owl_dense_matrix_generic` *)
 
+val dare
+  :  ?diag_r:bool
+  -> (float, 'b) t
+  -> (float, 'b) t
+  -> (float, 'b) t
+  -> (float, 'b) t
+  -> (float, 'b) t
+(** Refer to :doc:`owl_dense_matrix_generic` *)
+
 (** {5 Non-standard functions} *)
 
 val linsolve_lu : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t

--- a/src/base/linalg/owl_base_linalg_intf.ml
+++ b/src/base/linalg/owl_base_linalg_intf.ml
@@ -55,4 +55,6 @@ module type Real = sig
   type mat
 
   val care : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
+  
+  val dare : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
 end

--- a/src/base/types/owl_types_ndarray_algodiff.ml
+++ b/src/base/types/owl_types_ndarray_algodiff.ml
@@ -110,5 +110,7 @@ module type Sig = sig
     val linsolve : ?trans:bool -> ?typ:[ `n | `u | `l ] -> arr -> arr -> arr
 
     val care : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
+
+    val dare : ?diag_r:bool -> arr -> arr -> arr -> arr -> arr
   end
 end

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -1,5 +1,3 @@
-let () = Printexc.record_backtrace true
-
 (*
  * OWL - OCaml Scientific and Engineering Computing
  * Copyright (c) 2016-2020 Liang Wang <liang.wang@cl.cam.ac.uk>
@@ -928,7 +926,10 @@ let dare ?(diag_r = false) a b q r =
       M.(b * inv_r *@ transpose b))
     else M.(b *@ inv r *@ transpose b)
   in
-  let c = M.transpose (inv a) in
+  let c =
+    try M.transpose (inv a) with
+    | _ -> failwith "DARE: currently does not support singular A"
+  in
   let z = M.(concat_vh [| [| a + (g *@ c *@ q); neg g *@ c |]; [| neg c *@ q; c |] |]) in
   let t, u, wr, wi = Owl_lapacke.gees ~jobvs:'V' ~a:z in
   let select = M.(zeros int32 (row_num wr) (col_num wr)) in

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -1,3 +1,5 @@
+let () = Printexc.record_backtrace true
+
 (*
  * OWL - OCaml Scientific and Engineering Computing
  * Copyright (c) 2016-2020 Liang Wang <liang.wang@cl.cam.ac.uk>

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -859,8 +859,15 @@ let care ?(diag_r = false) a b q r =
   M.(u1 *@ inv u0)
 
 
-let dare a b q r =
-  let g = M.(b *@ inv r *@ transpose b) in
+let dare ?(diag_r = false) a b q r =
+  let g =
+    if diag_r
+    then (
+      let r = M.diag r in
+      let inv_r = M.reci r in
+      M.(b * inv_r *@ transpose b))
+    else M.(b *@ inv r *@ transpose b)
+  in
   let c = M.transpose (inv a) in
   let z = M.(concat_vh [| [| a + (g *@ c *@ q); neg g *@ c |]; [| neg c *@ q; c |] |]) in
   let t, u, wr, wi = Owl_lapacke.gees ~jobvs:'V' ~a:z in

--- a/src/owl/linalg/owl_linalg_generic.ml
+++ b/src/owl/linalg/owl_linalg_generic.ml
@@ -1,5 +1,3 @@
-let () = Printexc.record_backtrace true
-
 (*
  * OWL - OCaml Scientific and Engineering Computing
  * Copyright (c) 2016-2020 Liang Wang <liang.wang@cl.cam.ac.uk>

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -511,13 +511,14 @@ Returns:
  *)
 
 val dare
-  :  (float, 'a) t
+  :  ?diag_r:bool
+  -> (float, 'a) t
   -> (float, 'a) t
   -> (float, 'a) t
   -> (float, 'a) t
   -> (float, 'a) t
 (**
-``dare a b q r`` solves the discrete-time algebraic Riccati equation system
+``dare ?diag_r a b q r`` solves the discrete-time algebraic Riccati equation system
 in the following form. The algorithm is based on :cite:`laub1979schur`.
 
 .. math::

--- a/src/owl/linalg/owl_linalg_generic.mli
+++ b/src/owl/linalg/owl_linalg_generic.mli
@@ -504,7 +504,7 @@ Parameters:
   * ``b`` : real cofficient matrix B.
   * ``q`` : real cofficient matrix Q.
   * ``r`` : real cofficient matrix R. R must be non-singular.
-  * ``diag_r`` : true if R is a diagonal matrix. false by default
+  * ``diag_r`` : true if R is a diagonal matrix, false by default.
 
 Returns:
   * ``x`` : a solution matrix X.
@@ -529,6 +529,7 @@ Parameters:
   * ``b`` : real cofficient matrix B.
   * ``q`` : real cofficient matrix Q.
   * ``r`` : real cofficient matrix R. R must be non-singular.
+  * ``diag_r`` : true if R is a diagonal matrix, false by default.
 
 Returns:
   * ``x`` : a symmetric solution matrix X.

--- a/src/owl/linalg/owl_linalg_intf.ml
+++ b/src/owl/linalg/owl_linalg_intf.ml
@@ -109,8 +109,4 @@ end
 
 module type Real = sig
   include Owl_base_linalg_intf.Real
-
-  (* NOTE: functions below have not been implemented in Base Linalg *)
-
-  val dare : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
 end

--- a/src/owl/linalg/owl_linalg_intf.ml
+++ b/src/owl/linalg/owl_linalg_intf.ml
@@ -112,5 +112,5 @@ module type Real = sig
 
   (* NOTE: functions below have not been implemented in Base Linalg *)
 
-  val dare : mat -> mat -> mat -> mat -> mat
+  val dare : ?diag_r:bool -> mat -> mat -> mat -> mat -> mat
 end

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -364,6 +364,28 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       test_func f
 
 
+    let dare () =
+      let b = Mat.gaussian n n in
+      let q = Mat.gaussian n n in
+      let f x =
+        let a = x in
+        let b = Maths.(tril x + b) in
+        let r =
+          let e = Mat.eye n in
+          let r = Maths.(e + (a *@ transpose a)) in
+          Maths.(r *@ transpose r)
+        in
+        let q =
+          let q = Maths.(q + a) in
+          Maths.((q *@ transpose q) + Mat.(eye n))
+        in
+        let c1 = Linalg.care a b q r in
+        let c2 = Linalg.care ~diag_r:true a b q Maths.(diagm (diag r)) in
+        Maths.(c1 + c2)
+      in
+      test_func f
+
+
     let nested_grad1 =
       let x = Mat.gaussian 1 (n * n) in
       let r ~theta x = Maths.(sum' (sqr x *@ transpose (theta * theta))) in
@@ -411,7 +433,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       ; "sylvester", sylvester; "lyapunov1", lyapunov1; "lyapunov2", lyapunov2
       ; "discrete_lyapunov1", discrete_lyapunov1; "discrete_lyapunov2", discrete_lyapunov2
       ; "linsolve", linsolve; "linsolve_triangular", linsolve_triangular; "care", care
-      ; "log_sum_exp'", log_sum_exp'; "log_sum_exp", log_sum_exp
+      ; "dare", dare; "log_sum_exp'", log_sum_exp'; "log_sum_exp", log_sum_exp
       ; "nested_grad1", nested_grad1; "nested_grad2", nested_grad2 ]
       |> List.fold_left
            (fun (b, error_msg) (s, f) ->

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -345,8 +345,9 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
     let care () =
       let b = Mat.gaussian n n in
       let q = Mat.gaussian n n in
+      let id = Mat.eye n in
       let f x =
-        let a = x in
+        let a = Maths.(x - id) in
         let b = Maths.(tril x + b) in
         let r =
           let e = Mat.eye n in
@@ -354,7 +355,7 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
           Maths.(r *@ transpose r)
         in
         let q =
-          let q = Maths.(q + a) in
+          let q = Maths.(q + x) in
           Maths.((q *@ transpose q) + Mat.(eye n))
         in
         let c1 = Linalg.care a b q r in

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -253,7 +253,8 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       test_func f
 
 
-    let lyapunov () =
+    let lyapunov1 () =
+      (* test symmetric q *)
       let r = Mat.gaussian n n in
       let identity = Arr Owl.Mat.(eye n) in
       let f x =
@@ -266,11 +267,40 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       test_func f
 
 
-    let discrete_lyapunov () =
+    let lyapunov2 () =
+      (* test non-symmetric q *)
+      let r = Mat.gaussian n n in
+      let identity = Arr Owl.Mat.(eye n) in
+      let f x =
+        let q = Maths.(x + identity) in
+        let s = Maths.(r - transpose r) in
+        let p = Maths.(((r + x) *@ transpose (r + x)) + identity) in
+        let a = Maths.((s - (F 0.5 * q)) *@ inv p) in
+        Linalg.lyapunov a Maths.(neg q)
+      in
+      test_func f
+
+
+    let discrete_lyapunov1 () =
+      (* test symmetric q *)
       let r = Mat.gaussian n n in
       let identity = Arr Owl.Mat.(eye n) in
       let f x =
         let q = Maths.(F 0.5 * ((x *@ transpose x) + identity)) in
+        let s = Maths.(x - transpose x) in
+        let p = Maths.(((r + x) *@ transpose (r + x)) + identity) in
+        let a = Maths.(((s - (F 0.5 * q)) *@ inv p) - identity) in
+        Linalg.discrete_lyapunov a q
+      in
+      test_func f
+
+
+    let discrete_lyapunov2 () =
+      (* test symmetric q *)
+      let r = Mat.gaussian n n in
+      let identity = Arr Owl.Mat.(eye n) in
+      let f x =
+        let q = x in
         let s = Maths.(x - transpose x) in
         let p = Maths.(((r + x) *@ transpose (r + x)) + identity) in
         let a = Maths.(((s - (F 0.5 * q)) *@ inv p) - identity) in
@@ -378,9 +408,9 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
       ; "inv", inv; "logdet", logdet; "chol", chol; "qr", qr; "lq", lq; "split", split
       ; "concat", concat; "concatenate", concatenate; "stack", stack; "svd", svd
       ; "of_arrays", of_arrays; "to_arrays", to_arrays; "init_2d", init_2d
-      ; "sylvester", sylvester; "lyapunov", lyapunov
-      ; "discrete_lyapunov", discrete_lyapunov; "linsolve", linsolve
-      ; "linsolve_triangular", linsolve_triangular; "care", care
+      ; "sylvester", sylvester; "lyapunov1", lyapunov1; "lyapunov2", lyapunov2
+      ; "discrete_lyapunov1", discrete_lyapunov1; "discrete_lyapunov2", discrete_lyapunov2
+      ; "linsolve", linsolve; "linsolve_triangular", linsolve_triangular; "care", care
       ; "log_sum_exp'", log_sum_exp'; "log_sum_exp", log_sum_exp
       ; "nested_grad1", nested_grad1; "nested_grad2", nested_grad2 ]
       |> List.fold_left

--- a/test/unit_algodiff_matrix_generic.ml
+++ b/test/unit_algodiff_matrix_generic.ml
@@ -380,8 +380,8 @@ module Make (M : Ndarray_Algodiff with type elt = float) = struct
           let q = Maths.(q + a) in
           Maths.((q *@ transpose q) + Mat.(eye n))
         in
-        let c1 = Linalg.care a b q r in
-        let c2 = Linalg.care ~diag_r:true a b q Maths.(diagm (diag r)) in
+        let c1 = Linalg.dare a b q r in
+        let c2 = Linalg.dare ~diag_r:true a b q Maths.(diagm (diag r)) in
         Maths.(c1 + c2)
       in
       test_func f


### PR DESCRIPTION
This PR includes the following changes:

1. generalized derivatives of `AD.Linalg.lyapunov` and `AD.Linalg.discrete_lyapunov` to non-symmetric `Q`s
2. symmetrize `pbar` and `ptangents` in `care` because `p` is symmetric
3. added checks for the dimensions of the inputs to `care` and `dare`
4. added tests for the solutions of `care` and `dare` to make sure the solves were carried out correctly
5. added forward and reverse-mode derivatives for `dare`


