### PR TITLE
configure: add env vars as dependencies

### DIFF
--- a/src/owl/dune
+++ b/src/owl/dune
@@ -211,7 +211,12 @@
 (rule
  (targets c_flags.sexp c_library_flags.sexp ocaml_flags.sexp)
  (deps
-  (:deps-conf config/configure.exe))
+  (:deps-conf config/configure.exe)
+  (env_var OWL_CFLAGS)
+  (env_var OWL_ENABLE_DEVMODE)
+  (env_var OWL_ENABLE_OPENMP)
+  (env_var OWL_DISABLE_LAPACKE_LINKING_FLAG)
+  )
  (action
   (progn
    (run %{deps-conf}))))


### PR DESCRIPTION
When OWL_CFLAGS is set configure needs to be rerun. Fixes build issues when dune caching is used.
Especially useful when changing CFLAGS to remove -march=native in order to rerun under 'valgrind', etc.

P.S.: the use of '-march=native' can be problematic if deploying binaries on a machine that is different to the build machine, eventually it'd be good to add an easy mechanism to turn that off (e.g. using another 'dune' profile), but I'll leave that for a future PR.
(function multiversioning could be used instead which detects available CPU features on program startup using CPUID).