### PR TITLE
Support for ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script: bash -ex ./.travis-docker.sh
 
 env:
   global:
-    - EIGENCPP_OPTFLAGS="-Wno-ignored-attributes -O3 -Ofast -march=native -mfpmath=sse -funroll-loops -ffast-math"
+    - EIGENCPP_OPTFLAGS="-Wno-ignored-attributes -O3 -Ofast -march=native -funroll-loops -ffast-math"
     - PACKAGE="owl"
     - PINS="owl-base.master:. owl-plplot.master:. owl-top.master:. owl-zoo.master:. owl.master:."
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 sudo: false
+# See https://github.com/ocaml/ocaml-ci-scripts/issues/351
+dist: focal
 services: docker
 
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
@@ -18,11 +20,14 @@ matrix:
   #   osx_image: xcode10.1
   #   env: OCAML_VERSION=4.07
   - os: linux
-    env: OCAML_VERSION=4.10 DISTRO=debian-stable
+    env: OCAML_VERSION=4.10 DISTRO=debian
   - os: linux
     env: OCAML_VERSION=4.10 DISTRO=fedora
   - os: linux
     env: OCAML_VERSION=4.10 DISTRO=ubuntu
+  - os: linux
+    arch: arm64
+    env: OCAML_VERSION=4.10 DISTRO=debian
 
   fast_finish: true
   allow_failures:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ before compilation:
 - `OWL_CFLAGS` allows to change the default flags passed to the C targets,
   it defaults to
   ```
-  OWL_CFLAGS="-g -O3 -Ofast -march=native -mfpmath=sse -funroll-loops -ffast-math -DSFMT_MEXP=19937 -msse2 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare"`
+  OWL_CFLAGS="-g -O3 -Ofast -march=native -funroll-loops -ffast-math -DSFMT_MEXP=19937 -fno-strict-aliasing -Wno-tautological-constant-out-of-range-compare"`
   ```
 
 - `OWL_AEOS_CFLAGS` allows to change the default flags passed to the C targets

--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -90,14 +90,16 @@ let default_cflags =
     ; "-Ofast"
     ; (* FIXME: experimental switches *)
       (* "-mavx2"; "-mfma"; "-ffp-contract=fast"; *)
-      (* Experimental switches, -ffast-math may break IEEE754 semantics*)
+      (* Experimental switches, -ffast-math may break IEEE754 semantics *)
       "-march=native"
-    ; "-mfpmath=sse"
+    (* Not supported on ARM64 *)
+    (* ; "-mfpmath=sse" *)
     ; "-funroll-loops"
     ; "-ffast-math"
     ; (* Configure Mersenne Twister RNG *)
       "-DSFMT_MEXP=19937"
-    ; "-msse2"
+    (* Not supported on ARM64 *)
+    (* ; "-msse2" *)
     ; "-fno-strict-aliasing"
     ; "-Wno-tautological-constant-out-of-range-compare"
     ]


### PR DESCRIPTION
The sse flags are not supported by ARM64 (this was a potential issue also for new macs, but I don't have a way to test it). I suggest disabling them.

This should improve the situation (or even fix) https://github.com/owlbarn/owl/issues/569 and should fix (at least for now) https://github.com/owlbarn/owl/issues/568

I also added ARM to the tests, to double-check...