### PR TITLE
Update stats_scipy_get_distributions.py

### DIFF
--- a/test/stats_scipy_get_distributions.py
+++ b/test/stats_scipy_get_distributions.py
@@ -379,7 +379,7 @@ def show_dist(d):
         pass
     result +="|] \n"
     result +=");\n"
-    print result
+    print(result)
     pass
 
 distributions = [
@@ -474,10 +474,10 @@ distributions = [
                   chi2(df=30.),
                  ]
 
-print "module M = Owl_stats"
-print "let cdf_approximations = M.["
+print("module M = Owl_stats")
+print("let cdf_approximations = M.[")
 for d in distributions:
   show_dist(d)
   pass
-print "]"
+print("]")
 


### PR DESCRIPTION
"print x" no longer works in Python 3, in Python 3 it is "print(x)". 

I have tested the script after making the changes and it runs without crashing.