### PR TITLE
.os.yml: drop support for 4.12, check also 5.2

### DIFF
--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -15,10 +15,10 @@ jobs:
           - ubuntu-latest
           # - windows-latest
         ocaml-compiler:
+          - "5.2"
           - "5.1"
           - "4.14"
           - "4.12"
-          - "4.10"
 
     runs-on: ${{ matrix.os }}
 

--- a/owl-base.opam
+++ b/owl-base.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.12.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
 ]

--- a/owl-top.opam
+++ b/owl-top.opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.12.0"}
   "dune" {>= "2.0.0"}
   "ocaml-compiler-libs"
   "owl" {= version}

--- a/owl.opam
+++ b/owl.opam
@@ -22,7 +22,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.12.0"}
   "alcotest" {with-test}
   "base" {build}
   "base-bigarray"


### PR DESCRIPTION
And later we could switch to 5.3, to ensure compatibility with recent compilers