### PR TITLE
Fix grammar in the beginning of the document in `owl_types.ml`

### DIFF
--- a/src/base/types/owl_types.ml
+++ b/src/base/types/owl_types.ml
@@ -4,7 +4,7 @@
  *)
 
 (** This module defines the types shared by various sub-libraries in Owl.
-  Note that they just wrappers, to find the exact module signature, please
+  Note that they are just wrappers, to find the exact module signature, please
   refer to the definition in the corresponding module.
  *)
 


### PR DESCRIPTION
Fix grammar in the beginning of the document in `owl_types.ml`


Note that they just wrappers ->> Note that they are just wrappers