### PR TITLE
Owl_io.head: avoid log message about assertion failure on large CSV file

### DIFF
--- a/src/base/misc/owl_io.ml
+++ b/src/base/misc/owl_io.ml
@@ -135,7 +135,7 @@ let head n fname =
   (try
      iteri_lines_of_file
        (fun i s ->
-         assert (i < n);
+         if i >= n then raise_notrace End_of_file;
          Owl_utils.Stack.push lines s)
        fname
    with


### PR DESCRIPTION
Executing `Owl_dataframe.of_csv "large.csv"` prints:
```
2023-04-13 14:01:52.922 WARN : Owl_io.head: ignored exception File "src/base/misc/owl_io.ml", line 138, characters 9-15: Assertion failed
```

Using assertions for control-flow (early exit of loop) seems wrong, and causes log messages to be shown on the console. Raise an [End_of_file] exception instead which will be handled by the iteration function just as if the file ended early. Use [raise_notrace] because the exception is immediately caught and we don't need a backtrace.