### PR TITLE
Clean up exception raising functions

### DIFF
--- a/src/base/compute/owl_computation_operator.ml
+++ b/src/base/compute/owl_computation_operator.ml
@@ -722,15 +722,17 @@ module Make (Symbol : Owl_computation_symbol_sig.Sig) = struct
 
   let row_num x =
     let s = shape x in
+    let p = Array.length s = 2 in
     let exn = Owl_exception.NOT_MATRIX s in
-    Owl_exception.check (Array.length s = 2) exn;
+    Owl_exception.check p exn;
     s.(0)
 
 
   let col_num x =
     let s = shape x in
+    let p = Array.length s = 2 in
     let exn = Owl_exception.NOT_MATRIX s in
-    Owl_exception.check (Array.length s = 2) exn;
+    Owl_exception.check p exn;
     s.(1)
 
 

--- a/src/owl/dense/owl_dense_matrix_generic.ml
+++ b/src/owl/dense/owl_dense_matrix_generic.ml
@@ -11,9 +11,11 @@ include Owl_dense_ndarray_generic
 (* area function *)
 
 let shape x =
-  let x_shape = shape x in
-  assert (Array.length x_shape = 2);
-  x_shape.(0), x_shape.(1)
+  let s = shape x in
+  let p = Array.length s = 2 in
+  let exn = Owl_exception.NOT_MATRIX s in
+  Owl_exception.check p exn;
+  s.(0), s.(1)
 
 
 (* creation functions *)

--- a/src/owl/dense/owl_dense_ndarray_generic.ml
+++ b/src/owl/dense/owl_dense_ndarray_generic.ml
@@ -9893,12 +9893,15 @@ let row_num x =
   let p = Array.length s = 2 in
   let exn = Owl_exception.NOT_MATRIX s in
   Owl_exception.check p exn;
-  (shape x).(0)
+  s.(0)
 
 
 let col_num x =
-  if not (num_dims x = 2) then failwith "passed in parameter must be a matrix";
-  (shape x).(1)
+  let s = shape x in
+  let p = Array.length s = 2 in
+  let exn = Owl_exception.NOT_MATRIX s in
+  Owl_exception.check p exn;
+  s.(1)
 
 
 let row x i =


### PR DESCRIPTION
Some functions that check dimensions of the input argument raise a NOT_MATRIX exception, others raise Failure or Assert_failure.  This commit changes them to all use the same dimension checking logic and to raise a NOT_MATRIX exception.

The mli docs for these functions did not mention that they can raise exceptions, would you like me to add that info to the mli entries?

Also, now each of these functions has the same dimension check logic, maybe it would be a good idea to pull it out in its own function.  But then, maybe that should need benchmarking before doing that (though not sure if these particular functions would be in a hot path anyway...)