### PR TITLE
Clarify that linux/linux_elf are identical systems

### DIFF
--- a/src/owl/config/configure.ml
+++ b/src/owl/config/configure.ml
@@ -154,8 +154,8 @@ let get_openmp_config c =
   else (
     let cflags, libs =
       match get_os_type c with
+      | "linux_elf"
       | "linux"     -> [ "-fopenmp" ], [ "-lgomp" ]
-      | "linux_elf" -> [ "-fopenmp" ], [ "-lgomp" ]
       | "macosx"    -> [ "-Xpreprocessor"; "-fopenmp" ], [ "-lomp" ]
       | "mingw64"   -> [ "-fopenmp" ], [ "-lgomp" ]
       | _           -> [], []


### PR DESCRIPTION
ocaml/ocaml#12405 proposes using `linux` everywhere for the "system" variable. The change doesn't semantically affect the script, but it seemed worth making it clearer in the code that the two cases need to be identical.