### PR TITLE
add x-maintenance-intent

### DIFF
--- a/owl-base.opam
+++ b/owl-base.opam
@@ -18,3 +18,5 @@ depends: [
   "base-bigarray"
   "dune" {>= "2.0.0"}
 ]
+
+x-maintenance-intent: ["(latest)"]

--- a/owl-top.opam
+++ b/owl-top.opam
@@ -20,3 +20,5 @@ depends: [
   "ocaml-compiler-libs"
   "owl" {= version}
 ]
+
+x-maintenance-intent: ["(latest)"]

--- a/owl.opam
+++ b/owl.opam
@@ -33,3 +33,5 @@ depends: [
   "owl-base" {= version}
   "npy"
 ]
+
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Due to the opam repository archival process, we are keen to have the maintainers of packages specify their intention. It would be useful, also to ensure a smooth experience for the users, to clarify owl's maintenance intent.

Looking at the past and new releases, I think the most sensible setting is that only the latest released is considered maintained, but I am happy to change this if you disagree. You can read up on the policy at https://github.com/ocaml/opam-repository/blob/master/governance/policies/archiving.md and the x-maintenance-intent field at https://github.com/ocaml/opam-repository/blob/master/governance/policies/archiving.md#specification-of-the-x--fields-used-in-the-archiving-process