### PR TITLE
Enable github actions for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: Main workflow
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-14 # beta runner for macos arm64
+          - macos-latest
+          - ubuntu-latest
+          # - windows-latest
+        ocaml-version:
+          - 5.1.x
+          - 4.14.x
+          - 4.12.x
+          - 4.10.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: avsm/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-local-packages: |
+            *.opam
+
+      - run: opam depext owl --with-test
+    
+      - run: |
+          opam install owl-base --yes --deps-only --with-test
+          opam exec -- dune build -p owl-base
+          opam exec -- dune runtest -p owl-base
+  
+      - run: |
+          opam install owl --yes --deps-only --with-test
+          opam exec -- dune build -p owl
+          opam exec -- dune runtest -p owl
+  
+      - run: |
+          opam install owl-top --yes --deps-only --with-test
+          opam exec -- dune build -p owl-top
+          opam exec -- dune runtest -p owl-top

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: avsm/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-local-packages: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,11 +14,11 @@ jobs:
           - macos-latest
           - ubuntu-latest
           # - windows-latest
-        ocaml-version:
-          - 5.1.x
-          - 4.14.x
-          - 4.12.x
-          - 4.10.x
+        ocaml-compiler:
+          - "5.1"
+          - "4.14"
+          - "4.12"
+          - "4.10"
 
     runs-on: ${{ matrix.os }}
 

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (tests
  (names test_runner)
  (libraries alcotest owl)
+ (package owl)
  (action
   (run %{test})))


### PR DESCRIPTION
This tests separately the three packages, should catch packaging issues before releases are made. It also tests the arm builds for macos (they will fail until https://github.com/owlbarn/owl/pull/609 is merged)