### PR TITLE
Fix mli example for Owl_dense_matrix_generic.linspace

### DIFF
--- a/src/owl/dense/owl_dense_matrix_generic.mli
+++ b/src/owl/dense/owl_dense_matrix_generic.mli
@@ -136,7 +136,7 @@ val semidef : (float, 'b) kind -> int -> (float, 'b) t
 val linspace : ('a, 'b) kind -> 'a -> 'a -> int -> ('a, 'b) t
 (**
 [linspace a b n] linearly divides the interval [[a,b]] into [n] pieces by
-creating an [m] by [1] row vector. E.g., [linspace 0. 5. 5] will create a
+creating an [m] by [1] row vector. E.g., [linspace 0. 5. 6] will create a
 row vector [[0;1;2;3;4;5]].
  *)
 


### PR DESCRIPTION
This is a tiny fix for the example for the `Owl_dense_matrix_generic.linspace` mli file documentation.

The example shows:

```
[linspace 0. 5. 5] will create a row vector [[0;1;2;3;4;5]]
```

However, that code produces `0; 1.25; 2.5; 3.75; 5`.  So I changed the example code to `linspace 0. 5. 6` to get the nice `0; 1; 2; 3; 4; 5` output.